### PR TITLE
Queue progress update messages until Renderer is ready.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const IPC_CHANNELS = {
   LOADING_PROGRESS: 'loading-progress',
-  RENDERER_READY: 'renderer-ready'
+  RENDERER_READY: 'renderer-ready',
 };
 
 export const ELECTRON_BRIDGE_API = 'electronAPI';

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ let pythonProcess: ChildProcess | null = null;
 const host = '127.0.0.1'; // Replace with the desired IP address
 const port = 8188; // Replace with the port number your server is running on
 let mainWindow: BrowserWindow | null;
-const messageQueue: Array<any> = [] // Stores mesaages before renderer is ready.
+const messageQueue: Array<any> = []; // Stores mesaages before renderer is ready.
 
 const createWindow = async () => {
   const primaryDisplay = screen.getPrimaryDisplay();
@@ -63,11 +63,11 @@ const createWindow = async () => {
   }
 
   ipcMain.on(IPC_CHANNELS.RENDERER_READY, () => {
-    log.info('Received renderer-ready message!')
+    log.info('Received renderer-ready message!');
     // Send all queued messages
     while (messageQueue.length > 0) {
       const message = messageQueue.shift();
-      log.info("Sending queued message ", message.channel)
+      log.info('Sending queued message ', message.channel);
       mainWindow.webContents.send(message.channel, message.data);
     }
   });
@@ -247,14 +247,14 @@ function sendProgressUpdate(percentage: number, status: string): void {
     log.info('Sending progress update to renderer ' + status);
 
     if (!mainWindow.webContents || mainWindow.webContents.isLoading()) {
-      log.info('Queueing message since renderer is not ready yet.')
+      log.info('Queueing message since renderer is not ready yet.');
       messageQueue.push({
         channel: IPC_CHANNELS.LOADING_PROGRESS,
         data: {
-          percentage, 
-          status
-        }
-      })
+          percentage,
+          status,
+        },
+      });
       return;
     }
     mainWindow.webContents.send(IPC_CHANNELS.LOADING_PROGRESS, {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -15,7 +15,6 @@ const electronAPI = {
     log.info('Sending ready event to main process');
     ipcRenderer.send(IPC_CHANNELS.RENDERER_READY);
   },
-  
 };
 
 contextBridge.exposeInMainWorld(ELECTRON_BRIDGE_API, electronAPI);

--- a/src/renderer/screens/ProgressOverlay.tsx
+++ b/src/renderer/screens/ProgressOverlay.tsx
@@ -57,9 +57,9 @@ function ProgressOverlay(): React.ReactElement {
   useEffect(() => {
     if (ELECTRON_BRIDGE_API in window) {
       log.info(`Sending ready event from renderer`);
-      (window as any).electronAPI.sendReady()
+      (window as any).electronAPI.sendReady();
     }
-  }, [])
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
Sometimes if an error is thrown too quickly, the IPC renderer is not ready to receive the message and the message gets lost.