### PR TITLE
Fix python install record file on Windows

### DIFF
--- a/src/pythonEnvironment.ts
+++ b/src/pythonEnvironment.ts
@@ -13,11 +13,6 @@ export class PythonEnvironment {
    */
   readonly pythonRecordPath: string;
   /**
-   * @deprecated The legacy path to determine if Python is installed.
-   * The legacy path does not work on Windows, as Windows does not allow having a file and a directory with the same name.
-   */
-  private readonly legacyPythonRecordPath: string;
-  /**
    * The path to the python tar file in the app resources.
    */
   readonly pythonTarPath: string;
@@ -47,17 +42,13 @@ export class PythonEnvironment {
         ? path.join(this.pythonRootPath, 'python.exe')
         : path.join(this.pythonRootPath, 'bin', 'python');
     this.pythonRecordPath = path.join(this.pythonRootPath, 'INSTALLER');
-    this.legacyPythonRecordPath = path.join(this.pythonInterpreterPath, 'INSTALLER');
     this.pythonTarPath = path.join(appResourcesPath, 'python.tgz');
     this.wheelsPath = path.join(this.pythonRootPath, 'wheels');
     this.requirementsCompiledPath = path.join(this.pythonRootPath, 'requirements.compiled');
   }
 
   async isInstalled(): Promise<boolean> {
-    return (
-      (await pathAccessible(this.pythonInterpreterPath)) &&
-      ((await pathAccessible(this.pythonRecordPath)) || (await pathAccessible(this.legacyPythonRecordPath)))
-    );
+    return (await pathAccessible(this.pythonInterpreterPath)) && (await pathAccessible(this.pythonRecordPath));
   }
 
   async packWheels(): Promise<boolean> {


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/electron/issues/121

```
Windows:
- Windows does NOT allow a file and directory to have the same name in the same parent directory
- This is case-insensitive, so you can't have "folder" and "Folder" or "file.txt" and "FILE.txt"

Unix-like systems (Linux, macOS, BSD):
- You CAN have a file and directory with the same exact name in the same parent directory
- These systems are case-sensitive by default, so "folder", "Folder", and "FOLDER" can all exist simultaneously
- Example: You can have both "/home/user/documents" (directory) and "/home/user/documents" (file)
```

The legacy python record path was something like `electron/assets/python/python.exe/INSTALLER`, which does not work on Windows. This PR fixes the issue by moving the record file under python root, i.e. `electron/assets/python/INSTALLER`.