### PR TITLE
Fix presubmit typecheck hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+yarn run tsc --noEmit --strict

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "yaml": "^2.6.0"
   },
   "lint-staged": {
-    "./**/*.{js,ts,tsx}": "prettier --write",
-    "./src/**/*.{ts}": "tsc --noEmit --strict"
+    "./**/*.{js,ts,tsx}": "prettier --write"
   }
 }


### PR DESCRIPTION
"lint-staged" cannot correctly handle the range of typecheck. Adding the typecheck to pre-commit hook directly.