### PR TITLE
Add electron API to open external URLs.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export const IPC_CHANNELS = {
   CANCEL_DOWNLOAD: 'cancel-download',
   DELETE_MODEL: 'delete-model',
   GET_ALL_DOWNLOADS: 'get-all-downloads',
+  OPEN_EXTERNAL: 'open-external',
 } as const;
 
 export const COMFY_ERROR_MESSAGE =

--- a/src/main.ts
+++ b/src/main.ts
@@ -951,3 +951,9 @@ const rotateLogFiles = (logDir: string, baseName: string) => {
     fs.renameSync(currentLogPath, newLogPath);
   }
 };
+
+// TODO(robinhuang): Pop up a warning and ask user to optionally whitelist URLs.
+ipcMain.handle(IPC_CHANNELS.OPEN_EXTERNAL, async (_event, url: string) => {
+  log.info(`Opening external URL: ${url}`);
+  await shell.openExternal(url);
+});

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -48,6 +48,7 @@ export interface ElectronAPI {
     deleteModel: (filename: string, path: string) => Promise<boolean>;
     getAllDownloads: () => Promise<DownloadItem[]>;
   };
+  openExternal: (url: string) => Promise<void>;
 }
 
 const electronAPI: ElectronAPI = {
@@ -137,6 +138,9 @@ const electronAPI: ElectronAPI = {
     getAllDownloads: (): Promise<DownloadItem[]> => {
       return ipcRenderer.invoke(IPC_CHANNELS.GET_ALL_DOWNLOADS);
     },
+  },
+  openExternal: (url: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.OPEN_EXTERNAL, url);
   },
 };
 


### PR DESCRIPTION
Resolves #138 

`ComfyUI_frontend` needs to add something like :

```
document.addEventListener('click', (event) => {
    const target = event.target as HTMLElement;
    const anchor = target.closest('a');
    
    if (anchor && anchor.href && anchor.href.startsWith('http')) {
      event.preventDefault();
      electronAPI.openExternal(anchor.href);
    }
  });
  ```