### PR TITLE
[Refactor] Move registerIpcHandlers call out of getInstance

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -181,6 +181,8 @@ if (!gotTheLock) {
         return;
       }
       downloadManager = DownloadManager.getInstance(mainWindow!, getModelsDirectory(basePath));
+      downloadManager.registerIpcHandlers();
+
       port = await findAvailablePort(8000, 9999).catch((err) => {
         log.error(`ERROR: Failed to find available port: ${err}`);
         throw err;

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -258,12 +258,11 @@ export class DownloadManager {
   public static getInstance(mainWindow: BrowserWindow, modelsDirectory: string): DownloadManager {
     if (!DownloadManager.instance) {
       DownloadManager.instance = new DownloadManager(mainWindow, modelsDirectory);
-      DownloadManager.instance.registerIpcHandlers();
     }
     return DownloadManager.instance;
   }
 
-  private registerIpcHandlers() {
+  public registerIpcHandlers() {
     ipcMain.handle(IPC_CHANNELS.START_DOWNLOAD, (event, { url, path, filename }) =>
       this.startDownload(url, path, filename)
     );


### PR DESCRIPTION
`registerIpcHandlers` is an important lifecycle event that should not depend on when `DownloadManager` instance is first accessed.

Moving the call to main will give us explicit understanding of the lifecycle.