### PR TITLE
Cleanup webview devtools setup

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,6 @@ export const IPC_CHANNELS = {
   FIRST_TIME_SETUP_COMPLETE: 'first-time-setup-complete',
   DEFAULT_INSTALL_LOCATION: 'default-install-location',
   GET_PRELOAD_SCRIPT: 'get-preload-script',
-  OPEN_DEVTOOLS: 'open-devtools',
   OPEN_LOGS_FOLDER: 'open-logs-folder',
   DOWNLOAD_PROGRESS: 'download-progress',
   START_DOWNLOAD: 'start-download',

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -22,7 +22,6 @@ export interface ElectronAPI {
   onDefaultInstallLocation: (callback: (location: string) => void) => void;
   sendReady: () => void;
   restartApp: (customMessage?: string, delay?: number) => void;
-  onOpenDevTools: (callback: () => void) => void;
   isPackaged: () => Promise<boolean>;
   openDialog: (options: Electron.OpenDialogOptions) => Promise<string[] | undefined>;
   /**
@@ -80,9 +79,6 @@ const electronAPI: ElectronAPI = {
   restartApp: (customMessage?: string, delay?: number): void => {
     console.log('Sending restarting app message to main process with custom message: ', customMessage);
     ipcRenderer.send(IPC_CHANNELS.RESTART_APP, { customMessage, delay });
-  },
-  onOpenDevTools: (callback: () => void) => {
-    ipcRenderer.on(IPC_CHANNELS.OPEN_DEVTOOLS, () => callback());
   },
   onShowSelectDirectory: (callback: () => void) => {
     ipcRenderer.on(IPC_CHANNELS.SHOW_SELECT_DIRECTORY, () => callback());

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -88,12 +88,8 @@ export function SetupTray(
       click: () => shell.openPath(app.getPath('logs')),
     },
     {
-      label: 'Open devtools (Electron)',
+      label: 'Open devtools',
       click: () => mainView.webContents.openDevTools(),
-    },
-    {
-      label: 'Open devtools (ComfyUI)',
-      click: () => mainView.webContents.send(IPC_CHANNELS.OPEN_DEVTOOLS),
     },
     {
       label: 'Install Python Packages (Open Terminal)',


### PR DESCRIPTION
Cleanup left-over devtool setup only for webview.

Note: webview was removed in https://github.com/Comfy-Org/electron/pull/159