### PR TITLE
Move folder actions from tray to UI menu

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,6 @@ export const IPC_CHANNELS = {
   FIRST_TIME_SETUP_COMPLETE: 'first-time-setup-complete',
   DEFAULT_INSTALL_LOCATION: 'default-install-location',
   GET_PRELOAD_SCRIPT: 'get-preload-script',
-  OPEN_LOGS_FOLDER: 'open-logs-folder',
   DOWNLOAD_PROGRESS: 'download-progress',
   START_DOWNLOAD: 'start-download',
   PAUSE_DOWNLOAD: 'pause-download',
@@ -20,6 +19,10 @@ export const IPC_CHANNELS = {
   GET_ALL_DOWNLOADS: 'get-all-downloads',
   GET_ELECTRON_VERSION: 'get-electron-version',
   SEND_ERROR_TO_SENTRY: 'send-error-to-sentry',
+  GET_BASE_PATH: 'get-base-path',
+  GET_MODEL_CONFIG_PATH: 'get-model-config-path',
+  OPEN_PATH: 'open-path',
+  OPEN_DEV_TOOLS: 'open-dev-tools',
 } as const;
 
 export const COMFY_ERROR_MESSAGE =

--- a/src/main.ts
+++ b/src/main.ts
@@ -186,8 +186,17 @@ if (!gotTheLock) {
           ...options,
         });
       });
-      ipcMain.on(IPC_CHANNELS.OPEN_LOGS_FOLDER, () => {
-        shell.openPath(app.getPath('logs'));
+      ipcMain.handle(IPC_CHANNELS.GET_BASE_PATH, () => {
+        return basePath;
+      });
+      ipcMain.handle(IPC_CHANNELS.GET_MODEL_CONFIG_PATH, () => {
+        return modelConfigPath;
+      });
+      ipcMain.on(IPC_CHANNELS.OPEN_PATH, (event, folderPath: string) => {
+        shell.openPath(folderPath);
+      });
+      ipcMain.on(IPC_CHANNELS.OPEN_DEV_TOOLS, () => {
+        mainWindow?.webContents.openDevTools();
       });
       ipcMain.handle(IPC_CHANNELS.IS_PACKAGED, () => {
         return app.isPackaged;
@@ -217,8 +226,6 @@ if (!gotTheLock) {
         // TODO: Make tray setup more flexible here as not all actions depend on the python environment.
         SetupTray(
           mainWindow,
-          basePath,
-          modelConfigPath,
           () => {
             log.info('Resetting install location');
             fs.rmSync(modelConfigPath);

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,18 +1,10 @@
 import { Tray, Menu, BrowserWindow, app, shell } from 'electron';
 import path from 'path';
-import { IPC_CHANNELS } from './constants';
 import { exec } from 'child_process';
 import log from 'electron-log/main';
 import { PythonEnvironment } from './pythonEnvironment';
-import { getModelsDirectory } from './utils';
 
-export function SetupTray(
-  mainView: BrowserWindow,
-  basePath: string,
-  modelConfigPath: string,
-  reinstall: () => void,
-  pythonEnvironment: PythonEnvironment
-): Tray {
+export function SetupTray(mainView: BrowserWindow, reinstall: () => void, pythonEnvironment: PythonEnvironment): Tray {
   // Set icon for the tray
   // I think there is a way to packaged the icon in so you don't need to reference resourcesPath
   const trayImage = path.join(
@@ -63,34 +55,6 @@ export function SetupTray(
       click: () => reinstall(),
     },
     { type: 'separator' },
-    {
-      label: 'Open Models Folder',
-      click: () => shell.openPath(getModelsDirectory(basePath)),
-    },
-    {
-      label: 'Open Outputs Folder',
-      click: () => shell.openPath(path.join(basePath, 'output')),
-    },
-    {
-      label: 'Open Inputs Folder',
-      click: () => shell.openPath(path.join(basePath, 'input')),
-    },
-    {
-      label: 'Open Custom Nodes Folder',
-      click: () => shell.openPath(path.join(basePath, 'custom_nodes')),
-    },
-    {
-      label: 'Open Model Config',
-      click: () => shell.openPath(modelConfigPath),
-    },
-    {
-      label: 'Open Logs Folder',
-      click: () => shell.openPath(app.getPath('logs')),
-    },
-    {
-      label: 'Open devtools',
-      click: () => mainView.webContents.openDevTools(),
-    },
     {
       label: 'Install Python Packages (Open Terminal)',
       click: () => {


### PR DESCRIPTION
Requires https://github.com/Comfy-Org/DesktopSettingsExtension/pull/2

![image](https://github.com/user-attachments/assets/75709591-5835-4978-9bab-061f1c7a9519)

Moves folder actions and open devtools action from tray to UI help dropdown menu.