### PR TITLE
Standardize progress status

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,10 +27,43 @@ export const IPC_CHANNELS = {
   OPEN_FORUM: 'open-forum',
 } as const;
 
-export const COMFY_ERROR_MESSAGE =
-  'Was not able to start ComfyUI. Please check the logs for more details. You can open it from the Help menu. Please report issues to: https://forum.comfy.org';
+export enum ProgressStatus {
+  /**
+   * Initial state, after the app has started.
+   */
+  INITIAL_STATE = 'initial-state',
+  /**
+   * Setting up Python Environment.
+   */
+  PYTHON_SETUP = 'python-setup',
+  /**
+   * Starting ComfyUI server.
+   */
+  STARTING_SERVER = 'starting-server',
+  /**
+   * Ending state.
+   * The ComfyUI server successfully started. ComfyUI loaded into the main window.
+   */
+  READY = 'ready',
+  /**
+   * Ending state. General error state.
+   */
+  ERROR = 'error',
+  /**
+   * Error state. Installation path does not exist.
+   */
+  ERROR_INSTALL_PATH = 'error-install-path',
+}
 
-export const COMFY_FINISHING_MESSAGE = 'Finishing...';
+export const ProgressMessages = {
+  [ProgressStatus.INITIAL_STATE]: 'Loading...',
+  [ProgressStatus.PYTHON_SETUP]: 'Setting up Python Environment...',
+  [ProgressStatus.STARTING_SERVER]: 'Starting ComfyUI server...',
+  [ProgressStatus.READY]: 'Finishing...',
+  [ProgressStatus.ERROR]:
+    'Was not able to start ComfyUI. Please check the logs for more details. You can open it from the Help menu. Please report issues to: https://forum.comfy.org',
+  [ProgressStatus.ERROR_INSTALL_PATH]: 'Installation path does not exist. Please reset the installation location.',
+} as const;
 
 export type IPCChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, DownloadItem, ipcRenderer } from 'electron';
-import { IPC_CHANNELS, ELECTRON_BRIDGE_API } from './constants';
+import { IPC_CHANNELS, ELECTRON_BRIDGE_API, ProgressStatus } from './constants';
 import { DownloadStatus } from './models/DownloadManager';
 import path from 'node:path';
 
@@ -17,7 +17,7 @@ const electronAPI = {
    * Callback for progress updates from the main process for starting ComfyUI.
    * @param callback
    */
-  onProgressUpdate: (callback: (update: { status: string }) => void) => {
+  onProgressUpdate: (callback: (update: { status: ProgressStatus }) => void) => {
     ipcRenderer.on(IPC_CHANNELS.LOADING_PROGRESS, (_event, value) => {
       console.info(`Received ${IPC_CHANNELS.LOADING_PROGRESS} event`, value);
       callback(value);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -3,12 +3,7 @@ import ProgressOverlay from './screens/ProgressOverlay';
 import log from 'electron-log/renderer';
 import FirstTimeSetup from './screens/FirstTimeSetup';
 import { ElectronAPI } from 'src/preload';
-import { ELECTRON_BRIDGE_API } from 'src/constants';
-
-export interface ProgressUpdate {
-  status: string;
-  overwrite?: boolean;
-}
+import { ELECTRON_BRIDGE_API, ProgressStatus } from 'src/constants';
 
 const bodyStyle: React.CSSProperties = {
   fontFamily: 'Arial, sans-serif',
@@ -27,13 +22,12 @@ const bodyStyle: React.CSSProperties = {
 // after coming online the main.ts will replace the renderer with comfy's internal index.html
 const Home: React.FC = () => {
   const [showSetup, setShowSetup] = useState<boolean | null>(null);
-  const [status, setStatus] = useState('Starting...');
+  const [status, setStatus] = useState<ProgressStatus>(ProgressStatus.INITIAL_STATE);
   const [logs, setLogs] = useState<string[]>([]);
   const [defaultInstallLocation, setDefaultInstallLocation] = useState<string>('');
   const electronAPI: ElectronAPI = (window as any)[ELECTRON_BRIDGE_API];
 
-  const updateProgress = useCallback(({ status: newStatus }: ProgressUpdate) => {
-    log.info(`Setting new status: ${newStatus}`);
+  const updateProgress = useCallback(({ status: newStatus }: { status: ProgressStatus }) => {
     setStatus(newStatus);
     setLogs([]); // Clear logs when status changes
   }, []);

--- a/src/renderer/screens/ProgressOverlay.tsx
+++ b/src/renderer/screens/ProgressOverlay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { COMFY_ERROR_MESSAGE, COMFY_FINISHING_MESSAGE } from 'src/constants';
+import { ProgressMessages, ProgressStatus } from '/src/constants';
 import AnimatedLogDisplay from './AnimatedLogDisplay';
 import Linkify from 'linkify-react';
 
@@ -44,7 +44,7 @@ const logContainerStyle: React.CSSProperties = {
 };
 
 interface ProgressOverlayProps {
-  status: string;
+  status: ProgressStatus;
   logs: string[];
   openForum: () => void;
 }
@@ -79,10 +79,10 @@ const ProgressOverlay: React.FC<ProgressOverlayProps> = ({ status, logs, openFor
     <div style={outerContainerStyle}>
       <div style={containerStyle}>
         <div style={loadingTextStyle} id="loading-text">
-          <Linkify options={linkOptions}>{status}</Linkify>
+          <Linkify options={linkOptions}>{ProgressMessages[status]}</Linkify>
         </div>
         <div style={logContainerStyle}>
-          {status !== COMFY_FINISHING_MESSAGE && status !== COMFY_ERROR_MESSAGE && <AnimatedLogDisplay logs={logs} />}
+          {status !== ProgressStatus.READY && status !== ProgressStatus.ERROR && <AnimatedLogDisplay logs={logs} />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR standardize the progress status as an Enum for better downstream consumption.

```ts
export enum ProgressStatus {
  /**
   * Initial state, after the app has started.
   */
  INITIAL_STATE = 'initial-state',
  /**
   * Setting up Python Environment.
   */
  PYTHON_SETUP = 'python-setup',
  /**
   * Starting ComfyUI server.
   */
  STARTING_SERVER = 'starting-server',
  /**
   * Ending state.
   * The ComfyUI server successfully started. ComfyUI loaded into the main window.
   */
  READY = 'ready',
  /**
   * Ending state. General error state.
   */
  ERROR = 'error',
  /**
   * Error state. Installation path does not exist.
   */
  ERROR_INSTALL_PATH = 'error-install-path',
}
```