### PR TITLE
Add electronAPI.isFirstTimeSetup

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const IPC_CHANNELS = {
   OPEN_LOGS_PATH: 'open-logs-path',
   OPEN_DEV_TOOLS: 'open-dev-tools',
   OPEN_FORUM: 'open-forum',
+  IS_FIRST_TIME_SETUP: 'is-first-time-setup',
 } as const;
 
 export enum ProgressStatus {

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,7 +160,9 @@ if (!gotTheLock) {
       ipcMain.on(IPC_CHANNELS.OPEN_DEV_TOOLS, () => {
         appWindow.openDevTools();
       });
-
+      ipcMain.handle(IPC_CHANNELS.IS_FIRST_TIME_SETUP, () => {
+        return isFirstTimeSetup();
+      });
       await handleFirstTimeSetup();
       const basePath = await getBasePath();
       const pythonInstallPath = await getPythonInstallPath();

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -141,6 +141,12 @@ const electronAPI = {
       extras,
     });
   },
+  /**
+   * Check if the user has completed the first time setup wizard.
+   */
+  isFirstTimeSetup: (): Promise<boolean> => {
+    return ipcRenderer.invoke(IPC_CHANNELS.IS_FIRST_TIME_SETUP);
+  },
 } as const;
 
 export type ElectronAPI = typeof electronAPI;


### PR DESCRIPTION
Add `electronAPI.isFirstTimeSetup` to detect whether the user is installing the app for the first time. This can be useful later to determine whether we should show tutorial, etc.