### PR TITLE
Disable minify on main build

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -554,6 +554,7 @@ function findAvailablePort(startPort: number, endPort: number): Promise<number> 
  */
 function isFirstTimeSetup(): boolean {
   const extraModelsConfigPath = getModelConfigPath();
+  log.info(`Checking if first time setup is complete. Extra models config path: ${extraModelsConfigPath}`);
   return !fs.existsSync(extraModelsConfigPath);
 }
 

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,15 +1,13 @@
 import type { ConfigEnv, UserConfig } from 'vite';
 import { defineConfig, mergeConfig } from 'vite';
-import { getBuildConfig, getBuildDefine, external, pluginHotRestart } from './vite.base.config';
+import { getBuildConfig, external, pluginHotRestart } from './vite.base.config';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { version } from './package.json';
-import { resolve } from 'node:path';
 
 // https://vitejs.dev/config
 export default defineConfig((env) => {
-  const forgeEnv = env as ConfigEnv<'build'>;
-  const { forgeConfigSelf } = forgeEnv;
-  //const define = getBuildDefine(forgeEnv);
+  const forgeEnv = env as ConfigEnv;
+
   const config: UserConfig = {
     build: {
       outDir: '.vite/build',
@@ -22,6 +20,7 @@ export default defineConfig((env) => {
         external,
       },
       sourcemap: true,
+      minify: false,
     },
     plugins: [
       pluginHotRestart('restart'),


### PR DESCRIPTION
Disable minify to avoid following error messages with minified symbol names:
![image](https://github.com/user-attachments/assets/57505e95-4b82-4066-89b4-d2cadf50a235)
