### PR TITLE
Fix wrong download type in electronAPI

### DIFF
--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -5,7 +5,7 @@ import { IPC_CHANNELS } from '../constants';
 import log from 'electron-log/main';
 import { AppWindow } from '../main-process/appWindow';
 
-interface Download {
+export interface Download {
   url: string;
   filename: string;
   tempPath: string; // Temporary filename until the download is complete.
@@ -21,7 +21,7 @@ export enum DownloadStatus {
   ERROR = 'error',
   CANCELLED = 'cancelled',
 }
-interface DownloadState {
+export interface DownloadState {
   url: string;
   filename: string;
   state: DownloadStatus;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,6 @@
-import { contextBridge, DownloadItem, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 import { IPC_CHANNELS, ELECTRON_BRIDGE_API, ProgressStatus } from './constants';
-import { DownloadStatus } from './models/DownloadManager';
+import { DownloadState, DownloadStatus } from './models/DownloadManager';
 import path from 'node:path';
 
 /**
@@ -137,7 +137,7 @@ const electronAPI = {
     deleteModel: (filename: string, path: string): Promise<boolean> => {
       return ipcRenderer.invoke(IPC_CHANNELS.DELETE_MODEL, { filename, path });
     },
-    getAllDownloads: (): Promise<DownloadItem[]> => {
+    getAllDownloads: (): Promise<DownloadState[]> => {
       return ipcRenderer.invoke(IPC_CHANNELS.GET_ALL_DOWNLOADS);
     },
   },


### PR DESCRIPTION
Fix return value from `getAllDownloads`.