### PR TITLE
Fixed: Duplicate renderer messages being sent.

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -146,8 +146,8 @@ export class AppWindow {
       while (this.messageQueue.length > 0) {
         const message = this.messageQueue.shift();
         if (message) {
-          log.info('Sending queued message ', message.channel);
-          this.send(message.channel, message.data);
+          log.info('Sending queued message ', message.channel, message.data);
+          this.window.webContents.send(message.channel, message.data);
         }
       }
     });


### PR DESCRIPTION
By calling `this.send`, all queued messages will be sent twice.