### PR TITLE
Remove unreliable settings backup

### DIFF
--- a/src/config/comfyConfigManager.ts
+++ b/src/config/comfyConfigManager.ts
@@ -60,22 +60,11 @@ export class ComfyConfigManager {
     }
     this.createComfyDirectories(localComfyDirectory);
     const userSettingsPath = path.join(localComfyDirectory, 'user', 'default');
-    this.createComfyConfigFile(userSettingsPath, true);
+    this.createComfyConfigFile(userSettingsPath);
   }
 
-  public static createComfyConfigFile(userSettingsPath: string, overwrite: boolean = false): void {
+  public static createComfyConfigFile(userSettingsPath: string): void {
     const configFilePath = path.join(userSettingsPath, 'comfy.settings.json');
-
-    if (fs.existsSync(configFilePath) && overwrite) {
-      const backupFilePath = path.join(userSettingsPath, 'old_comfy.settings.json');
-      try {
-        fs.renameSync(configFilePath, backupFilePath);
-        log.info(`Renaming existing user settings file to: ${backupFilePath}`);
-      } catch (error) {
-        log.error(`Failed to backup existing user settings file: ${error}`);
-        return;
-      }
-    }
 
     try {
       fs.writeFileSync(configFilePath, JSON.stringify(this.DEFAULT_CONFIG, null, 2));

--- a/tests/unit/comfyConfigManager.test.ts
+++ b/tests/unit/comfyConfigManager.test.ts
@@ -89,32 +89,10 @@ describe('ComfyConfigManager', () => {
     it('should create new config file when none exists', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(false);
 
-      ComfyConfigManager.createComfyConfigFile('/fake/path', false);
+      ComfyConfigManager.createComfyConfigFile('/fake/path');
 
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
       expect(fs.renameSync).not.toHaveBeenCalled();
-    });
-
-    it('should backup existing config file when overwrite is true', () => {
-      (fs.existsSync as jest.Mock).mockImplementation((path: string) => {
-        return path === '/user/default/comfy.settings.json';
-      });
-
-      ComfyConfigManager.createComfyConfigFile('/user/default', true);
-
-      expect(fs.renameSync).toHaveBeenCalledTimes(1);
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-    });
-
-    it('should handle backup failure gracefully', () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(true);
-      (fs.renameSync as jest.Mock).mockImplementation(() => {
-        throw new Error('Backup failed');
-      });
-
-      ComfyConfigManager.createComfyConfigFile('/fake/path', true);
-
-      expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This PR removes the unreliable settings backup. The original backup logic is flawed as the `settings.old.json` can be overwritten by multiple installs.

Given following scenario:
- User installs Comfy Desktop to an existing ComfyUI repo. Their original settings is write to `settings.old.json`
- User uninstalls ComfyDesktop manually
- User installs Comfy Desktop again. The original settings `settings.old.json` will be overwritten by the default Comfy Desktop settings generated in step1.

As we banned installing in an existing ComfyUI directory, the unreliable backup logic can now be removed. 

Ref: https://github.com/Comfy-Org/electron/pull/256