### PR TITLE
Move findAvailablePort to utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import * as net from 'net';
 import * as fsPromises from 'node:fs/promises';
 import path from 'node:path';
 
@@ -12,4 +13,28 @@ export async function pathAccessible(path: string): Promise<boolean> {
 
 export function getModelsDirectory(comfyUIBasePath: string): string {
   return path.join(comfyUIBasePath, 'models');
+}
+
+export function findAvailablePort(host: string, startPort: number, endPort: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    function tryPort(port: number) {
+      if (port > endPort) {
+        reject(new Error('No available ports found'));
+        return;
+      }
+
+      const server = net.createServer();
+      server.listen(port, host, () => {
+        server.once('close', () => {
+          resolve(port);
+        });
+        server.close();
+      });
+      server.on('error', () => {
+        tryPort(port + 1);
+      });
+    }
+
+    tryPort(startPort);
+  });
 }


### PR DESCRIPTION
Decouples `findAvailablePort`'s dependency on `host` global var.