### PR TITLE
Skip build CI step for README and config files.

### DIFF
--- a/.github/workflows/debug_all.yml
+++ b/.github/workflows/debug_all.yml
@@ -5,20 +5,28 @@ on:
     branches:
       - 'main'
     paths-ignore:
-      - '.github/**'
       - '.prettierrc'
       - '.eslintrc.json'
       - '.prettierignore'
       - 'README.md'
+      - 'husky/**'
+      - '.vscode/**'
+      - 'scripts/**'
+      - '.gitignore'
+      - 'todesktop.json'
   push:
     branches:
       - 'main'
     paths-ignore:
-      - '.github/**'
       - '.prettierrc'
       - '.eslintrc.json'
       - '.prettierignore'
       - 'README.md'
+      - 'husky/**'
+      - '.vscode/**'
+      - 'scripts/**'
+      - '.gitignore'
+      - 'todesktop.json'
 
 jobs:
   build-windows-debug-all:


### PR DESCRIPTION
Skip for README, and other config files.

Enable for github workflows + package.json.