### PR TITLE
Fixed: Error when user does not choose migration location

### DIFF
--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -208,11 +208,9 @@ export class ComfyServerConfig {
   public static async getMigrationConfig(
     migrationSource?: string,
     migrationItemIds: Set<string> = new Set()
-  ): Promise<Record<string, ModelPaths>> {
+  ): Promise<{ comfyui: ModelPaths } & Record<string, ModelPaths>> {
     if (!migrationSource || !migrationItemIds.has('models')) {
-      return {
-        comfyui: {},
-      };
+      return { comfyui: {} };
     }
     // The yaml file exited in migration source repo.
     const migrationServerConfig = await ComfyServerConfig.getConfigFromRepoPath(migrationSource);

--- a/tests/unit/comfyServerConfig.test.ts
+++ b/tests/unit/comfyServerConfig.test.ts
@@ -141,7 +141,9 @@ comfyui:
   describe('getMigrationConfig', () => {
     it('should return empty object when no migration source is provided', async () => {
       const result = await ComfyServerConfig.getMigrationConfig(undefined);
-      expect(result).toEqual({});
+      expect(result).toEqual({
+        comfyui: {},
+      });
     });
 
     it('should merge configs and remove custom_nodes when migration source is provided', async () => {


### PR DESCRIPTION
If user doesn't choose a migration location, the `getMigrationConfig` returns an empty dictionary. But the caller depends on the `comfyui` key being there:

```
const { comfyui: comfyuiConfig, ...extraConfigs } = await ComfyServerConfig.getMigrationConfig(
    migrationSource,
    migrationItemIds
  );
  comfyuiConfig['base_path'] = actualComfyDirectory;
  ```

Updated the return type to make sure `comfyui` is in the return value.

```
17:02:52.116 › Created new ComfyUI config file at: /Users/junhanhuang/Desktop/ComfyUI/user/default/comfy.settings.json
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
TypeError: Cannot set properties of undefined (setting 'base_path')
    at handleInstall (/Users/junhanhuang/Documents/electron/.vite/build/main.js:24636:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    ```