### PR TITLE
Update frontend to 1.4.0 and remove DesktopSettingsExtension requirement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": ".vite/build/main.js",
   "packageManager": "yarn@4.5.0",
   "config": {
-    "frontendVersion": "1.3.43",
+    "frontendVersion": "1.4.0",
     "comfyVersion": "0.2.7",
     "managerCommit": "e629215c100c89a9a9d33fc03be3248069ff67ef",
     "uvVersion": "0.5.1"
@@ -19,12 +19,11 @@
     "clean:uv": "rimraf assets/uv",
     "clean:assets": "rimraf assets/.env assets/ComfyUI assets/python.tgz & yarn run clean:assets:dev",
     "clean:assets:dev": "yarn run clean:assets:git && rimraf assets/python assets/override.txt & rimraf assets/cpython*.tar.gz & rimraf assets/requirements.*",
-    "clean:assets:git": "rimraf assets/ComfyUI/.git assets/ComfyUI/custom_nodes/ComfyUI_Manager/.git assets/ComfyUI/custom_nodes/DesktopSettingsExtension/.git",
+    "clean:assets:git": "rimraf assets/ComfyUI/.git assets/ComfyUI/custom_nodes/ComfyUI_Manager/.git",
     "clean:slate": "yarn run clean & yarn run clean:assets & rimraf node_modules",
-    "clone-settings-extension": "git clone https://github.com/Comfy-Org/DesktopSettingsExtension.git assets/ComfyUI/custom_nodes/DesktopSettingsExtension",
     "download:uv": "node scripts/downloadUV.js",
     "download-frontend": "node scripts/downloadFrontend.js",
-    "make:frontend": "yarn run download-frontend && yarn run clone-settings-extension",
+    "make:frontend": "yarn run download-frontend",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint": "eslint --ext .ts,.tsx .",


### PR DESCRIPTION
Now that settings has migrated to ComfyUI_frontend and is available in 1.4.0, we can remove the DesktopSettingsExtension.