### PR TITLE
Sanity check if the double yarn install bug happens again

### DIFF
--- a/scripts/todesktop/postInstall.js
+++ b/scripts/todesktop/postInstall.js
@@ -11,6 +11,10 @@ async function postInstall() {
     if (!firstInstallOnToDesktopServers) return;
 
     console.log('After Yarn Install ' , os.platform());
+    if (fs.existsSync(path.join('./assets','ComfyUI')))
+    {
+        throw new Error("ComfyUI has already been installed!");
+    }
 
     if (os.platform() === "win32")
     {
@@ -52,7 +56,7 @@ async function postInstall() {
         fs.rmSync(path.join('./assets', tgzFile));
       }
     });
-
+    
 };
 
 postInstall();


### PR DESCRIPTION
There was a bug in ToDesktop that would cause the second yarn install to not have the correct "first run" flag. Although that is fixed this will catch any other scenario that would cause comfyUI to try to install again.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-284-Sanity-check-if-the-double-yarn-install-bug-happens-again-15f6d73d365081bc9734dab9584d932d) by [Unito](https://www.unito.io)
