### PR TITLE
Rename SendCrashStatistics to SendStatistics

### DIFF
--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -4,12 +4,12 @@ import log from 'electron-log/main';
 
 const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy-Desktop.AutoUpdate': true,
-  'Comfy-Desktop.SendCrashStatistics': true,
+  'Comfy-Desktop.SendStatistics': true,
 } as const;
 
 export interface ComfySettingsData {
   'Comfy-Desktop.AutoUpdate': boolean;
-  'Comfy-Desktop.SendCrashStatistics': boolean;
+  'Comfy-Desktop.SendStatistics': boolean;
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,7 @@ if (!gotTheLock) {
     try {
       const comfyDesktopApp = await ComfyDesktopApp.create(appWindow);
       await comfyDesktopApp.initialize();
-      alwaysSendCrashReports = comfyDesktopApp.comfySettings.get('Comfy-Desktop.SendCrashStatistics');
+      alwaysSendCrashReports = comfyDesktopApp.comfySettings.get('Comfy-Desktop.SendStatistics');
 
       const useExternalServer = process.env.USE_EXTERNAL_SERVER === 'true';
       const host = process.env.COMFY_HOST || DEFAULT_SERVER_ARGS.host;


### PR DESCRIPTION
We want to use a single setting to control reporting of all kind of metrics instead of just crash metrics