### PR TITLE
Write comfy desktop install options to settings

### DIFF
--- a/src/config/comfyConfigManager.ts
+++ b/src/config/comfyConfigManager.ts
@@ -47,31 +47,11 @@ export class ComfyConfigManager {
     ],
   ];
 
-  private static readonly DEFAULT_CONFIG = {
-    'Comfy.ColorPalette': 'dark',
-    'Comfy.UseNewMenu': 'Top',
-    'Comfy.Workflow.WorkflowTabsPosition': 'Topbar',
-    'Comfy.Workflow.ShowMissingModelsWarning': true,
-  };
-
   public static setUpComfyUI(localComfyDirectory: string) {
     if (fs.existsSync(localComfyDirectory)) {
       throw new Error(`Selected directory ${localComfyDirectory} already exists`);
     }
     this.createComfyDirectories(localComfyDirectory);
-    const userSettingsPath = path.join(localComfyDirectory, 'user', 'default');
-    this.createComfyConfigFile(userSettingsPath);
-  }
-
-  public static createComfyConfigFile(userSettingsPath: string): void {
-    const configFilePath = path.join(userSettingsPath, 'comfy.settings.json');
-
-    try {
-      fs.writeFileSync(configFilePath, JSON.stringify(this.DEFAULT_CONFIG, null, 2));
-      log.info(`Created new ComfyUI config file at: ${configFilePath}`);
-    } catch (error) {
-      log.error(`Failed to create new ComfyUI config file: ${error}`);
-    }
   }
 
   public static isComfyUIDirectory(directory: string): boolean {

--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -2,14 +2,19 @@ import * as fs from 'fs';
 import * as path from 'path';
 import log from 'electron-log/main';
 
-const DEFAULT_SETTINGS: ComfySettingsData = {
+export const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy-Desktop.AutoUpdate': true,
   'Comfy-Desktop.SendStatistics': true,
+  'Comfy.ColorPalette': 'dark',
+  'Comfy.UseNewMenu': 'Top',
+  'Comfy.Workflow.WorkflowTabsPosition': 'Topbar',
+  'Comfy.Workflow.ShowMissingModelsWarning': true,
 } as const;
 
 export interface ComfySettingsData {
   'Comfy-Desktop.AutoUpdate': boolean;
   'Comfy-Desktop.SendStatistics': boolean;
+  [key: string]: unknown;
 }
 
 /**

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/electron/main';
 import { graphics } from 'systeminformation';
 import todesktop from '@todesktop/runtime';
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
-import { ComfySettings } from '../config/comfySettings';
+import { ComfySettings, DEFAULT_SETTINGS } from '../config/comfySettings';
 import { AppWindow } from './appWindow';
 import { ComfyServer } from './comfyServer';
 import { ComfyServerConfig } from '../config/comfyServerConfig';
@@ -134,8 +134,21 @@ export class ComfyDesktopApp {
         const migrationItemIds = new Set<string>(installOptions.migrationItemIds ?? []);
 
         const basePath = path.join(installOptions.installPath, 'ComfyUI');
+        // Setup folder structures.
         ComfyConfigManager.setUpComfyUI(basePath);
 
+        // Setup comfy.settings.json file
+        const settings = {
+          ...DEFAULT_SETTINGS,
+          'Comfy-Desktop.AutoUpdate': installOptions.autoUpdate,
+          'Comfy-Desktop.SendStatistics': installOptions.allowMetrics,
+        };
+        const settingsJson = JSON.stringify(settings, null, 2);
+        const settingsPath = path.join(basePath, 'user', 'default', 'comfy.settings.json');
+        fs.writeFileSync(settingsPath, settingsJson);
+        log.info(`Wrote settings to ${settingsPath}: ${settingsJson}`);
+
+        // Setup extra_model_paths.yaml file
         const { comfyui: comfyuiConfig, ...extraConfigs } = await ComfyServerConfig.getMigrationConfig(
           migrationSource,
           migrationItemIds

--- a/tests/unit/comfyConfigManager.test.ts
+++ b/tests/unit/comfyConfigManager.test.ts
@@ -85,17 +85,6 @@ describe('ComfyConfigManager', () => {
     });
   });
 
-  describe('createComfyConfigFile', () => {
-    it('should create new config file when none exists', () => {
-      (fs.existsSync as jest.Mock).mockReturnValue(false);
-
-      ComfyConfigManager.createComfyConfigFile('/fake/path');
-
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-      expect(fs.renameSync).not.toHaveBeenCalled();
-    });
-  });
-
   describe('createNestedDirectories', () => {
     it('should create nested directory structure correctly', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(false);


### PR DESCRIPTION
Write desktop specific config from install view to config json.

Sample log:
```
22:54:22.920 > Wrote settings to C:\Users\hcl\Documents\ComfyUI\user\default\comfy.settings.json: {
  "Comfy-Desktop.AutoUpdate": false,
  "Comfy-Desktop.SendStatistics": true,
  "Comfy.ColorPalette": "dark",
  "Comfy.UseNewMenu": "Top",
  "Comfy.Workflow.WorkflowTabsPosition": "Topbar",
  "Comfy.Workflow.ShowMissingModelsWarning": true
}
```