### PR TITLE
[cleanup] Remove index.css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,0 @@
-body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  margin: auto;
-}


### PR DESCRIPTION
`index.html` was removed in https://github.com/Comfy-Org/desktop/pull/251. This PR cleans up index.css which is no longer used.