### PR TITLE
Fix leaked electron impl in types library

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -108,3 +108,12 @@ export const DEFAULT_SERVER_ARGS = {
 };
 
 export type ServerArgs = typeof DEFAULT_SERVER_ARGS;
+
+export enum DownloadStatus {
+  PENDING = 'pending',
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  PAUSED = 'paused',
+  ERROR = 'error',
+  CANCELLED = 'cancelled',
+}

--- a/src/main_types.ts
+++ b/src/main_types.ts
@@ -1,8 +1,3 @@
 export * from './constants';
-export * from './models/DownloadManager';
+export type { DownloadManager, Download } from './models/DownloadManager';
 export type { ElectronAPI } from './preload';
-
-import { ElectronAPI } from './preload';
-declare global {
-  const electronAPI: ElectronAPI;
-}

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { IPC_CHANNELS } from '../constants';
 import log from 'electron-log/main';
-import { AppWindow } from '../main-process/appWindow';
+import type { AppWindow } from '../main-process/appWindow';
+import { DownloadStatus } from '../main_types';
 
 export interface Download {
   url: string;
@@ -13,14 +14,6 @@ export interface Download {
   item: DownloadItem | null;
 }
 
-export enum DownloadStatus {
-  PENDING = 'pending',
-  IN_PROGRESS = 'in_progress',
-  COMPLETED = 'completed',
-  PAUSED = 'paused',
-  ERROR = 'error',
-  CANCELLED = 'cancelled',
-}
 export interface DownloadState {
   url: string;
   filename: string;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { IPC_CHANNELS, ELECTRON_BRIDGE_API, ProgressStatus } from './constants';
-import { DownloadState, DownloadStatus } from './models/DownloadManager';
+import { IPC_CHANNELS, ELECTRON_BRIDGE_API, ProgressStatus, DownloadStatus } from './constants';
+import type { DownloadState } from './models/DownloadManager';
 import path from 'node:path';
 
 /**

--- a/vite.types.config.ts
+++ b/vite.types.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     rollupOptions: {
       external: ['electron'],
     },
+    minify: false,
   },
   plugins: [
     dts({


### PR DESCRIPTION
This PR moves the enum definiton of `DownloadStatus` to `constants.ts` so that we do pure type import from `DownloadManager.ts`. This prevents the electron specific implementation being built into the type library.

Related issue:
https://github.com/Comfy-Org/ComfyUI_frontend/issues/1624