### PR TITLE
Install nightly pytorch for macos.

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -134,16 +134,17 @@ export class VirtualEnvironment {
   }
 
   public async installRequirements(callbacks?: ProcessCallbacks): Promise<void> {
-    const installCmd = ['pip', 'install', '-r', this.requirementsCompiledPath, '--index-strategy', 'unsafe-best-match'];
+    if (process.platform === 'darwin') {
+      return this.manualInstall(callbacks);
+    }
 
+    const installCmd = ['pip', 'install', '-r', this.requirementsCompiledPath, '--index-strategy', 'unsafe-best-match'];
     const { exitCode } = await this.runUvCommandAsync(installCmd, callbacks);
-    if (exitCode !== 0) {
+    if (exitCode == 0) {
       log.error(
         `Failed to install requirements.compiled: exit code ${exitCode}. Falling back to installing requirements.txt`
       );
-      await this.installPytorch(callbacks);
-      await this.installComfyUIRequirements(callbacks);
-      await this.installComfyUIManagerRequirements(callbacks);
+      return this.manualInstall(callbacks);
     }
   }
 
@@ -268,6 +269,12 @@ export class VirtualEnvironment {
         reject(err);
       });
     });
+  }
+
+  private async manualInstall(callbacks?: ProcessCallbacks): Promise<void> {
+    await this.installPytorch(callbacks);
+    await this.installComfyUIRequirements(callbacks);
+    await this.installComfyUIManagerRequirements(callbacks);
   }
 
   private async installPytorch(callbacks?: ProcessCallbacks): Promise<void> {


### PR DESCRIPTION
Requirements.compiled currently does not take into account pypi prereleases. Not sure how to fix that so just doing manual install for macos for now.