### PR TITLE
Settings store

### DIFF
--- a/scripts/resetInstall.js
+++ b/scripts/resetInstall.js
@@ -6,15 +6,16 @@ const readline = require('readline');
 
 /**
  * Get the path to the extra_models_config.yaml file based on the platform.
+ * @param {string} filename The name of the file to find in the user data folder
  * @returns The path to the extra_models_config.yaml file.
  */
 
-function getConfigPath() {
+function getConfigPath(filename) {
   switch (process.platform) {
     case 'darwin': // macOS
-      return path.join(os.homedir(), 'Library', 'Application Support', 'ComfyUI', 'extra_models_config.yaml');
+      return path.join(os.homedir(), 'Library', 'Application Support', 'ComfyUI', filename);
     case 'win32': // Windows
-      return path.join(process.env.APPDATA, 'ComfyUI', 'extra_models_config.yaml');
+      return path.join(process.env.APPDATA, 'ComfyUI', filename);
     default:
       console.log('Platform not supported for this operation');
       process.exit(1);
@@ -37,27 +38,54 @@ async function askForConfirmation(question) {
 
 async function main() {
   try {
-    const configPath = getConfigPath();
+    const configPath = getConfigPath('config.json');
+    const windowStorePath = getConfigPath('window.json');
+    const modelsConfigPath = getConfigPath('extra_models_config.yaml');
+    let desktopBasePath = null;
     let basePath = null;
 
-    // Read base_path before deleting the config file
+    // Read basePath from desktop config
     if (fs.existsSync(configPath)) {
       const configContent = fs.readFileSync(configPath, 'utf8');
+      const parsed = JSON.parse(configContent);
+      desktopBasePath = parsed?.basePath;
+    }
+
+    // Read base_path before deleting the config file
+    if (fs.existsSync(modelsConfigPath)) {
+      const configContent = fs.readFileSync(modelsConfigPath, 'utf8');
       const config = yaml.parse(configContent);
       basePath = config?.comfyui?.base_path;
-      
-      // Delete config file
-      fs.unlinkSync(configPath);
-      console.log(`Successfully removed ${configPath}`);
     } else {
       console.log('Config file not found, nothing to remove');
     }
 
-    // If base_path exists, ask user if they want to delete it
-    if (basePath && fs.existsSync(basePath)) {
-      console.log(`Found ComfyUI installation directory at: ${basePath}`);
+    // Delete all config files
+    for (const file of [configPath, windowStorePath, modelsConfigPath]) {
+      if (fs.existsSync(file)) {
+        fs.unlinkSync(file);
+        console.log(`Successfully removed ${file}`);
+      }
+    }
+
+    // If config.json basePath exists, ask user if they want to delete it
+    if (desktopBasePath && fs.existsSync(desktopBasePath)) {
+      console.log(`Found ComfyUI installation directory at: ${desktopBasePath}`);
       const shouldDelete = await askForConfirmation('Would you like to delete this directory as well?');
-      
+
+      if (shouldDelete) {
+        fs.rmSync(desktopBasePath, { recursive: true, force: true });
+        console.log(`Successfully removed ComfyUI directory at ${desktopBasePath}`);
+      } else {
+        console.log('Skipping ComfyUI directory deletion');
+      }
+    }
+
+    // If base_path exists and does not match basePath, ask user if they want to delete it
+    if (basePath && basePath !== desktopBasePath && fs.existsSync(basePath)) {
+      console.log(`Found ComfyUI models directory at: ${basePath}`);
+      const shouldDelete = await askForConfirmation('Would you like to delete this directory as well?');
+
       if (shouldDelete) {
         fs.rmSync(basePath, { recursive: true, force: true });
         console.log(`Successfully removed ComfyUI directory at ${basePath}`);

--- a/src/install/installationValidator.ts
+++ b/src/install/installationValidator.ts
@@ -1,0 +1,29 @@
+import { app, dialog, shell } from 'electron';
+
+export class InstallationValidator {
+  /**
+   * Shows a dialog box with an option to open the problematic file in the native shell file viewer.
+   * @param options The options paramter of {@link dialog.showMessageBox}, filled with defaults for invalid config
+   * @returns
+   */
+  static async showInvalidFileAndQuit(file: string, options: Electron.MessageBoxOptions): Promise<void> {
+    const defaults: Electron.MessageBoxOptions = {
+      // Message must be set by caller.
+      message: `Was unable to read the file shown below.  It could be missing, inaccessible, or corrupt.\n\n${file}`,
+      title: 'Invalid file',
+      type: 'error',
+      buttons: ['Locate the &file (then quit)', '&Quit'],
+      defaultId: 0,
+      cancelId: 1,
+      normalizeAccessKeys: true,
+    };
+    const opt = Object.assign(defaults, options);
+
+    const result = await dialog.showMessageBox(opt);
+
+    if (result.response === 0) shell.showItemInFolder(file);
+    app.quit();
+    // Wait patiently for graceful termination.
+    await new Promise(() => {});
+  }
+}

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, screen, app, shell, ipcMain, Tray, Menu, dialog, MenuItem } from 'electron';
 import path from 'node:path';
 import Store from 'electron-store';
-import { StoreType } from '../store';
+import { AppWindowSettings } from '../store';
 import log from 'electron-log/main';
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { getAppResourcesPath } from '../install/resourcePaths';
@@ -12,7 +12,7 @@ import { getAppResourcesPath } from '../install/resourcePaths';
  */
 export class AppWindow {
   private window: BrowserWindow;
-  private store: Store<StoreType>;
+  private store: Store<AppWindowSettings>;
   private messageQueue: Array<{ channel: string; data: any }> = [];
   private rendererReady: boolean = false;
 
@@ -142,10 +142,10 @@ export class AppWindow {
    * There are edge cases where this might not be a catastrophic failure, but inability
    * to write to our own datastore may result in unexpected user data loss.
    */
-  private loadWindowStore(): Store<StoreType> {
+  private loadWindowStore(): Store<AppWindowSettings> {
     try {
       // Separate file for non-critical convenience settings - just resets itself if invalid
-      return new Store<StoreType>({
+      return new Store<AppWindowSettings>({
         clearInvalidConfig: true,
         name: 'window',
       });

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -16,7 +16,7 @@ import { DownloadManager } from '../models/DownloadManager';
 import { VirtualEnvironment } from '../virtualEnvironment';
 import { InstallWizard } from '../install/installWizard';
 import { Terminal } from '../terminal';
-import { useDesktopStore } from '../store/store';
+import { DesktopConfig } from '../store/desktopConfig';
 import { InstallationValidator } from '../install/installationValidator';
 import { restoreCustomNodes } from '../services/backup';
 
@@ -146,7 +146,7 @@ export class ComfyDesktopApp {
     return new Promise<string>((resolve) => {
       ipcMain.on(IPC_CHANNELS.INSTALL_COMFYUI, async (event, installOptions: InstallOptions) => {
         const installWizard = new InstallWizard(installOptions);
-        const { store } = useDesktopStore();
+        const { store } = DesktopConfig;
         store.set('basePath', installWizard.basePath);
 
         await installWizard.install();
@@ -187,7 +187,7 @@ export class ComfyDesktopApp {
         this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
       },
     });
-    const { store } = useDesktopStore();
+    const { store } = DesktopConfig;
     if (!store.get('Comfy-Desktop.RestoredCustomNodes', false)) {
       try {
         await restoreCustomNodes(virtualEnvironment, this.appWindow);
@@ -205,7 +205,7 @@ export class ComfyDesktopApp {
   }
 
   static async create(appWindow: AppWindow): Promise<ComfyDesktopApp> {
-    const { store } = useDesktopStore();
+    const { store } = DesktopConfig;
     // Migrate settings from old version if required
     const installState = store.get('installState') ?? (await ComfyDesktopApp.migrateInstallState());
 
@@ -228,7 +228,7 @@ export class ComfyDesktopApp {
     const basePath = await ComfyDesktopApp.loadBasePath();
 
     // Migrate config
-    const { store } = useDesktopStore();
+    const { store } = DesktopConfig;
     const upgraded = 'upgraded';
     store.set('installState', upgraded);
     store.set('basePath', basePath);

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -17,6 +17,7 @@ import { VirtualEnvironment } from '../virtualEnvironment';
 import { InstallWizard } from '../install/installWizard';
 import { Terminal } from '../terminal';
 import { useDesktopStore } from '../store/store';
+import { InstallationValidator } from '../install/installationValidator';
 import { restoreCustomNodes } from '../services/backup';
 
 export class ComfyDesktopApp {
@@ -205,14 +206,45 @@ export class ComfyDesktopApp {
 
   static async create(appWindow: AppWindow): Promise<ComfyDesktopApp> {
     const { store } = useDesktopStore();
+    // Migrate settings from old version if required
+    const installState = store.get('installState') ?? (await ComfyDesktopApp.migrateInstallState());
 
-    const installed = store.get('installState') === 'installed';
-    const basePath = installed ? store.get('basePath') : await this.install(appWindow);
+    // Fresh install
+    const basePath =
+      installState === undefined ? await ComfyDesktopApp.install(appWindow) : await ComfyDesktopApp.loadBasePath();
 
-    if (!basePath) {
-      throw new Error(`Base path not found! ${ComfyServerConfig.configPath} is probably corrupted.`);
-    }
     return new ComfyDesktopApp(basePath, new ComfySettings(basePath), appWindow);
+  }
+
+  /**
+   * Sets the ugpraded state if this is a version upgrade from <= 0.3.18
+   * @returns 'upgraded' if this install has just been upgraded, or undefined for a fresh install
+   */
+  static async migrateInstallState(): Promise<string | undefined> {
+    // Fresh install
+    if (!ComfyServerConfig.exists()) return undefined;
+
+    // Upgrade
+    const basePath = await ComfyDesktopApp.loadBasePath();
+
+    // Migrate config
+    const { store } = useDesktopStore();
+    const upgraded = 'upgraded';
+    store.set('installState', upgraded);
+    store.set('basePath', basePath);
+    return upgraded;
+  }
+
+  /** Loads the base_path value from the YAML config. Quits in the event of failure. */
+  static async loadBasePath(): Promise<string> {
+    const basePath = await ComfyServerConfig.readBasePathFromConfig(ComfyServerConfig.configPath);
+    if (basePath) return basePath;
+
+    log.error(`Base path not found! ${ComfyServerConfig.configPath} is probably corrupted.`);
+    await InstallationValidator.showInvalidFileAndQuit(ComfyServerConfig.configPath, {
+      message: `Base path not found! This file is probably corrupt:\n\n${ComfyServerConfig.configPath}`,
+    });
+    throw new Error(/* Unreachable. */);
   }
 
   uninstall(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { AppInfoHandlers } from './handlers/appInfoHandlers';
 import { ComfyDesktopApp } from './main-process/comfyDesktopApp';
 import { LevelOption } from 'electron-log';
 import SentryLogging from './services/sentry';
+import { useDesktopStore } from './store/store';
 
 dotenv.config();
 log.initialize();
@@ -40,6 +41,17 @@ if (!gotTheLock) {
   app.on('ready', async () => {
     log.debug('App ready');
 
+    const store = await useDesktopStore().loadStore();
+    if (store) {
+      startApp();
+    } else {
+      app.exit(20);
+    }
+  });
+}
+
+async function startApp() {
+  try {
     const appWindow = new AppWindow();
     appWindow.onClose(() => {
       log.info('App window closed. Quitting application.');
@@ -79,5 +91,8 @@ if (!gotTheLock) {
       appWindow.sendServerStartProgress(ProgressStatus.ERROR);
       appWindow.send(IPC_CHANNELS.LOG_MESSAGE, error);
     }
-  });
+  } catch (error) {
+    log.error('Fatal error occurred during app startup.', error);
+    app.exit(2024);
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { AppInfoHandlers } from './handlers/appInfoHandlers';
 import { ComfyDesktopApp } from './main-process/comfyDesktopApp';
 import { LevelOption } from 'electron-log';
 import SentryLogging from './services/sentry';
-import { useDesktopStore } from './store/store';
+import { DesktopConfig } from './store/desktopConfig';
 
 dotenv.config();
 log.initialize();
@@ -41,7 +41,7 @@ if (!gotTheLock) {
   app.on('ready', async () => {
     log.debug('App ready');
 
-    const store = await useDesktopStore().loadStore();
+    const store = await DesktopConfig.load();
     if (store) {
       startApp();
     } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,5 +7,6 @@ export type AppWindowSettings = {
 };
 
 export type DesktopSettings = {
-  installState: 'started' | 'installed' | undefined;
-}
+  basePath?: string;
+  installState?: 'started' | 'installed';
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,4 @@
-export type StoreType = {
+export type AppWindowSettings = {
   windowWidth: number;
   windowHeight: number;
   windowX: number | undefined;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,5 +8,5 @@ export type AppWindowSettings = {
 
 export type DesktopSettings = {
   basePath?: string;
-  installState?: 'started' | 'installed';
+  installState?: 'started' | 'installed' | 'upgraded';
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,3 +5,7 @@ export type AppWindowSettings = {
   windowY: number | undefined;
   windowMaximized?: boolean;
 };
+
+export type DesktopSettings = {
+  installState: 'started' | 'installed' | undefined;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,5 +8,12 @@ export type AppWindowSettings = {
 
 export type DesktopSettings = {
   basePath?: string;
+  /**
+   * The state of the installation.
+   * - `started`: The installation has started.
+   * - `installed`: A fresh installation.
+   * - `upgraded`: An upgrade from a previous version that stores the base path
+   * in the yaml config.
+   */
   installState?: 'started' | 'installed' | 'upgraded';
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,99 @@
+import log from 'electron-log/main';
+import ElectronStore from 'electron-store';
+import { app, dialog } from 'electron';
+import path from 'node:path';
+import fs from 'fs/promises';
+import type { DesktopSettings } from '.';
+
+let currentStore: ElectronStore<DesktopSettings>;
+
+/** Generic wrapper class to load electron stores and handle errors. */
+export function useDesktopStore() {
+  const store = currentStore;
+
+  async function loadStore(
+    options?: ConstructorParameters<typeof ElectronStore<DesktopSettings>>[0]
+  ): Promise<ElectronStore<DesktopSettings> | undefined> {
+    try {
+      currentStore = new ElectronStore<DesktopSettings>(options);
+      return currentStore;
+    } catch (error) {
+      const configFilePath = path.join(getUserDataOrQuit(), `${options?.name ?? 'config'}.json`);
+
+      if (error instanceof SyntaxError) {
+        // The .json file is invalid.  Prompt user to reset.
+        const { response } = await showResetPrompt(configFilePath);
+
+        // You sure?
+        if (response === 0) {
+          const { response } = await showConfirmReset(configFilePath);
+
+          if (response === 0) {
+            // Delete all settings
+            await tryDeleteConfigFile(configFilePath);
+
+            // Causing a stack overflow from this recursion would take immense patience.
+            return loadStore(options);
+          }
+        }
+
+        // User chose to exit
+        app.quit();
+      } else {
+        // Crash: Unknown filesystem error, permission denied on user data folder, etc
+        log.error(`Unknown error whilst loading configuration file: ${configFilePath}`, error);
+        dialog.showErrorBox('User Data', `Unknown error whilst writing to user data folder:\n\n${configFilePath}`);
+      }
+    }
+  }
+
+  return {
+    store,
+    loadStore,
+  };
+}
+
+function showResetPrompt(configFilePath: string): Promise<Electron.MessageBoxReturnValue> {
+  return dialog.showMessageBox({
+    title: 'Invalid configuration file',
+    type: 'error',
+    message: `Format of the configuration file is invalid:\n\n${configFilePath}`,
+    buttons: ['&Reset the configuration file', '&Quit'],
+    defaultId: 1,
+    cancelId: 1,
+    normalizeAccessKeys: true,
+  });
+}
+
+function showConfirmReset(configFilePath: string): Promise<Electron.MessageBoxReturnValue> {
+  return dialog.showMessageBox({
+    title: 'Confirm reset settings',
+    type: 'warning',
+    message: `The configuration file below will be cleared and all settings will be reset.  You should back this file up before deleting it.\n\n${configFilePath}`,
+    buttons: ['Try to open the &file', '&Yes, delete all settings', '&Quit'],
+    defaultId: 1,
+    cancelId: 1,
+    normalizeAccessKeys: true,
+  });
+}
+
+async function tryDeleteConfigFile(configFilePath: string) {
+  try {
+    await fs.rm(configFilePath);
+  } catch (error) {
+    log.error(`Unable to delete configuration file: ${configFilePath}`, error);
+    dialog.showErrorBox('Delete Failed', `Unknown error whilst attempting to delete config file:\n\n${configFilePath}`);
+  }
+}
+
+function getUserDataOrQuit() {
+  try {
+    return app.getPath('userData');
+  } catch (error) {
+    // Crash: Can't even find the user userData folder
+    log.error('Cannot find user data folder.', error);
+    dialog.showErrorBox('User Data', 'Unknown error whilst attempting to determine user data folder.');
+    app.quit();
+    throw error;
+  }
+}


### PR DESCRIPTION
Adds an electron-store config store to house desktop-specific installation state / config.  Includes fairly(?) complete error handling and pre-window interaction.

### `config.json`

```json
{
  "basePath": "C:\\Users\\User\\Documents\\ComfyUI",
  "installState": "installed"
}
```

- Install state is `undefined` until an install has started, `'started'`, or `'installed'`.
  - `'upgraded'` status is temporarily used when upgrading from a version prior to this PR, and changed to `'installed'` when successful
- Base path is set immediately before the install process starts
  - The `base_path` in `extra_models_config.yaml` is still the source of truth
  - `basePath` in config.json is used as a fallback only

### Failures
If the settings store is invalid (file is present, but can't be parsed as json), the user is prompted to resolve the issue:

![image](https://github.com/user-attachments/assets/400dfb8d-6a5b-4711-8c90-75bf7f8a26c8)

Confirmation if they choose to reset:

![image](https://github.com/user-attachments/assets/a3354f96-4599-437f-91e4-5d141dd5b339)

Resolves #360 