### PR TITLE
Installer window

### DIFF
--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -153,6 +153,7 @@ export class ComfyDesktopApp {
 
         await installWizard.install();
         store.set('installState', 'installed');
+        appWindow.maximize();
         resolve(installWizard.basePath);
       });
     });


### PR DESCRIPTION
- Requires #362

This simply has different window sizes for the install process:
- Window starts centred on screen, 1024 x 768
- User runs through the install process
- Window is maximised as the final step of installation
- Also increases the window min size to 640 x 640
- No effect if the user has moved or altered the window before in any way

#### 32:9 - New default window size / position

![image](https://github.com/user-attachments/assets/f1d89c23-3163-4be9-92d2-abcf8bfd68f7)

#### 16:9 - Same window size, half screen res

![image](https://github.com/user-attachments/assets/dd3078d2-4635-4527-b43f-159f1c5c679e)
