### PR TITLE
Fixes running uv command with spaces in path

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -196,8 +196,9 @@ export class VirtualEnvironment {
    * @returns
    */
   public async runUvCommandAsync(args: string[], callbacks?: ProcessCallbacks): Promise<{ exitCode: number | null }> {
-    log.info(`Running uv command: ${this.uvPath} ${args.join(' ')}`);
-    return this.runPtyCommandAsync(`${this.uvPath} ${args.map((a) => `"${a}"`).join(' ')}`, callbacks?.onStdout);
+    const uvCommand = os.platform() === 'win32' ? `&"${this.uvPath}"` : this.uvPath;
+    log.info(`Running uv command: ${uvCommand} ${args.join(' ')}`);
+    return this.runPtyCommandAsync(`${uvCommand} ${args.map((a) => `"${a}"`).join(' ')}`, callbacks?.onStdout);
   }
 
   private async runPtyCommandAsync(command: string, onData?: (data: string) => void): Promise<{ exitCode: number }> {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/95fddadd-ad3c-4e92-a0a2-7ffaec7efa90)

![image](https://github.com/user-attachments/assets/665d7a7c-98ad-4758-ab8e-bcb9369c0bcb)

This fix is only applied on Windows/Powershell