### PR TITLE
Fix activating venv in integrated terminal

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -110,10 +110,10 @@ export class VirtualEnvironment {
    */
   public activateEnvironmentCommand(): string {
     if (process.platform === 'darwin' || process.platform === 'linux') {
-      return `source ${this.venvPath}/bin/activate\r`;
+      return `source "${this.venvPath}/bin/activate"\r`;
     }
     if (process.platform === 'win32') {
-      return `${this.venvPath}\\Scripts\\activate.bat\r`;
+      return `Set-ExecutionPolicy Unrestricted -Scope Process -Force; &"${this.venvPath}\\Scripts\\activate.ps1"; Set-ExecutionPolicy Default -Scope Process -Force\r`;
     }
     throw new Error(`Unsupported platform: ${process.platform}`);
   }


### PR DESCRIPTION
Fixes paths with spaces in
Swaps win32 from using bat (doesnt work in powershell) to ps1 script, bypassing execution policy