### PR TITLE
Upgrade uv to 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "frontendVersion": "1.4.13",
     "comfyVersion": "0.3.2",
     "managerCommit": "ada683c6bafcb983c8366e4310b7f95f66bd6362",
-    "uvVersion": "0.5.2"
+    "uvVersion": "0.5.4"
   },
   "scripts": {
     "clean": "rimraf .vite dist out",


### PR DESCRIPTION
Issue: https://github.com/Comfy-Org/desktop/issues/380

Getting reports of python failing to be installed / extracted. 

Seems to be related to: https://github.com/astral-sh/uv/issues/6331. Some people have confirmed that retrying works, which was added in `uv 0.5.4`

https://github.com/astral-sh/uv/pull/9274