### PR TITLE
Add async log rotation with max files

### DIFF
--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -96,7 +96,7 @@ export class ComfyServer {
   }
 
   async start() {
-    rotateLogFiles(app.getPath('logs'), 'comfyui');
+    await rotateLogFiles(app.getPath('logs'), 'comfyui', 50);
     return new Promise<void>(async (resolve, reject) => {
       const comfyUILog = log.create({ logId: 'comfyui' });
       comfyUILog.transports.file.fileName = 'comfyui.log';


### PR DESCRIPTION
- Fixes bug in log rotation that resulted in only the most recent log being stored
- Adds maximum log count - default 50
- All filesystem access is now async

#### Limitations

- Currently no limit on file size