### PR TITLE
feat: Save user preference for crashes after confirmation dialog

### DIFF
--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -51,6 +51,6 @@ export class ComfySettings {
 
   set<K extends keyof ComfySettingsData>(key: K, value: ComfySettingsData[K]) {
     this.settings[key] = value;
-    this.saveSettings()
+    this.saveSettings();
   }
 }

--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -5,7 +5,6 @@ import log from 'electron-log/main';
 export const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy-Desktop.AutoUpdate': true,
   'Comfy-Desktop.SendStatistics': true,
-  'Comfy-Desktop.AlwaysSendCrashReports': false,
   'Comfy.ColorPalette': 'dark',
   'Comfy.UseNewMenu': 'Top',
   'Comfy.Workflow.WorkflowTabsPosition': 'Topbar',
@@ -16,7 +15,6 @@ export const DEFAULT_SETTINGS: ComfySettingsData = {
 export interface ComfySettingsData {
   'Comfy-Desktop.AutoUpdate': boolean;
   'Comfy-Desktop.SendStatistics': boolean;
-  'Comfy-Desktop.AlwaysSendCrashReports': boolean;
   'Comfy.Server.LaunchArgs': Record<string, string>;
   [key: string]: unknown;
 }
@@ -41,16 +39,7 @@ export class ComfySettings {
     this.settings = JSON.parse(fileContent);
   }
 
-  public saveSettings() {
-    fs.writeFileSync(this.filePath, JSON.stringify(this.settings), 'utf-8');
-  }
-
   get<K extends keyof ComfySettingsData>(key: K): ComfySettingsData[K] {
     return this.settings[key] ?? DEFAULT_SETTINGS[key];
-  }
-
-  set<K extends keyof ComfySettingsData>(key: K, value: ComfySettingsData[K]) {
-    this.settings[key] = value;
-    this.saveSettings();
   }
 }

--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -5,6 +5,7 @@ import log from 'electron-log/main';
 export const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy-Desktop.AutoUpdate': true,
   'Comfy-Desktop.SendStatistics': true,
+  'Comfy-Desktop.AlwaysSendCrashReports': false,
   'Comfy.ColorPalette': 'dark',
   'Comfy.UseNewMenu': 'Top',
   'Comfy.Workflow.WorkflowTabsPosition': 'Topbar',
@@ -15,6 +16,7 @@ export const DEFAULT_SETTINGS: ComfySettingsData = {
 export interface ComfySettingsData {
   'Comfy-Desktop.AutoUpdate': boolean;
   'Comfy-Desktop.SendStatistics': boolean;
+  'Comfy-Desktop.AlwaysSendCrashReports': boolean;
   'Comfy.Server.LaunchArgs': Record<string, string>;
   [key: string]: unknown;
 }
@@ -39,11 +41,16 @@ export class ComfySettings {
     this.settings = JSON.parse(fileContent);
   }
 
+  public saveSettings() {
+    fs.writeFileSync(this.filePath, JSON.stringify(this.settings), 'utf-8');
+  }
+
   get<K extends keyof ComfySettingsData>(key: K): ComfySettingsData[K] {
     return this.settings[key] ?? DEFAULT_SETTINGS[key];
   }
 
   set<K extends keyof ComfySettingsData>(key: K, value: ComfySettingsData[K]) {
     this.settings[key] = value;
+    this.saveSettings()
   }
 }

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -12,7 +12,7 @@ import { getAppResourcesPath } from '../install/resourcePaths';
  */
 export class AppWindow {
   private window: BrowserWindow;
-  private store: Store<StoreType>;
+  public store: Store<StoreType>;
   private messageQueue: Array<{ channel: string; data: any }> = [];
   private rendererReady: boolean = false;
 

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -18,7 +18,7 @@ class SentryLogging {
 
         if (
           event.extra?.comfyUIExecutionError ||
-          this.comfyDesktopApp?.comfySettings.get('Comfy-Desktop.SendStatistics') || 
+          this.comfyDesktopApp?.comfySettings.get('Comfy-Desktop.SendStatistics') ||
           alwaysSendCrashReports
         ) {
           return event;
@@ -36,7 +36,7 @@ class SentryLogging {
         });
 
         if (response === 1) {
-          this.comfyDesktopApp?.comfySettings?.set('Comfy-Desktop.AlwaysSendCrashReports', true)
+          this.comfyDesktopApp?.comfySettings?.set('Comfy-Desktop.AlwaysSendCrashReports', true);
         }
 
         return response !== 2 ? event : null;

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -14,7 +14,7 @@ class SentryLogging {
       beforeSend: async (event) => {
         this.filterEvent(event);
 
-        const alwaysSendCrashReports = this.comfyDesktopApp?.comfySettings?.get('Comfy-Desktop.AlwaysSendCrashReports');
+        const alwaysSendCrashReports = this.comfyDesktopApp?.appWindow?.store?.get('alwaysSendCrashReports', false);
 
         if (
           event.extra?.comfyUIExecutionError ||
@@ -36,7 +36,7 @@ class SentryLogging {
         });
 
         if (response === 1) {
-          this.comfyDesktopApp?.comfySettings?.set('Comfy-Desktop.AlwaysSendCrashReports', true);
+          this.comfyDesktopApp?.appWindow?.store?.set('alwaysSendCrashReports', true);
         }
 
         return response !== 2 ? event : null;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,4 +4,5 @@ export type StoreType = {
   windowX: number | undefined;
   windowY: number | undefined;
   windowMaximized?: boolean;
+  alwaysSendCrashReports?: boolean;
 };


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/Issue-1952-feat-Save-user-preference-for-crashes-after-confirmation-dialog-15f6d73d365081feb0f9d2f8690051d5) by [Unito](https://www.unito.io)
