### PR TITLE
Limit access to core settings

### DIFF
--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'fs/promises';
 import * as path from 'path';
 import log from 'electron-log/main';
 
@@ -32,13 +32,19 @@ export class ComfySettings {
     this.filePath = path.join(basePath, 'user', 'default', 'comfy.settings.json');
   }
 
-  public loadSettings() {
-    if (!fs.existsSync(this.filePath)) {
+  public async loadSettings() {
+    try {
+      await fs.access(this.filePath);
+    } catch {
       log.info(`Settings file ${this.filePath} does not exist. Using default settings.`);
       return;
     }
-    const fileContent = fs.readFileSync(this.filePath, 'utf-8');
-    this.settings = JSON.parse(fileContent);
+    try {
+      const fileContent = await fs.readFile(this.filePath, 'utf-8');
+      this.settings = JSON.parse(fileContent);
+    } catch (error) {
+      log.error(`Settings file cannot be loaded.`, error);
+    }
   }
 
   get<K extends keyof ComfySettingsData>(key: K): ComfySettingsData[K] {

--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -21,7 +21,7 @@ export interface ComfySettingsData {
 
 /**
  * ComfySettings is a class that loads settings from the comfy.settings.json file.
- * 
+ *
  * No save or write methods are exposed; this file is exclusively written to by ComfyUI core.
  */
 export class ComfySettings {

--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -21,6 +21,8 @@ export interface ComfySettingsData {
 
 /**
  * ComfySettings is a class that loads settings from the comfy.settings.json file.
+ * 
+ * No save or write methods are exposed; this file is exclusively written to by ComfyUI core.
  */
 export class ComfySettings {
   public readonly filePath: string;
@@ -41,9 +43,5 @@ export class ComfySettings {
 
   get<K extends keyof ComfySettingsData>(key: K): ComfySettingsData[K] {
     return this.settings[key] ?? DEFAULT_SETTINGS[key];
-  }
-
-  set<K extends keyof ComfySettingsData>(key: K, value: ComfySettingsData[K]) {
-    this.settings[key] = value;
   }
 }

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -82,7 +82,7 @@ function showConfirmReset(configFilePath: string): Promise<Electron.MessageBoxRe
   });
 }
 
-async function tryDeleteConfigFile(configFilePath: string) {
+async function tryDeleteConfigFile(configFilePath: string): Promise<void> {
   try {
     await fs.rm(configFilePath);
   } catch (error) {
@@ -91,7 +91,7 @@ async function tryDeleteConfigFile(configFilePath: string) {
   }
 }
 
-function getUserDataOrQuit() {
+function getUserDataOrQuit(): string {
   try {
     return app.getPath('userData');
   } catch (error) {


### PR DESCRIPTION
- Removes `set` method from the ComfyUI core settings reader
  - Unused, and there is no write method so it seems misleading
- Adds guards for permission / filesystem errors
- Converts to async FS access