### PR TITLE
Add api.getComfyUIVersion

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+declare const __COMFYUI_VERSION__: string;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -130,6 +130,9 @@ const electronAPI = {
   getElectronVersion: () => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_ELECTRON_VERSION);
   },
+  getComfyUIVersion: () => {
+    return __COMFYUI_VERSION__;
+  },
   /**
    * Send an error message to Sentry
    * @param error The error object or message to send

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -23,6 +23,10 @@ export function getBuildConfig(env: ConfigEnv): UserConfig {
       minify: command === 'build',
     },
     clearScreen: false,
+
+    define: {
+      __COMFYUI_VERSION__: JSON.stringify(pkg.config.comfyVersion),
+    },
   };
 }
 


### PR DESCRIPTION
This PR adds `getComfyUIVersion` api endpoint to get ComfyUI version, as the built-in server side ComfyUI version endpoint requires the app to be hosted in a Git repo, while the electron app is not shipped with ComfyUI's git repo.