### PR TITLE
Add custom window / native window controls

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export const IPC_CHANNELS = {
   SHOW_CONTEXT_MENU: 'show-context-menu',
   RESTART_CORE: 'restart-core',
   GET_GPU: 'get-gpu',
+  SET_WINDOW_STYLE: 'set-window-style',
 } as const;
 
 export enum ProgressStatus {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export const IPC_CHANNELS = {
   VALIDATE_COMFYUI_SOURCE: 'validate-comfyui-source',
   SHOW_DIRECTORY_PICKER: 'show-directory-picker',
   INSTALL_COMFYUI: 'install-comfyui',
+  CHANGE_THEME: 'change-theme',
   SHOW_CONTEXT_MENU: 'show-context-menu',
   RESTART_CORE: 'restart-core',
   GET_GPU: 'get-gpu',

--- a/src/handlers/appInfoHandlers.ts
+++ b/src/handlers/appInfoHandlers.ts
@@ -2,6 +2,7 @@ import { app, ipcMain } from 'electron';
 import { IPC_CHANNELS } from '../constants';
 import { useDesktopConfig } from '../store/desktopConfig';
 import type { TorchDeviceType } from '../preload';
+import type { DesktopSettings } from '../store/desktopSettings';
 
 /**
  * Handles information about the app and current state in IPC channels.
@@ -20,5 +21,11 @@ export class AppInfoHandlers {
     ipcMain.handle(IPC_CHANNELS.GET_GPU, async (): Promise<TorchDeviceType | undefined> => {
       return await useDesktopConfig().getAsync('detectedGpu');
     });
+    ipcMain.handle(
+      IPC_CHANNELS.SET_WINDOW_STYLE,
+      async (_event: Electron.IpcMainInvokeEvent, style: DesktopSettings['windowStyle']): Promise<void> => {
+        await useDesktopConfig().setAsync('windowStyle', style);
+      }
+    );
   }
 }

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -275,6 +275,7 @@ export class AppWindow {
     if (process.platform === 'darwin' || useDesktopConfig().get('windowStyle') === 'default') return;
 
     if (options.height) options.height = Math.round(options.height);
+    if (!options.height) delete options.height;
     this.window.setTitleBarOverlay(options);
   }
 

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -1,4 +1,16 @@
-import { BrowserWindow, screen, app, shell, ipcMain, Tray, Menu, dialog, MenuItem, nativeTheme } from 'electron';
+import {
+  BrowserWindow,
+  screen,
+  app,
+  shell,
+  ipcMain,
+  Tray,
+  Menu,
+  dialog,
+  MenuItem,
+  nativeTheme,
+  type TitleBarOverlayOptions,
+} from 'electron';
 import path from 'node:path';
 import Store from 'electron-store';
 import { AppWindowSettings } from '../store/AppWindowSettings';
@@ -18,6 +30,10 @@ export class AppWindow {
   private store: Store<AppWindowSettings>;
   private messageQueue: Array<{ channel: string; data: unknown }> = [];
   private rendererReady: boolean = false;
+  /** Default dark mode config for system window overlay (min/max/close window). */
+  private darkOverlay = { color: '#00000000', height: 44, symbolColor: '#ddd' };
+  /** Default light mode config for system window overlay (min/max/close window). */
+  private lightOverlay = { ...this.darkOverlay, symbolColor: '#333' };
   /** The application menu. */
   private menu: Electron.Menu | null;
   /** The "edit" menu - cut/copy/paste etc. */
@@ -251,8 +267,9 @@ export class AppWindow {
     });
   }
 
-  private darkOverlay = { color: '#00000000', height: 44, symbolColor: '#ddd' };
-  private lightOverlay = { ...this.darkOverlay, symbolColor: '#333' };
+  changeTheme(options: TitleBarOverlayOptions): void {
+    this.window.setTitleBarOverlay(options);
+  }
 
   showSystemContextMenu(options?: ElectronContextMenuOptions): void {
     if (options?.type === 'text') {

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -54,7 +54,7 @@ export class AppWindow {
 
     // macOS requires different handling to linux / win32
     const customChrome: Pick<Electron.BrowserWindowConstructorOptions, 'titleBarStyle' | 'titleBarOverlay'> =
-      process.platform !== 'darwin' && useDesktopConfig().get('windowStyle') !== 'default'
+      process.platform !== 'darwin' && useDesktopConfig().get('windowStyle') === 'custom'
         ? {
             titleBarStyle: 'hidden',
             titleBarOverlay: nativeTheme.shouldUseDarkColors ? this.darkOverlay : this.lightOverlay,
@@ -272,7 +272,7 @@ export class AppWindow {
   }
 
   changeTheme(options: TitleBarOverlayOptions): void {
-    if (process.platform === 'darwin' || useDesktopConfig().get('windowStyle') === 'default') return;
+    if (process.platform === 'darwin' || useDesktopConfig().get('windowStyle') !== 'custom') return;
 
     if (options.height) options.height = Math.round(options.height);
     if (!options.height) delete options.height;

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -31,7 +31,7 @@ export class AppWindow {
   private messageQueue: Array<{ channel: string; data: unknown }> = [];
   private rendererReady: boolean = false;
   /** Default dark mode config for system window overlay (min/max/close window). */
-  private darkOverlay = { color: '#00000000', height: 44, symbolColor: '#ddd' };
+  private darkOverlay = { color: '#00000000', symbolColor: '#ddd' };
   /** Default light mode config for system window overlay (min/max/close window). */
   private lightOverlay = { ...this.darkOverlay, symbolColor: '#333' };
   /** The application menu. */
@@ -272,6 +272,9 @@ export class AppWindow {
   }
 
   changeTheme(options: TitleBarOverlayOptions): void {
+    if (process.platform === 'darwin' || useDesktopConfig().get('windowStyle') === 'default') return;
+
+    if (options.height) options.height = Math.round(options.height);
     this.window.setTitleBarOverlay(options);
   }
 

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -52,6 +52,15 @@ export class AppWindow {
     const storedX = store.get('windowX');
     const storedY = store.get('windowY');
 
+    // macOS requires different handling to linux / win32
+    const customChrome: Pick<Electron.BrowserWindowConstructorOptions, 'titleBarStyle' | 'titleBarOverlay'> =
+      process.platform !== 'darwin' && useDesktopConfig().get('windowStyle') !== 'default'
+        ? {
+            titleBarStyle: 'hidden',
+            titleBarOverlay: nativeTheme.shouldUseDarkColors ? this.darkOverlay : this.lightOverlay,
+          }
+        : {};
+
     this.window = new BrowserWindow({
       title: 'ComfyUI',
       width: storedWidth,
@@ -69,12 +78,7 @@ export class AppWindow {
         devTools: true,
       },
       autoHideMenuBar: true,
-      ...(process.platform === 'darwin'
-        ? {}
-        : {
-            titleBarStyle: 'hidden',
-            titleBarOverlay: nativeTheme.shouldUseDarkColors ? this.darkOverlay : this.lightOverlay,
-          }),
+      ...customChrome,
     });
 
     if (!installed && storedX === undefined) this.window.center();

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen, app, shell, ipcMain, Tray, Menu, dialog, MenuItem } from 'electron';
+import { BrowserWindow, screen, app, shell, ipcMain, Tray, Menu, dialog, MenuItem, nativeTheme } from 'electron';
 import path from 'node:path';
 import Store from 'electron-store';
 import { AppWindowSettings } from '../store/AppWindowSettings';
@@ -53,6 +53,12 @@ export class AppWindow {
         devTools: true,
       },
       autoHideMenuBar: true,
+      ...(process.platform === 'darwin'
+        ? {}
+        : {
+            titleBarStyle: 'hidden',
+            titleBarOverlay: nativeTheme.shouldUseDarkColors ? this.darkOverlay : this.lightOverlay,
+          }),
     });
 
     if (!installed && storedX === undefined) this.window.center();
@@ -244,6 +250,9 @@ export class AppWindow {
       }
     });
   }
+
+  private darkOverlay = { color: '#00000000', height: 44, symbolColor: '#ddd' };
+  private lightOverlay = { ...this.darkOverlay, symbolColor: '#333' };
 
   showSystemContextMenu(options?: ElectronContextMenuOptions): void {
     if (options?.type === 'text') {

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -1,4 +1,4 @@
-import { app, dialog, ipcMain, Notification } from 'electron';
+import { app, dialog, ipcMain, Notification, type TitleBarOverlayOptions } from 'electron';
 import log from 'electron-log/main';
 import * as Sentry from '@sentry/electron/main';
 import { graphics } from 'systeminformation';
@@ -91,6 +91,9 @@ export class ComfyDesktopApp {
   }
 
   registerIPCHandlers(): void {
+    ipcMain.on(IPC_CHANNELS.CHANGE_THEME, (_event, options: TitleBarOverlayOptions) => {
+      this.appWindow.changeTheme(options);
+    });
     ipcMain.on(IPC_CHANNELS.SHOW_CONTEXT_MENU, (_event, options?: ElectronContextMenuOptions) => {
       this.appWindow.showSystemContextMenu(options);
     });

--- a/src/main_types.ts
+++ b/src/main_types.ts
@@ -9,4 +9,5 @@ export type {
   PathValidationResult,
   SystemPaths,
   DownloadProgressUpdate,
+  ElectronOverlayOptions,
 } from './preload';

--- a/src/main_types.ts
+++ b/src/main_types.ts
@@ -1,3 +1,12 @@
 export * from './constants';
 export type { DownloadManager, Download, DownloadState } from './models/DownloadManager';
-export type { ElectronAPI } from './preload';
+export type {
+  ElectronAPI,
+  ElectronContextMenuOptions,
+  InstallOptions,
+  GpuType,
+  TorchDeviceType,
+  PathValidationResult,
+  SystemPaths,
+  DownloadProgressUpdate,
+} from './preload';

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -1,10 +1,9 @@
 import { session, DownloadItem, ipcMain } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
-import { IPC_CHANNELS } from '../constants';
+import { DownloadStatus, IPC_CHANNELS } from '../constants';
 import log from 'electron-log/main';
 import type { AppWindow } from '../main-process/appWindow';
-import { DownloadStatus } from '../main_types';
 
 export interface Download {
   url: string;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { IPC_CHANNELS, ELECTRON_BRIDGE_API, ProgressStatus, DownloadStatus } from './constants';
 import type { DownloadState } from './models/DownloadManager';
 import path from 'node:path';
+import type { DesktopSettings } from './store/desktopSettings';
 
 /**
  * Open a folder in the system's default file explorer.
@@ -282,6 +283,10 @@ const electronAPI = {
     getDetectedGpu: async (): Promise<GpuType | undefined> => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return await ipcRenderer.invoke(IPC_CHANNELS.GET_GPU);
+    },
+    /** Sets the window style */
+    setWindowStyle: (style: DesktopSettings['windowStyle']): Promise<void> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.SET_WINDOW_STYLE, style);
     },
   },
   /** Restart the python server without restarting desktop. */

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -102,14 +102,15 @@ const electronAPI = {
     console.log('Sending ready event to main process');
     ipcRenderer.send(IPC_CHANNELS.RENDERER_READY);
   },
-  isPackaged: () => {
+  /** Emulates app.ispackaged in renderer */
+  isPackaged: (): Promise<boolean> => {
     return ipcRenderer.invoke(IPC_CHANNELS.IS_PACKAGED);
-  }, //Emulates app.ispackaged in renderer
+  },
   restartApp: (customMessage?: string, delay?: number): void => {
     console.log('Sending restarting app message to main process with custom message:', customMessage);
     ipcRenderer.send(IPC_CHANNELS.RESTART_APP, { customMessage, delay });
   },
-  reinstall: () => {
+  reinstall: (): Promise<void> => {
     return ipcRenderer.invoke(IPC_CHANNELS.REINSTALL);
   },
   openDialog: (options: Electron.OpenDialogOptions) => {
@@ -177,9 +178,8 @@ const electronAPI = {
   getElectronVersion: () => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_ELECTRON_VERSION);
   },
-  getComfyUIVersion: () => {
-    return __COMFYUI_VERSION__;
-  },
+  /** The ComfyUI core version (as defined in package.json) */
+  getComfyUIVersion: () => __COMFYUI_VERSION__,
   /**
    * Send an error message to Sentry
    * @param error The error object or message to send
@@ -289,9 +289,8 @@ const electronAPI = {
     console.log('Restarting core process');
     await ipcRenderer.invoke(IPC_CHANNELS.RESTART_APP);
   },
-  getPlatform: (): NodeJS.Platform => {
-    return process.platform;
-  },
+  /** Gets the platform reported by node.js */
+  getPlatform: () => process.platform,
 } as const;
 
 export type ElectronAPI = typeof electronAPI;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -41,6 +41,22 @@ export interface DownloadProgressUpdate {
   message?: string;
 }
 
+/** @todo Type inference chain broken by comfyui-electron-types. This is duplication. */
+export interface ElectronOverlayOptions {
+  /**
+   * The CSS color of the Window Controls Overlay when enabled.
+   */
+  color?: string;
+  /**
+   * The CSS color of the symbols on the Window Controls Overlay when enabled.
+   */
+  symbolColor?: string;
+  /**
+   * The height of the title bar and Window Controls Overlay in pixels.
+   */
+  height?: number;
+}
+
 export interface ElectronContextMenuOptions {
   type: 'system' | 'text' | 'image';
   pos?: Electron.Point;
@@ -243,6 +259,12 @@ const electronAPI = {
   installComfyUI: (installOptions: InstallOptions) => {
     ipcRenderer.send(IPC_CHANNELS.INSTALL_COMFYUI, installOptions);
   },
+  /**
+   * Update the Window Controls Overlay theme overrides
+   * @param theme The theme settings to apply
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window_Controls_Overlay_API}
+   */
+  changeTheme: (theme: ElectronOverlayOptions): void => ipcRenderer.send(IPC_CHANNELS.CHANGE_THEME, theme),
   /**
    * Opens native context menus.
    *

--- a/src/store/desktopSettings.ts
+++ b/src/store/desktopSettings.ts
@@ -22,4 +22,10 @@ export type DesktopSettings = {
   /** The pytorch device that the user selected during installation. */
   selectedDevice?: TorchDeviceType;
   'Comfy-Desktop.RestoredCustomNodes': boolean;
+  /**
+   * Controls whether to use a custom window on linux/win32
+   * - `custom`: Modern, theme-reactive, feels like an integral part of the UI
+   * - `default`: Impersonal, static, plain - default window title bar
+   */
+  windowStyle?: 'custom' | 'default';
 };


### PR DESCRIPTION
### Modern linux / win32 window

- Requires #567
- Provides API only; screenshots are examples
- Adds OS-native window code for custom window replacement on linux / win32
  - Adjusts button size to toolbar
  - Transparent background
  - Theme-reactive - colours dictated by frontend API
- Enables (WIP) Comfy-Org/ComfyUI_frontend/pull/1856
- No changes to default behaviour

#### Example implementation:

![image](https://github.com/user-attachments/assets/ba0356e8-c0a1-4a35-87c8-1bf725bddb59)

https://github.com/user-attachments/assets/558b80d9-8cdd-48de-8adb-d8f55721bbea

```ts
// Configured in config.json
"windowStyle": "default" | "custom"
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/Issue-1964-Add-custom-window-native-window-controls-15f6d73d365081a7901bccad64315f02) by [Unito](https://www.unito.io)
