### PR TITLE
Improve log legibility

### DIFF
--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -185,11 +185,11 @@ export class ComfyDesktopApp {
     const virtualEnvironment = new VirtualEnvironment(this.basePath);
     await virtualEnvironment.create({
       onStdout: (data) => {
-        log.info(data);
+        log.info(data.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''));
         this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
       },
       onStderr: (data) => {
-        log.error(data);
+        log.error(data.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''));
         this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
       },
     });

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -11,7 +11,7 @@ import { ComfyServerConfig } from '../config/comfyServerConfig';
 import fs from 'fs';
 import { InstallOptions, type ElectronContextMenuOptions } from '../preload';
 import path from 'path';
-import { getModelsDirectory, validateHardware } from '../utils';
+import { ansiCodes, getModelsDirectory, validateHardware } from '../utils';
 import { DownloadManager } from '../models/DownloadManager';
 import { VirtualEnvironment } from '../virtualEnvironment';
 import { InstallWizard } from '../install/installWizard';
@@ -185,11 +185,11 @@ export class ComfyDesktopApp {
     const virtualEnvironment = new VirtualEnvironment(this.basePath);
     await virtualEnvironment.create({
       onStdout: (data) => {
-        log.info(data.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''));
+        log.info(data.replaceAll(ansiCodes, ''));
         this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
       },
       onStderr: (data) => {
-        log.error(data.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ''));
+        log.error(data.replaceAll(ansiCodes, ''));
         this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
       },
     });

--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -103,11 +103,15 @@ export class ComfyServer {
 
       const comfyServerProcess = this.virtualEnvironment.runPythonCommand(this.launchArgs, {
         onStdout: (data) => {
-          comfyUILog.info(data);
+          comfyUILog.info(
+            data.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+          );
           this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
         },
         onStderr: (data) => {
-          comfyUILog.error(data);
+          comfyUILog.error(
+            data.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+          );
           this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
         },
       });

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -73,10 +73,14 @@ async function installCustomNodes(
     ];
     const { exitCode } = await virtualEnvironment.runPythonCommandAsync(cmd, {
       onStdout: (data) => {
-        log.info(data.toString());
+        log.info(
+          data.toString().replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+        );
       },
       onStderr: (data) => {
-        log.error(data.toString());
+        log.error(
+          data.toString().replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+        );
       },
     });
     if (exitCode !== 0) {

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -7,6 +7,7 @@ import { getAppResourcesPath } from '../install/resourcePaths';
 import log from 'electron-log/main';
 import { AppWindow } from '../main-process/appWindow';
 import { IPC_CHANNELS } from '../constants';
+import { ansiCodes } from '../utils';
 
 function parseLogFile(logPath: string): Set<string> {
   console.log('Parsing log file:', logPath);
@@ -72,16 +73,8 @@ async function installCustomNodes(
       '--no-deps',
     ];
     const { exitCode } = await virtualEnvironment.runPythonCommandAsync(cmd, {
-      onStdout: (data) => {
-        log.info(
-          data.toString().replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
-        );
-      },
-      onStderr: (data) => {
-        log.error(
-          data.toString().replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
-        );
-      },
+      onStdout: (data) => log.info(data.toString().replaceAll(ansiCodes, '')),
+      onStderr: (data) => log.error(data.toString().replaceAll(ansiCodes, '')),
     });
     if (exitCode !== 0) {
       log.error(`Failed to install custom nodes: ${exitCode}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,8 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import log from 'electron-log/main';
 
+export const ansiCodes = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+
 export async function pathAccessible(path: string): Promise<boolean> {
   try {
     await fsPromises.access(path);


### PR DESCRIPTION
Strips all escape codes from wrapped-process output logs.

#### From this:

```log
[2024-12-12 23:55:59.116] [info]  [?25l[37m[H⠸ [m[2mResolving dependencies...                                                     [K[?25h[1;134H
[2024-12-12 23:55:59.135] [info]  [?25l[22m[1;80H[?25h
[2024-12-12 23:55:59.309] [info]  [?25l[37m[H⠸ [m[2maiohappyeyeballs==2.4.3                                                       [K[?25h[1;136H
[2024-12-12 23:55:59.328] [info]  [?25l[22m[37m[H⠼ [m[2maiohappyeyeballs==2.4.3                                                       [K[?25h[1;136H
```

#### To this:

```log
[2024-12-12 23:55:59.116] [info]  ⠸ Resolving dependencies...                                                     
[2024-12-12 23:55:59.135] [info]  
[2024-12-12 23:55:59.309] [info]  ⠸ aiohappyeyeballs==2.4.3                                                       
[2024-12-12 23:55:59.328] [info]  ⠼ aiohappyeyeballs==2.4.3                                                       
```