### PR TITLE
Make port and host configurable with setting.launchArgs

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -104,7 +104,8 @@ export class AppWindow {
   }
 
   public loadComfyUI(serverArgs: ServerArgs) {
-    this.window.loadURL(`http://${serverArgs.host}:${serverArgs.port}`);
+    const host = serverArgs.host === '0.0.0.0' ? 'localhost' : serverArgs.host;
+    this.window.loadURL(`http://${host}:${serverArgs.port}`);
   }
 
   public openDevTools(): void {

--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -75,6 +75,7 @@ export class ComfyServer {
       'front-end-root': this.webRootPath,
       'extra-model-paths-config': ComfyServerConfig.configPath,
       port: this.serverArgs.port.toString(),
+      listen: this.serverArgs.host,
     };
   }
 


### PR DESCRIPTION
Follow-up on https://github.com/Comfy-Org/desktop/pull/465

This PR makes host and port configurable in the frontend server config panel.