### PR TITLE
[Refactor] Improve separation of concerns / lifecycle

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -5,7 +5,7 @@ import { AppWindowSettings } from '../store';
 import log from 'electron-log/main';
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { getAppResourcesPath } from '../install/resourcePaths';
-import { DesktopConfig } from '../store/desktopConfig';
+import { useDesktopConfig } from '../store/desktopConfig';
 import type { ElectronContextMenuOptions } from '../preload';
 
 /**
@@ -24,7 +24,7 @@ export class AppWindow {
   private editMenu?: Menu;
 
   public constructor() {
-    const installed = DesktopConfig.store.get('installState') === 'installed';
+    const installed = useDesktopConfig().get('installState') === 'installed';
     const primaryDisplay = screen.getPrimaryDisplay();
     const { width, height } = installed ? primaryDisplay.workAreaSize : { width: 1024, height: 768 };
     const store = this.loadWindowStore();

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,12 +41,15 @@ if (!gotTheLock) {
   app.on('ready', async () => {
     log.debug('App ready');
 
-    const store = await DesktopConfig.load(shell);
-    if (store) {
-      startApp();
-    } else {
+    try {
+      const store = await DesktopConfig.load(shell);
+      if (!store) throw new Error('Unknown error loading app config on startup.');
+    } catch (error) {
+      dialog.showErrorBox('User Data', `Unknown error whilst writing to user data folder:\n\n${error}`);
       app.exit(20);
     }
+
+    await startApp();
   });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { IPC_CHANNELS, DEFAULT_SERVER_ARGS, ProgressStatus } from './constants';
-import { app, dialog, ipcMain } from 'electron';
+import { app, dialog, ipcMain, shell } from 'electron';
 import log from 'electron-log/main';
 import { findAvailablePort } from './utils';
 import dotenv from 'dotenv';
@@ -41,7 +41,7 @@ if (!gotTheLock) {
   app.on('ready', async () => {
     log.debug('App ready');
 
-    const store = await DesktopConfig.load();
+    const store = await DesktopConfig.load(shell);
     if (store) {
       startApp();
     } else {

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -1,6 +1,6 @@
 import log from 'electron-log/main';
 import ElectronStore from 'electron-store';
-import { app, dialog, shell } from 'electron';
+import { app, dialog } from 'electron';
 import path from 'node:path';
 import fs from 'fs/promises';
 import type { DesktopSettings } from '.';
@@ -16,6 +16,7 @@ export class DesktopConfig {
   }
 
   static async load(
+    shell: Electron.Shell,
     options?: ConstructorParameters<typeof ElectronStore<DesktopSettings>>[0]
   ): Promise<ElectronStore<DesktopSettings> | undefined> {
     try {
@@ -44,7 +45,7 @@ export class DesktopConfig {
             await tryDeleteConfigFile(configFilePath);
 
             // Causing a stack overflow from this recursion would take immense patience.
-            return DesktopConfig.load(options);
+            return DesktopConfig.load(shell, options);
           }
         }
 

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -17,11 +17,6 @@ export function useDesktopConfig() {
 
 /** Handles loading of electron-store config, pre-window errors, and provides a non-null interface for the store. */
 export class DesktopConfig {
-  /** @deprecated */
-  static get store() {
-    return current.#store;
-  }
-
   #store: ElectronStore<DesktopSettings>;
 
   private constructor(store: ElectronStore<DesktopSettings>) {
@@ -89,11 +84,11 @@ export class DesktopConfig {
    * @param value The value to be saved.  Must be valid.
    * @returns A promise that resolves on successful save, or rejects with the first caught error.
    */
-  static async setAsync<Key extends keyof DesktopSettings>(key: Key, value: DesktopSettings[Key]): Promise<void> {
+  async setAsync<Key extends keyof DesktopSettings>(key: Key, value: DesktopSettings[Key]): Promise<void> {
     return new Promise((resolve, reject) => {
       log.info(`Saving setting: [${key}]`, value);
       try {
-        DesktopConfig.store.set(key, value);
+        this.#store.set(key, value);
         resolve();
       } catch (error) {
         reject(error);
@@ -102,10 +97,10 @@ export class DesktopConfig {
   }
 
   /** @inheritdoc {@link ElectronStore.get} */
-  static async getAsync<Key extends keyof DesktopSettings>(key: Key): Promise<DesktopSettings[Key]> {
+  async getAsync<Key extends keyof DesktopSettings>(key: Key): Promise<DesktopSettings[Key]> {
     return new Promise((resolve, reject) => {
       try {
-        resolve(DesktopConfig.store.get(key));
+        resolve(this.#store.get(key));
       } catch (error) {
         reject(error);
       }

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -33,6 +33,12 @@ export class DesktopConfig {
     return value === undefined ? this.#store.delete(key) : this.#store.set(key, value);
   }
 
+  /**
+   * Static factory method. Loads the config from disk.
+   * @param shell Shell environment that can open file and folder views for the user
+   * @param options electron-store options to pass through to the backing store
+   * @throws On unknown error
+   */
   static async load(
     shell: Electron.Shell,
     options?: ConstructorParameters<typeof ElectronStore<DesktopSettings>>[0]

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -73,7 +73,7 @@ export class DesktopConfig {
       } else {
         // Crash: Unknown filesystem error, permission denied on user data folder, etc
         log.error(`Unknown error whilst loading configuration file: ${configFilePath}`, error);
-        dialog.showErrorBox('User Data', `Unknown error whilst writing to user data folder:\n\n${configFilePath}`);
+        throw new Error(configFilePath);
       }
     }
   }

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -15,10 +15,6 @@ export class DesktopConfig {
     return store;
   }
 
-  static get gpu(): TorchDeviceType | undefined {
-    return DesktopConfig.store.get('detectedGpu');
-  }
-
   static async load(
     options?: ConstructorParameters<typeof ElectronStore<DesktopSettings>>[0]
   ): Promise<ElectronStore<DesktopSettings> | undefined> {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,7 +9,7 @@ export type AppWindowSettings = {
 };
 
 export type DesktopSettings = {
-  basePath?: string;
+  basePath?: string | null;
   /**
    * The state of the installation.
    * - `started`: The installation has started.
@@ -25,4 +25,5 @@ export type DesktopSettings = {
   detectedGpu?: GpuType;
   /** The pytorch device that the user selected during installation. */
   selectedDevice?: TorchDeviceType;
+  'Comfy-Desktop.RestoredCustomNodes': boolean;
 };


### PR DESCRIPTION
### Clean up - Part I

- Improves separation of concerns in `DesktopConfig`
- Refactors to `use()` pattern
- Converts / removes static accessors

Intention is to require less future-effort.  No libraries I checked use static classes for this kind of thing.