### PR TITLE
Fix crash on load when not using cjs output

### DIFF
--- a/builder-debug.config.ts
+++ b/builder-debug.config.ts
@@ -8,7 +8,7 @@ const debugConfig: Configuration = {
     { from: './assets/uv/uvx', to: 'uv/uvx' },
     { from: './assets/UI', to: 'UI' },
   ],
-  beforeBuild: './scripts/preMake.cjs',
+  beforeBuild: './scripts/preMake.js',
   win: {
     icon: './assets/UI/Comfy_Logo.ico',
     target: 'zip',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.3.34",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
-  "main": ".vite/build/main.js",
+  "main": ".vite/build/main.cjs",
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {

--- a/scripts/preMake.js
+++ b/scripts/preMake.js
@@ -1,10 +1,10 @@
-const { exec, execSync, spawnSync, spawn } = require("child_process");
-const path = require("path");
-const os = require('os');
-const process = require("process");
-const fs = require('fs-extra');
+import { exec, execSync, spawnSync, spawn } from "child_process"
+import path from "path"
+import * as os from 'os'
+import process from "process"
+import fs from 'fs-extra'
 
-module.exports = async ({ appOutDir, packager, outDir }) => {
+export default async ({ appOutDir, packager, outDir }) => {
 
     const firstInstallOnToDesktopServers =
         process.env.TODESKTOP_CI && process.env.TODESKTOP_INITIAL_INSTALL_PHASE;

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -45,7 +45,7 @@ export class AppWindow {
       x: storedX,
       y: storedY,
       webPreferences: {
-        preload: path.join(__dirname, '../build/preload.mjs'),
+        preload: path.join(__dirname, '../build/preload.cjs'),
         nodeIntegration: true,
         contextIsolation: true,
         webviewTag: true,

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -45,7 +45,7 @@ export class AppWindow {
       x: storedX,
       y: storedY,
       webPreferences: {
-        preload: path.join(import.meta.dirname, '../build/preload.cjs'),
+        preload: path.join(__dirname, '../build/preload.mjs'),
         nodeIntegration: true,
         contextIsolation: true,
         webviewTag: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react",
     "target": "ESNext",
-    "module": "ES2022",
+    "module": "ESNext",
     "allowJs": true,
     "strict": true,
     "skipLibCheck": true,

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -11,8 +11,8 @@ export default defineConfig((env) => {
       outDir: '.vite/build',
       lib: {
         entry: './src/main.ts',
-        fileName: () => '[name].js',
-        formats: ['es'],
+        fileName: (_format, name) => `${name}.cjs`,
+        formats: ['cjs'],
       },
       rollupOptions: {
         external,


### PR DESCRIPTION
- toDesktop auto update calls use CommonJS require()
- Partially reverts #491
  - Limitation on `preMake.cjs` resolved - now also an ES module, extension changed to `.js`
- `main.js` output script is now `main.cjs`
- `preload.cjs` now works as an ES Module - `preload.mjs`
  - `.mjs` ext is [an Electron requirement](https://www.electronjs.org/docs/latest/tutorial/esm#esm-preload-scripts-must-have-the-mjs-extension)

┆Issue is synchronized with this [Notion page](https://www.notion.so/497-Fix-crash-on-load-when-not-using-cjs-output-15f6d73d365081c5839be8a60e369e6e) by [Unito](https://www.unito.io)
