### PR TITLE
[chore] Update frontend to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.5.14",
+    "frontendVersion": "1.6.1",
     "comfyVersion": "0.3.7",
     "managerCommit": "52b6e4b2eb6481333b29556788f28633e73bd0a9",
     "uvVersion": "0.5.8"


### PR DESCRIPTION
Automated frontend update to 1.6.1

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-532-chore-Update-frontend-to-1-6-1-1606d73d3650812e9135e7e89c9ae8b6) by [Unito](https://www.unito.io)
