### PR TITLE
Fix cannot install on macOS with certain zsh config

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -240,7 +240,7 @@ export class VirtualEnvironment {
   private async runPtyCommandAsync(command: string, onData?: (data: string) => void): Promise<{ exitCode: number }> {
     const id = Date.now();
     return new Promise((res) => {
-      const endMarker = `--end-${id}:`;
+      const endMarker = `_-end-${id}:`;
       const input = `clear; ${command}; echo "${endMarker}$?"`;
       const dataReader = this.uvPtyInstance.onData((data) => {
         const lines = data.split('\n');


### PR DESCRIPTION
`zsh` parses hyphen inside double-quoted arguments as a command argument, not a string.

Just use a different prefix.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-543-Fix-cannot-install-on-macOS-with-certain-zsh-config-1626d73d36508111abe4c38db919c90d) by [Unito](https://www.unito.io)
