### PR TITLE
Fix install hangs on terminal commands

### DIFF
--- a/src/shell/terminal.ts
+++ b/src/shell/terminal.ts
@@ -2,6 +2,7 @@ import pty from 'node-pty';
 import { AppWindow } from '../main-process/appWindow';
 import { IPC_CHANNELS } from '../constants';
 import { getDefaultShell } from './util';
+import { EOL } from 'node:os';
 
 export class Terminal {
   #pty: pty.IPty | undefined;
@@ -60,10 +61,10 @@ export class Terminal {
 
     if (process.platform === 'win32') {
       // PowerShell function
-      instance.write(`function pip { & "${this.#uvPath}" pip $args }\r\n`);
+      instance.write(`function pip { & "${this.#uvPath}" pip $args }${EOL}`);
     } else {
       // Bash/Zsh alias
-      instance.write(`alias pip='"${this.#uvPath}" pip'\r\n`);
+      instance.write(`alias pip='"${this.#uvPath}" pip'${EOL}`);
     }
 
     instance.onData((data) => {

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -4,7 +4,7 @@ import log from 'electron-log/main';
 import { pathAccessible } from './utils';
 import { app } from 'electron';
 import pty from 'node-pty';
-import os from 'node:os';
+import os, { EOL } from 'node:os';
 import { getDefaultShell } from './shell/util';
 import type { TorchDeviceType } from './preload';
 
@@ -55,7 +55,8 @@ export class VirtualEnvironment {
     this.pythonVersion = pythonVersion;
     this.selectedDevice = selectedDevice;
 
-    this.venvPath = path.join(venvPath, '.venv'); // uv defaults to .venv
+    // uv defaults to .venv
+    this.venvPath = path.join(venvPath, '.venv');
     const resourcesPath = app.isPackaged ? path.join(process.resourcesPath) : path.join(app.getAppPath(), 'assets');
     this.comfyUIRequirementsPath = path.join(resourcesPath, 'ComfyUI', 'requirements.txt');
     this.comfyUIManagerRequirementsPath = path.join(
@@ -126,10 +127,10 @@ export class VirtualEnvironment {
    */
   public activateEnvironmentCommand(): string {
     if (process.platform === 'darwin' || process.platform === 'linux') {
-      return `source "${this.venvPath}/bin/activate"\r`;
+      return `source "${this.venvPath}/bin/activate"${EOL}`;
     }
     if (process.platform === 'win32') {
-      return `Set-ExecutionPolicy Unrestricted -Scope Process -Force; &"${this.venvPath}\\Scripts\\activate.ps1"; Set-ExecutionPolicy Default -Scope Process -Force\r`;
+      return `Set-ExecutionPolicy Unrestricted -Scope Process -Force${EOL}& "${this.venvPath}\\Scripts\\activate.ps1"${EOL}Set-ExecutionPolicy Default -Scope Process -Force${EOL}`;
     }
     throw new Error(`Unsupported platform: ${process.platform}`);
   }
@@ -232,7 +233,7 @@ export class VirtualEnvironment {
    * @returns
    */
   public async runUvCommandAsync(args: string[], callbacks?: ProcessCallbacks): Promise<{ exitCode: number | null }> {
-    const uvCommand = os.platform() === 'win32' ? `&"${this.uvPath}"` : this.uvPath;
+    const uvCommand = os.platform() === 'win32' ? `& "${this.uvPath}"` : this.uvPath;
     log.info(`Running uv command: ${uvCommand} ${args.join(' ')}`);
     return this.runPtyCommandAsync(`${uvCommand} ${args.map((a) => `"${a}"`).join(' ')}`, callbacks?.onStdout);
   }
@@ -241,9 +242,9 @@ export class VirtualEnvironment {
     const id = Date.now();
     return new Promise((res) => {
       const endMarker = `_-end-${id}:`;
-      const input = `clear; ${command}; echo "${endMarker}$?"`;
+      const input = `clear${EOL}${command}${EOL}echo "${endMarker}$?"`;
       const dataReader = this.uvPtyInstance.onData((data) => {
-        const lines = data.split('\n');
+        const lines = data.split(/(\r\n|\n)/);
         for (const line of lines) {
           // Remove ansi sequences to see if this the exit marker
           const clean = line.replaceAll(/\u001B\[[\d;?]*[A-Za-z]/g, '');
@@ -272,7 +273,7 @@ export class VirtualEnvironment {
         }
         onData?.(data);
       });
-      this.uvPtyInstance.write(`${input}\r\n`);
+      this.uvPtyInstance.write(`${input}${EOL}`);
     });
   }
 


### PR DESCRIPTION
Use OS-specific EOL at the end of every terminal command, more closely emulating real keyboard input.

This is expected to resolve lockups during install caused by interpretation of argument boundaries.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-545-Fix-install-hangs-on-terminal-commands-1626d73d36508127b3bad6342bc5d89d) by [Unito](https://www.unito.io)
