### PR TITLE
Improve startup error reporting / handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,14 @@ async function startApp() {
 
       // Start server
       if (!useExternalServer) {
-        await comfyDesktopApp.startComfyServer({ host, port, extraServerArgs });
+        try {
+          await comfyDesktopApp.startComfyServer({ host, port, extraServerArgs });
+        } catch (error) {
+          log.error('Unhandled exception during server start', error);
+          appWindow.send(IPC_CHANNELS.LOG_MESSAGE, `${error}\n`);
+          appWindow.sendServerStartProgress(ProgressStatus.ERROR);
+          return;
+        }
       }
       appWindow.sendServerStartProgress(ProgressStatus.READY);
       await appWindow.loadComfyUI({ host, port, extraServerArgs });

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,7 +112,7 @@ async function startApp() {
     } catch (error) {
       log.error('Unhandled exception during app startup', error);
       appWindow.sendServerStartProgress(ProgressStatus.ERROR);
-      appWindow.send(IPC_CHANNELS.LOG_MESSAGE, error);
+      appWindow.send(IPC_CHANNELS.LOG_MESSAGE, `${error}\n`);
       if (!quitting) {
         dialog.showErrorBox(
           'Unhandled exception',

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,12 @@ app.on('window-all-closed', () => {
   }
 });
 
+// Suppress unhandled exception dialog when already quitting.
+let quitting = false;
+app.on('before-quit', () => {
+  quitting = true;
+});
+
 // Sentry needs to be initialized at the top level.
 SentryLogging.init();
 
@@ -107,7 +113,7 @@ async function startApp() {
       log.error('Unhandled exception during app startup', error);
       appWindow.sendServerStartProgress(ProgressStatus.ERROR);
       appWindow.send(IPC_CHANNELS.LOG_MESSAGE, error);
-      dialog.showErrorBox('Unhandled exception', `An unhandled exception occurred:\n\n${error}`);
+      if (!quitting) dialog.showErrorBox('Unhandled exception', `An unhandled exception occurred:\n\n${error}`);
     }
   } catch (error) {
     log.error('Fatal error occurred during app pre-startup.', error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,7 +113,13 @@ async function startApp() {
       log.error('Unhandled exception during app startup', error);
       appWindow.sendServerStartProgress(ProgressStatus.ERROR);
       appWindow.send(IPC_CHANNELS.LOG_MESSAGE, error);
-      if (!quitting) dialog.showErrorBox('Unhandled exception', `An unhandled exception occurred:\n\n${error}`);
+      if (!quitting) {
+        dialog.showErrorBox(
+          'Unhandled exception',
+          `An unexpected error occurred whilst starting the app, and it needs to be closed.\n\nError message:\n\n${error}`
+        );
+        app.quit();
+      }
     }
   } catch (error) {
     log.error('Fatal error occurred during app pre-startup.', error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,7 @@ async function startApp() {
       log.error('Unhandled exception during app startup', error);
       appWindow.sendServerStartProgress(ProgressStatus.ERROR);
       appWindow.send(IPC_CHANNELS.LOG_MESSAGE, error);
+      dialog.showErrorBox('Unhandled exception', `An unhandled exception occurred:\n\n${error}`);
     }
   } catch (error) {
     log.error('Fatal error occurred during app pre-startup.', error);


### PR DESCRIPTION
- Adds error handling specific to python server startup
- Shows OS-native unhandled error message rather than silent quit
  - Skips this if already quitting
- Fixes errors not shown in terminal (missing EOL)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-551-Improve-startup-error-reporting-handling-1646d73d3650815692aacaa9178e3611) by [Unito](https://www.unito.io)
