### PR TITLE
Prevent browser console log spam

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -53,14 +53,14 @@ const electronAPI = {
    */
   onProgressUpdate: (callback: (update: { status: ProgressStatus }) => void) => {
     ipcRenderer.on(IPC_CHANNELS.LOADING_PROGRESS, (_event, value) => {
-      console.info(`Received ${IPC_CHANNELS.LOADING_PROGRESS} event`, value);
+      console.debug(`Received ${IPC_CHANNELS.LOADING_PROGRESS} event`, value);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       callback(value);
     });
   },
   onLogMessage: (callback: (message: string) => void) => {
     ipcRenderer.on(IPC_CHANNELS.LOG_MESSAGE, (_event, value) => {
-      console.info(`Received ${IPC_CHANNELS.LOG_MESSAGE} event`, value);
+      console.debug(`Received ${IPC_CHANNELS.LOG_MESSAGE} event`, value);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       callback(value);
     });


### PR DESCRIPTION
Lower log level of terminal output to debug

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-552-Prevent-browser-console-log-spam-1656d73d36508171aef4dc7d68c15226) by [Unito](https://www.unito.io)
