### PR TITLE
Improve install path selection UX

### DIFF
--- a/playwright.setup.ts
+++ b/playwright.setup.ts
@@ -1,9 +1,19 @@
 import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
 
 async function globalSetup() {
   console.log('Playwright globalSetup called');
 
   return new Promise<void>((resolve, reject) => {
+    // HACK: Force graphics card check to pass
+    process.env.CI = '1';
+
+    // Documents dir in CI
+    if (!process.env.USERPROFILE) throw new Error('USERPROFILE not set');
+    const documents = path.join(process.env.USERPROFILE, 'Documents');
+    if (!existsSync(documents)) mkdirSync(documents);
+
     const electron = spawn('node', ['./scripts/launchCI.js']);
 
     electron.on('close', () => {

--- a/playwright.setup.ts
+++ b/playwright.setup.ts
@@ -1,19 +1,9 @@
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync } from 'node:fs';
-import path from 'node:path';
 
 async function globalSetup() {
   console.log('Playwright globalSetup called');
 
   return new Promise<void>((resolve, reject) => {
-    // HACK: Force graphics card check to pass
-    process.env.CI = '1';
-
-    // Documents dir in CI
-    if (!process.env.USERPROFILE) throw new Error('USERPROFILE not set');
-    const documents = path.join(process.env.USERPROFILE, 'Documents');
-    if (!existsSync(documents)) mkdirSync(documents);
-
     const electron = spawn('node', ['./scripts/launchCI.js']);
 
     electron.on('close', () => {

--- a/scripts/prepareTypes.js
+++ b/scripts/prepareTypes.js
@@ -6,9 +6,9 @@ import mainPackage from './getPackage.js';
 const typesPackage = {
   name: `${mainPackage.name}-types`,
   version: mainPackage.version,
-  main: './index.mjs',
+  main: './index.js',
   types: './index.d.ts',
-  files: ['index.d.ts', 'index.mjs'],
+  files: ['index.d.ts', 'index.js'],
   publishConfig: {
     access: 'public',
   },

--- a/scripts/prepareTypes.js
+++ b/scripts/prepareTypes.js
@@ -6,6 +6,7 @@ import mainPackage from './getPackage.js';
 const typesPackage = {
   name: `${mainPackage.name}-types`,
   version: mainPackage.version,
+  type: 'module',
   main: './index.js',
   types: './index.d.ts',
   files: ['index.d.ts', 'index.js'],

--- a/src/config/comfyConfigManager.ts
+++ b/src/config/comfyConfigManager.ts
@@ -47,13 +47,6 @@ export class ComfyConfigManager {
     ],
   ];
 
-  public static setUpComfyUI(localComfyDirectory: string) {
-    if (fs.existsSync(localComfyDirectory)) {
-      throw new Error(`Selected directory ${localComfyDirectory} already exists`);
-    }
-    this.createComfyDirectories(localComfyDirectory);
-  }
-
   public static isComfyUIDirectory(directory: string): boolean {
     const requiredSubdirs = ['models', 'input', 'user', 'output', 'custom_nodes'];
     return requiredSubdirs.every((subdir) => fs.existsSync(path.join(directory, subdir)));

--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -33,7 +33,7 @@ export class PathHandlers {
       return {
         appData: app.getPath('appData'),
         appPath: app.getAppPath(),
-        defaultInstallPath: app.getPath('documents'),
+        defaultInstallPath: path.join(app.getPath('documents'), 'ComfyUI'),
       };
     });
 
@@ -48,12 +48,6 @@ export class PathHandlers {
           // Check if path exists
           if (!fs.existsSync(inputPath)) {
             return { isValid: false, error: 'Path does not exist' };
-          }
-
-          // Check if `path/ComfyUI` exists
-          // We are going to create a ComfyUI directory in the selected path
-          if (fs.existsSync(path.join(inputPath, 'ComfyUI'))) {
-            return { isValid: false, error: 'Path already contains ComfyUI/' };
           }
 
           // Check if path is writable

--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -2,7 +2,7 @@ import { app, dialog, ipcMain, shell } from 'electron';
 import { IPC_CHANNELS } from '../constants';
 import log from 'electron-log/main';
 import { ComfyServerConfig } from '../config/comfyServerConfig';
-import type { SystemPaths } from '../preload';
+import type { PathValidationResult, SystemPaths } from '../preload';
 import fs from 'node:fs';
 import si from 'systeminformation';
 import { ComfyConfigManager } from '../config/comfyConfigManager';
@@ -43,38 +43,50 @@ export class PathHandlers {
      */
     ipcMain.handle(
       IPC_CHANNELS.VALIDATE_INSTALL_PATH,
-      async (event, inputPath: string): Promise<{ isValid: boolean; error?: string }> => {
+      async (event, inputPath: string): Promise<PathValidationResult> => {
+        const result: PathValidationResult = {
+          isValid: true,
+          freeSpace: -1,
+          requiredSpace: PathHandlers.REQUIRED_SPACE,
+        };
+
         try {
+          // Check if root path exists
+          const parent = path.dirname(inputPath);
+          if (!fs.existsSync(parent)) {
+            result.parentMissing = true;
+          }
+
           // Check if path exists
-          if (!fs.existsSync(inputPath)) {
-            return { isValid: false, error: 'Path does not exist' };
+          if (fs.existsSync(inputPath)) {
+            result.exists = true;
           }
 
           // Check if path is writable
           try {
-            fs.accessSync(inputPath, fs.constants.W_OK);
+            fs.accessSync(parent, fs.constants.W_OK);
           } catch {
-            return { isValid: false, error: 'Path is not writable' };
+            result.cannotWrite = true;
           }
 
           // Check available disk space (require at least 10GB free)
           const disks = await si.fsSize();
           const disk = disks.find((disk) => inputPath.startsWith(disk.mount));
-          if (disk && disk.available < PathHandlers.REQUIRED_SPACE) {
-            return {
-              isValid: false,
-              error: 'Insufficient disk space. At least 10GB of free space is required.',
-            };
-          }
-
-          return { isValid: true };
+          if (disk) result.freeSpace = disk.available;
         } catch (error) {
           log.error('Error validating install path:', error);
-          return {
-            isValid: false,
-            error: `Failed to validate install path: ${error}`,
-          };
+          result.error = `${error}`;
         }
+
+        if (
+          result.cannotWrite ||
+          result.parentMissing ||
+          result.freeSpace < PathHandlers.REQUIRED_SPACE ||
+          result.error
+        ) {
+          result.isValid = false;
+        }
+        return result;
       }
     );
     /**

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -17,18 +17,6 @@ export class InstallWizard {
     return this.installOptions.migrationSourcePath;
   }
 
-  get shouldMigrateUserFiles(): boolean {
-    return !!this.migrationSource && this.migrationItemIds.has('user_files');
-  }
-
-  get shouldMigrateModels(): boolean {
-    return !!this.migrationSource && this.migrationItemIds.has('models');
-  }
-
-  get shouldMigrateCustomNodes(): boolean {
-    return !!this.migrationSource && this.migrationItemIds.has('custom_nodes');
-  }
-
   get basePath(): string {
     return path.join(this.installOptions.installPath, 'ComfyUI');
   }
@@ -45,11 +33,11 @@ export class InstallWizard {
    * Copy user files from migration source to the new ComfyUI folder.
    */
   public initializeUserFiles() {
-    if (!this.shouldMigrateUserFiles) {
-      return;
-    }
+    const shouldMigrateUserFiles = !!this.migrationSource && this.migrationItemIds.has('user_files');
+    if (!shouldMigrateUserFiles) return;
+
     // Copy user files from migration source to the new ComfyUI folder.
-    const srcUserFilesDir = path.join(this.migrationSource!, 'user');
+    const srcUserFilesDir = path.join(this.migrationSource, 'user');
     const destUserFilesDir = path.join(this.basePath, 'user');
     fs.cpSync(srcUserFilesDir, destUserFilesDir, { recursive: true });
   }
@@ -90,8 +78,10 @@ export class InstallWizard {
     const comfyDesktopConfig = ComfyServerConfig.getBaseConfig();
     comfyDesktopConfig['base_path'] = this.basePath;
 
-    if (this.shouldMigrateModels) {
-      const migrationSource = this.migrationSource!;
+    const { migrationSource } = this;
+    const shouldMigrateModels = !!migrationSource && this.migrationItemIds.has('models');
+
+    if (shouldMigrateModels) {
       // The yaml file exists in migration source repo.
       const migrationServerConfigs = await ComfyServerConfig.getConfigFromRepoPath(migrationSource);
 

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -70,7 +70,7 @@ export class InstallWizard {
   }
 
   /**
-   * Setup extra_model_paths.yaml file
+   * Setup extra_models_config.yaml file
    */
   public async initializeModelPaths() {
     let yamlContent: Record<string, ModelPaths>;

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -18,12 +18,12 @@ export class InstallWizard {
   }
 
   get basePath(): string {
-    return path.join(this.installOptions.installPath, 'ComfyUI');
+    return this.installOptions.installPath;
   }
 
   public async install() {
     // Setup the ComfyUI folder structure.
-    ComfyConfigManager.setUpComfyUI(this.basePath);
+    ComfyConfigManager.createComfyDirectories(this.basePath);
     this.initializeUserFiles();
     this.initializeSettings();
     await this.initializeModelPaths();

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -85,7 +85,7 @@ export class InstallWizard {
    * Setup extra_model_paths.yaml file
    */
   public async initializeModelPaths() {
-    let yamlContent: Record<string, ModelPaths> = {};
+    let yamlContent: Record<string, ModelPaths>;
 
     const comfyDesktopConfig = ComfyServerConfig.getBaseConfig();
     comfyDesktopConfig['base_path'] = this.basePath;

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -48,7 +48,10 @@ export class InstallationManager {
    */
   async resumeInstallation(installation: ComfyInstallation) {
     // TODO: Resume install at point of interruption
-    if (installation.state === 'started') await this.freshInstall();
+    if (installation.state === 'started') {
+      await this.freshInstall();
+      installation.setState('installed');
+    }
     if (installation.state === 'upgraded') installation.upgradeConfig();
   }
 

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -95,7 +95,9 @@ export class InstallationManager {
 
     await installWizard.install();
     this.appWindow.maximize();
-    if (installWizard.shouldMigrateCustomNodes && installWizard.migrationSource) {
+    const shouldMigrateCustomNodes =
+      !!installWizard.migrationSource && installWizard.migrationItemIds.has('custom_nodes');
+    if (shouldMigrateCustomNodes) {
       useDesktopConfig().set('migrateCustomNodesFrom', installWizard.migrationSource);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,8 @@ async function startApp() {
       // Install / validate installation is complete
       const installManager = new InstallationManager(appWindow);
       const installation = await installManager.ensureInstalled();
-      if (!installation.isValid) throw new Error('Fatal: Could not validate installation.');
+      if (!installation.isValid)
+        throw new Error(`Fatal: Could not validate installation: [${installation.state}/${installation.issues.size}]`);
 
       // Initialize app
       const comfyDesktopApp = ComfyDesktopApp.create(appWindow, installation.basePath);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -46,6 +46,23 @@ export interface ElectronContextMenuOptions {
   pos?: Electron.Point;
 }
 
+/** The result of validating a path (originally for ComfyUI installation). */
+export type PathValidationResult = {
+  isValid: boolean;
+  /** `true` if the parent of the selected path (via `dirname()`) is not present (it must be present). */
+  parentMissing?: boolean;
+  /** `true` if the selected path already exists. */
+  exists?: boolean;
+  /** `true` if the selected path is not writable. */
+  cannotWrite?: boolean;
+  /** The amount of free space in the path. `-1` if this could not be determined. */
+  freeSpace: number;
+  /** The amount of space in bytes required to install ComfyUI. */
+  requiredSpace: number;
+  /** If any unhandled exceptions occured, this is the result of casting the error to string. */
+  error?: string;
+};
+
 const electronAPI = {
   /**
    * Callback for progress updates from the main process for starting ComfyUI.
@@ -205,7 +222,7 @@ const electronAPI = {
    * Validate the install path for the application. Check whether the path is valid
    * and writable. The disk should have enough free space to install the application.
    */
-  validateInstallPath: (path: string): Promise<{ isValid: boolean; error?: string }> => {
+  validateInstallPath: (path: string): Promise<PathValidationResult> => {
     return ipcRenderer.invoke(IPC_CHANNELS.VALIDATE_INSTALL_PATH, path);
   },
   /**

--- a/tests/unit/comfyConfigManager.test.ts
+++ b/tests/unit/comfyConfigManager.test.ts
@@ -27,9 +27,9 @@ describe('ComfyConfigManager', () => {
   });
 
   describe('setUpComfyUI', () => {
-    it('should reject existing directory when it contains ComfyUI structure', () => {
+    it('should allow existing directory when it contains ComfyUI structure', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      expect(() => ComfyConfigManager.createComfyDirectories(path.normalize('/existing/ComfyUI'))).toThrow();
+      expect(() => ComfyConfigManager.createComfyDirectories(path.normalize('/existing/ComfyUI'))).not.toThrow();
     });
 
     it('should create ComfyUI subdirectory when it is missing', () => {

--- a/tests/unit/comfyConfigManager.test.ts
+++ b/tests/unit/comfyConfigManager.test.ts
@@ -29,7 +29,7 @@ describe('ComfyConfigManager', () => {
   describe('setUpComfyUI', () => {
     it('should reject existing directory when it contains ComfyUI structure', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      expect(() => ComfyConfigManager.setUpComfyUI(path.normalize('/existing/ComfyUI'))).toThrow();
+      expect(() => ComfyConfigManager.createComfyDirectories(path.normalize('/existing/ComfyUI'))).toThrow();
     });
 
     it('should create ComfyUI subdirectory when it is missing', () => {
@@ -40,7 +40,7 @@ describe('ComfyConfigManager', () => {
         return true;
       });
 
-      ComfyConfigManager.setUpComfyUI(path.normalize('/some/base/path/ComfyUI'));
+      ComfyConfigManager.createComfyDirectories(path.normalize('/some/base/path/ComfyUI'));
     });
   });
 


### PR DESCRIPTION
- ComfyUI is no longer forcefully appended to the install path selected by the user
  - e.g. Installing to `Documents/ComfyUI`
  - Old: `Documents/ComfyUI/ComfyUI`
  - New: `Documents/ComfyUI`
- Existing paths can be re-used
- Paired with frontend commit INSERT_PR_HERE
  - Electron API Types from this PR are required by the frontend PR 
  - Works without the frontend commit, but will not display a warning if the path exists

Default install screen - full install path is now shown in frontend:
![image](https://github.com/user-attachments/assets/60342920-a98e-4dc3-8859-d3ce2a32d891)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-555-Improve-install-path-selection-UX-1666d73d36508181b406eef0da54bf98) by [Unito](https://www.unito.io)
