### PR TITLE
Fix uv shell never exits

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -108,17 +108,8 @@ export class VirtualEnvironment {
     try {
       await this.createEnvironment(callbacks);
     } finally {
-      if (this.uvPty) {
-        // If we have a pty instance then we need to kill it on a delay
-        // else you may get an EPIPE error on reading the stream if it is
-        // reading/writing as you kill it
-        const pty = this.uvPty;
-        this.uvPty = undefined;
-        pty.pause();
-        setTimeout(() => {
-          this.uvPty?.kill();
-        }, 100);
-      }
+      const pid = this.uvPty?.pid;
+      if (pid) process.kill(pid);
     }
   }
 


### PR DESCRIPTION
Current:
- `uv` shell continues running until app is closed
- `kill()` is never called - optional chained after an explicitly `undefined` value
- If fixed to use `pty.kill()`, the EPIPE exception is still raised even with a 10sec timer

Proposed:
- Just kill the process ID

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-558-Fix-uv-shell-never-exits-1666d73d365081438b61e0f133c560ba) by [Unito](https://www.unito.io)
