### PR TITLE
Fix release notes formatting

### DIFF
--- a/.github/actions/build/todesktop/action.yml
+++ b/.github/actions/build/todesktop/action.yml
@@ -66,22 +66,22 @@ runs:
           if [ -n "${{ inputs.RELEASE_TAG }}" ]; then
             # Create download links section
             DOWNLOAD_LINKS="
-            ### Download Latest:
-            Mac (Apple Silicon): https://download.comfy.org/mac/dmg/arm64
-            Windows: https://download.comfy.org/windows/nsis/x64
+        ### Download Latest:
+        Mac (Apple Silicon): https://download.comfy.org/mac/dmg/arm64
+        Windows: https://download.comfy.org/windows/nsis/x64
 
-            <details>
+        <details>
 
-            <summary>
+        <summary>
 
-            ### Artifacts of current release
+        ### Artifacts of current release
 
-            </summary>
+        </summary>
 
-            Mac (Apple Silicon): https://download.comfy.org/${BUILD_ID}/mac/dmg/arm64
-            Windows: https://download.comfy.org/${BUILD_ID}/windows/nsis/x64"
+        Mac (Apple Silicon): https://download.comfy.org/${BUILD_ID}/mac/dmg/arm64
+        Windows: https://download.comfy.org/${BUILD_ID}/windows/nsis/x64
 
-            </details>
+        </details>"
             
             # First get existing release notes
             EXISTING_NOTES=$(gh release view ${{ inputs.RELEASE_TAG }} --json body -q .body)


### PR DESCRIPTION
Removes additional spaces added to start of line in release notes GH action, which breaks MD formatting.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-563-Fix-release-notes-formatting-1676d73d36508149881dfeb6e105b70e) by [Unito](https://www.unito.io)
