### PR TITLE
Bump frontend version to 1.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.6.1",
+    "frontendVersion": "1.6.6",
     "comfyVersion": "0.3.9",
     "managerCommit": "b4e52e65ec87978fc6294e82d55e1b91c5b02d55",
     "uvVersion": "0.5.8"


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-564-Bump-frontend-version-to-1-6-6-1676d73d365081c9b5dbfd532efacd37) by [Unito](https://www.unito.io)
