### PR TITLE
Fix reinstall breaks config

### DIFF
--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -219,6 +219,18 @@ export class ComfyServerConfig {
   /** @deprecated Do not use.  Tempoary workaround for validation only. */
   public static async setBasePathInDefaultConfig(basePath: string): Promise<boolean> {
     const parsedConfig = await ComfyServerConfig.readConfigFile(ComfyServerConfig.configPath);
+    // TODO: Prompt user to attempt this as a troubleshooting option.
+    if (parsedConfig === null) {
+      // File does not exist.  Just create default.
+      log.warn("Extra model paths config file doesn't exist.  Creating default.");
+
+      const comfyDesktopConfig = ComfyServerConfig.getBaseConfig();
+      comfyDesktopConfig['base_path'] = basePath;
+
+      return await ComfyServerConfig.createConfigFile(ComfyServerConfig.configPath, {
+        comfyui_desktop: comfyDesktopConfig,
+      });
+    }
     if (!parsedConfig) return false;
 
     parsedConfig.comfyui_desktop ??= {};

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -39,6 +39,10 @@ export class DesktopConfig {
     this.#store.delete(key);
   }
 
+  async permanentlyDeleteConfigFile() {
+    await fs.rm(path.join(app.getPath('userData'), 'config.json'));
+  }
+
   /**
    * Static factory method. Loads the config from disk.
    * @param shell Shell environment that can open file and folder views for the user


### PR DESCRIPTION
- Fixes immediate issue by removing config.json when user confirms reinstall
- Accounts for corruption of state - if config.json is present and extra_models_config.yaml is deleted, the YAML file will be regenerated with defaults

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-565-Fix-reinstall-breaks-config-1676d73d36508116a119c8a9410f3365) by [Unito](https://www.unito.io)
