### PR TITLE
[chore] Update frontend to 1.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.6.1",
+    "frontendVersion": "1.6.6",
     "comfyVersion": "0.3.9",
     "managerCommit": "b4e52e65ec87978fc6294e82d55e1b91c5b02d55",
     "uvVersion": "0.5.8"


### PR DESCRIPTION
Automated frontend update to 1.6.6

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-566-chore-Update-frontend-to-1-6-6-1676d73d3650811891a7e5ddf990e1ef) by [Unito](https://www.unito.io)
