### PR TITLE
Export all API types

### DIFF
--- a/src/main_types.ts
+++ b/src/main_types.ts
@@ -1,3 +1,12 @@
 export * from './constants';
 export type { DownloadManager, Download, DownloadState } from './models/DownloadManager';
-export type { ElectronAPI } from './preload';
+export type {
+  ElectronAPI,
+  ElectronContextMenuOptions,
+  InstallOptions,
+  GpuType,
+  TorchDeviceType,
+  PathValidationResult,
+  SystemPaths,
+  DownloadProgressUpdate,
+} from './preload';

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -1,10 +1,9 @@
 import { session, DownloadItem, ipcMain } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
-import { IPC_CHANNELS } from '../constants';
+import { DownloadStatus, IPC_CHANNELS } from '../constants';
 import log from 'electron-log/main';
 import type { AppWindow } from '../main-process/appWindow';
-import { DownloadStatus } from '../main_types';
 
 export interface Download {
   url: string;


### PR DESCRIPTION
- Allows all API types to be imported
- Removes need to redeclare types in frontend (e.g. via `Parameters<>` decls)
- Fixes a local type import that was using the `main_types` API entry point

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-567-Export-all-API-types-1686d73d365081d3b481f28851890d15) by [Unito](https://www.unito.io)
