### PR TITLE
Prevent installer from re-running once on first app start

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -101,7 +101,9 @@ export class InstallationManager {
       useDesktopConfig().set('migrateCustomNodesFrom', installWizard.migrationSource);
     }
 
-    return new ComfyInstallation('installed', installWizard.basePath);
+    const installation = new ComfyInstallation('installed', installWizard.basePath);
+    installation.setState('installed');
+    return installation;
   }
 
   /**


### PR DESCRIPTION
Sets installed state after first installation.  Install wizard will no longer be shown a second time, during the first time the app is opened after being installed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-569-Prevent-installer-from-re-running-once-on-first-app-start-1686d73d36508132bef0cd15247bbbe7) by [Unito](https://www.unito.io)
