### PR TITLE
Use latest python 3.12 as default.

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -50,7 +50,7 @@ export class VirtualEnvironment {
     return this.uvPty;
   }
 
-  constructor(venvPath: string, selectedDevice: TorchDeviceType | undefined, pythonVersion: string = '3.12.4') {
+  constructor(venvPath: string, selectedDevice: TorchDeviceType | undefined, pythonVersion: string = '3.12.8') {
     this.venvRootPath = venvPath;
     this.pythonVersion = pythonVersion;
     this.selectedDevice = selectedDevice;


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-570-Use-latest-python-3-12-as-default-1686d73d365081d3abf6d446da9144fc) by [Unito](https://www.unito.io)
