### PR TITLE
Add main.log upload steps to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -43,7 +43,11 @@ body:
     attributes:
       label: Debug Logs
       description: |
-        Please copy the output from your terminal logs here.
+        Please copy the output from your terminal logs here.  If the issue is related to app startup, please include the contents of `main.log`, located in the ComfyUI log directory:
+
+        on macOS: `~/Library/Logs/ComfyUI`
+        on Windows: `%AppData%\ComfyUI\logs`
+
         ![DebugLogs](https://github.com/user-attachments/assets/168b6ea3-ab93-445b-9cd2-670bd9c098a7)
       render: powershell
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -43,7 +43,7 @@ body:
     attributes:
       label: Debug Logs
       description: |
-        Please copy the output from your terminal logs here.  If the issue is related to app startup, please include the contents of `main.log`, located in the ComfyUI log directory:
+        Please copy the output from your terminal logs here.  If the issue is related to app startup, please include `main.log` and `comfyui.log`, located in the ComfyUI log directory:
 
         on macOS: `~/Library/Logs/ComfyUI`
         on Windows: `%AppData%\ComfyUI\logs`


### PR DESCRIPTION
### Proposed:

![image](https://github.com/user-attachments/assets/2a53d378-b269-4892-9cb5-8d7ef94b5180)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-572-Add-main-log-upload-steps-to-issue-template-1686d73d3650810cb3f2f9f1888583dc) by [Unito](https://www.unito.io)
