### PR TITLE
Add api.Config.getWindowStyle

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export const IPC_CHANNELS = {
   RESTART_CORE: 'restart-core',
   GET_GPU: 'get-gpu',
   SET_WINDOW_STYLE: 'set-window-style',
+  GET_WINDOW_STYLE: 'get-window-style',
 } as const;
 
 export enum ProgressStatus {

--- a/src/handlers/appInfoHandlers.ts
+++ b/src/handlers/appInfoHandlers.ts
@@ -27,5 +27,8 @@ export class AppInfoHandlers {
         await useDesktopConfig().setAsync('windowStyle', style);
       }
     );
+    ipcMain.handle(IPC_CHANNELS.GET_WINDOW_STYLE, async (): Promise<DesktopSettings['windowStyle']> => {
+      return await useDesktopConfig().getAsync('windowStyle');
+    });
   }
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -288,6 +288,9 @@ const electronAPI = {
     setWindowStyle: (style: DesktopSettings['windowStyle']): Promise<void> => {
       return ipcRenderer.invoke(IPC_CHANNELS.SET_WINDOW_STYLE, style);
     },
+    getWindowStyle: (): Promise<DesktopSettings['windowStyle']> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.GET_WINDOW_STYLE);
+    },
   },
   /** Restart the python server without restarting desktop. */
   restartCore: async (): Promise<void> => {


### PR DESCRIPTION
Follow up on https://github.com/Comfy-Org/desktop/pull/457.

Adds the window style getter as the user setting is not available when the frontend is loaded as static html, i.e. for install pages.