### PR TITLE
Fix exception on window style change

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -56,8 +56,7 @@ export class AppWindow {
     const storedY = store.get('windowY');
 
     // macOS requires different handling to linux / win32
-    const customChrome: Pick<Electron.BrowserWindowConstructorOptions, 'titleBarStyle' | 'titleBarOverlay'> = this
-      .customWindowEnabled
+    const customChrome: Electron.BrowserWindowConstructorOptions = this.customWindowEnabled
       ? {
           titleBarStyle: 'hidden',
           titleBarOverlay: nativeTheme.shouldUseDarkColors ? this.darkOverlay : this.lightOverlay,

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -38,6 +38,9 @@ export class AppWindow {
   private menu: Electron.Menu | null;
   /** The "edit" menu - cut/copy/paste etc. */
   private editMenu?: Menu;
+  /** Whether this window was created with title bar overlay enabled. When `false`, Electron throws when calling {@link BrowserWindow.setTitleBarOverlay}. */
+  public readonly customWindowEnabled: boolean =
+    process.platform !== 'darwin' && useDesktopConfig().get('windowStyle') === 'custom';
 
   public constructor() {
     const installed = useDesktopConfig().get('installState') === 'installed';
@@ -53,13 +56,13 @@ export class AppWindow {
     const storedY = store.get('windowY');
 
     // macOS requires different handling to linux / win32
-    const customChrome: Pick<Electron.BrowserWindowConstructorOptions, 'titleBarStyle' | 'titleBarOverlay'> =
-      process.platform !== 'darwin' && useDesktopConfig().get('windowStyle') === 'custom'
-        ? {
-            titleBarStyle: 'hidden',
-            titleBarOverlay: nativeTheme.shouldUseDarkColors ? this.darkOverlay : this.lightOverlay,
-          }
-        : {};
+    const customChrome: Pick<Electron.BrowserWindowConstructorOptions, 'titleBarStyle' | 'titleBarOverlay'> = this
+      .customWindowEnabled
+      ? {
+          titleBarStyle: 'hidden',
+          titleBarOverlay: nativeTheme.shouldUseDarkColors ? this.darkOverlay : this.lightOverlay,
+        }
+      : {};
 
     this.window = new BrowserWindow({
       title: 'ComfyUI',
@@ -272,9 +275,9 @@ export class AppWindow {
   }
 
   changeTheme(options: TitleBarOverlayOptions): void {
-    if (process.platform === 'darwin' || useDesktopConfig().get('windowStyle') !== 'custom') return;
+    if (!this.customWindowEnabled) return;
 
-    if (options.height) options.height = Math.round(options.height);
+    options.height &&= Math.round(options.height);
     if (!options.height) delete options.height;
     this.window.setTitleBarOverlay(options);
   }


### PR DESCRIPTION
Guards against exception.  Repro:

1. Change from default window style to `custom` via `setWindowStyle`
2. Send any window controls theme update (change button size / colour)
3. Throws

#### Solution
AppWindow now checks the settings it was created with, rather than the current settings.

#### Cause
Original frontend impl. was incomplete (settings), so the flaw went unnoticed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-599-Fix-exception-on-window-style-change-1786d73d36508128962ec734d4e7ab13) by [Unito](https://www.unito.io)
