### PR TITLE
Allow dev server via env when app is unpackaged

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,14 +1,5 @@
-# The host to use for the ComfyUI server.
-COMFY_HOST=127.0.0.1
-
-# The port to use for the ComfyUI server.
-COMFY_PORT=8188
-
-# Whether to use an external server instead of starting one locally.
-USE_EXTERNAL_SERVER=false
-
 # The URL of the development server to use.
-# This is for the install/server-startup screen.
+# You can attach your own ComfyUI instance to the frontend dev server as well.
 # Run `npm run dev` in the frontend repo(https://github.com/Comfy-Org/ComfyUI_frontend)
 # to start a development server.
 DEV_SERVER_URL=http://192.168.2.20:5173

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -132,9 +132,8 @@ export class AppWindow {
 
   public async loadComfyUI(serverArgs: ServerArgs) {
     const host = serverArgs.host === '0.0.0.0' ? 'localhost' : serverArgs.host;
-    const url = !app.isPackaged && process.env.DEV_SERVER_URL 
-              ? process.env.DEV_SERVER_URL 
-              : `http://${host}:${serverArgs.port}`;
+    const url =
+      !app.isPackaged && process.env.DEV_SERVER_URL ? process.env.DEV_SERVER_URL : `http://${host}:${serverArgs.port}`;
     await this.window.loadURL(url);
   }
 

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -132,8 +132,10 @@ export class AppWindow {
 
   public async loadComfyUI(serverArgs: ServerArgs) {
     const host = serverArgs.host === '0.0.0.0' ? 'localhost' : serverArgs.host;
-    const devUrl = !app.isPackaged ? process.env.DEV_SERVER_URL : undefined;
-    await this.window.loadURL(devUrl ?? `http://${host}:${serverArgs.port}`);
+    const url = !app.isPackaged && process.env.DEV_SERVER_URL 
+              ? process.env.DEV_SERVER_URL 
+              : `http://${host}:${serverArgs.port}`;
+    await this.window.loadURL(url);
   }
 
   public openDevTools(): void {

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -132,7 +132,8 @@ export class AppWindow {
 
   public async loadComfyUI(serverArgs: ServerArgs) {
     const host = serverArgs.host === '0.0.0.0' ? 'localhost' : serverArgs.host;
-    await this.window.loadURL(`http://${host}:${serverArgs.port}`);
+    const devUrl = !app.isPackaged ? process.env.DEV_SERVER_URL : undefined;
+    await this.window.loadURL(devUrl ?? `http://${host}:${serverArgs.port}`);
   }
 
   public openDevTools(): void {
@@ -164,9 +165,8 @@ export class AppWindow {
   }
 
   public async loadRenderer(urlPath: string = ''): Promise<void> {
-    if (process.env.DEV_SERVER_URL) {
+    if (!app.isPackaged && process.env.DEV_SERVER_URL) {
       const url = `${process.env.DEV_SERVER_URL}/${urlPath}`;
-      this.rendererReady = true; // TODO: Look into why dev server ready event is not being sent to main process.
       log.info(`Loading development server ${url}`);
       await this.window.loadURL(url);
       this.window.webContents.openDevTools();

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,22 +97,22 @@ async function startApp() {
       SentryLogging.comfyDesktopApp = comfyDesktopApp;
 
       // Construct core launch args
-      const useExternalServer = process.env.USE_EXTERNAL_SERVER === 'true';
+      const useDevServer = !app.isPackaged && process.env.DEV_SERVER_URL;
       const cpuOnly: Record<string, string> = process.env.COMFYUI_CPU_ONLY === 'true' ? { cpu: '' } : {};
       const extraServerArgs: Record<string, string> = {
         ...comfyDesktopApp.comfySettings.get('Comfy.Server.LaunchArgs'),
         ...cpuOnly,
       };
-      const host = process.env.COMFY_HOST ?? extraServerArgs.listen ?? DEFAULT_SERVER_ARGS.host;
-      const targetPort = Number(process.env.COMFY_PORT ?? extraServerArgs.port ?? DEFAULT_SERVER_ARGS.port);
-      const port = useExternalServer ? targetPort : await findAvailablePort(host, targetPort, targetPort + 1000);
+      const host = extraServerArgs.listen ?? DEFAULT_SERVER_ARGS.host;
+      const targetPort = Number(extraServerArgs.port ?? DEFAULT_SERVER_ARGS.port);
+      const port = useDevServer ? targetPort : await findAvailablePort(host, targetPort, targetPort + 1000);
 
       // Remove listen and port from extraServerArgs so core launch args are used instead.
       delete extraServerArgs.listen;
       delete extraServerArgs.port;
 
       // Start server
-      if (!useExternalServer) {
+      if (!useDevServer) {
         try {
           await comfyDesktopApp.startComfyServer({ host, port, extraServerArgs });
         } catch (error) {


### PR DESCRIPTION
#### Current
- Can use frontend HMR via vite dev server only when performing installation process / hacky router manipulation

#### Proposed
- Attempt to use dev server for both router pages and regular usage (so, everything), provided that:
  - `app.isPackaged` is falsy
  - `DEV_SERVER_URL` env var is non-nullish

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-600-Allow-dev-server-via-env-when-app-is-unpackaged-1786d73d36508192b7ddd765d826a698) by [Unito](https://www.unito.io)
