### PR TITLE
[Cleanup] Remove unused ProgressMessages

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,15 +62,6 @@ export enum ProgressStatus {
   ERROR = 'error',
 }
 
-export const ProgressMessages = {
-  [ProgressStatus.INITIAL_STATE]: 'Loading...',
-  [ProgressStatus.PYTHON_SETUP]: 'Setting up Python Environment...',
-  [ProgressStatus.STARTING_SERVER]: 'Starting ComfyUI server...',
-  [ProgressStatus.READY]: 'Finishing...',
-  [ProgressStatus.ERROR]:
-    'Was not able to start ComfyUI. Please check the logs for more details. You can open it from the Help menu. Please report issues to: https://forum.comfy.org',
-} as const;
-
 export type IPCChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
 
 export const ELECTRON_BRIDGE_API = 'electronAPI';


### PR DESCRIPTION
`ProgressMessages` was moved to the frontend repo in https://github.com/Comfy-Org/ComfyUI_frontend/pull/1831.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-603-Cleanup-Remove-unused-ProgressMessages-1796d73d3650815c9085c75123b71089) by [Unito](https://www.unito.io)
