### PR TITLE
[Metrics] Capture server start progress status

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -19,6 +19,7 @@ import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { getAppResourcesPath } from '../install/resourcePaths';
 import { useDesktopConfig } from '../store/desktopConfig';
 import type { ElectronContextMenuOptions } from '../preload';
+import * as Sentry from '@sentry/electron/main';
 
 /**
  * Creates a single application window that displays the renderer and encapsulates all the logic for sending messages to the renderer.
@@ -128,6 +129,12 @@ export class AppWindow {
   sendServerStartProgress(status: ProgressStatus): void {
     this.send(IPC_CHANNELS.LOADING_PROGRESS, {
       status,
+    });
+    Sentry.captureMessage(status, {
+      level: status === ProgressStatus.ERROR ? 'error' : 'info',
+      tags: {
+        comfyorigin: 'core',
+      },
     });
   }
 


### PR DESCRIPTION
This PR adds metrics collection for python server startup state changes.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-607-Metrics-Capture-server-start-progress-status-17b6d73d365081688a2ef52fd558cdba) by [Unito](https://www.unito.io)
