### PR TITLE
[Cleanup] Remove electronAPI.sendErrorToSentry

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,6 @@ export const IPC_CHANNELS = {
   DELETE_MODEL: 'delete-model',
   GET_ALL_DOWNLOADS: 'get-all-downloads',
   GET_ELECTRON_VERSION: 'get-electron-version',
-  SEND_ERROR_TO_SENTRY: 'send-error-to-sentry',
   GET_BASE_PATH: 'get-base-path',
   GET_MODEL_CONFIG_PATH: 'get-model-config-path',
   OPEN_PATH: 'open-path',

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -122,29 +122,6 @@ export class ComfyDesktopApp {
       log.info('Reinstalling...');
       await this.reinstall();
     });
-    type SentryErrorDetail = {
-      error: string;
-      extras?: Record<string, unknown>;
-    };
-
-    ipcMain.handle(
-      IPC_CHANNELS.SEND_ERROR_TO_SENTRY,
-      // eslint-disable-next-line @typescript-eslint/require-await
-      async (_event, { error, extras }: SentryErrorDetail): Promise<string | null> => {
-        try {
-          return Sentry.captureMessage(error, {
-            level: 'error',
-            extra: { ...extras, comfyUIExecutionError: true },
-            tags: {
-              comfyorigin: 'core',
-            },
-          });
-        } catch (error_) {
-          log.error('Failed to send error to Sentry:', error_);
-          return null;
-        }
-      }
-    );
     // Restart core
     ipcMain.handle(IPC_CHANNELS.RESTART_CORE, async (): Promise<boolean> => {
       if (!this.comfyServer) return false;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -181,14 +181,6 @@ const electronAPI = {
   },
   /** The ComfyUI core version (as defined in package.json) */
   getComfyUIVersion: () => __COMFYUI_VERSION__,
-  /**
-   * Send an error message to Sentry
-   * @param error The error object or message to send
-   * @param extras Optional additional context/data to attach
-   */
-  sendErrorToSentry: (error: string, extras?: Record<string, unknown>) => {
-    return ipcRenderer.invoke(IPC_CHANNELS.SEND_ERROR_TO_SENTRY, { error, extras });
-  },
   Terminal: {
     /**
      * Writes the data to the terminal

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -14,10 +14,7 @@ class SentryLogging {
       beforeSend: async (event) => {
         this.filterEvent(event);
 
-        if (
-          event.extra?.comfyUIExecutionError ||
-          this.comfyDesktopApp?.comfySettings.get('Comfy-Desktop.SendStatistics')
-        ) {
+        if (this.comfyDesktopApp?.comfySettings.get('Comfy-Desktop.SendStatistics')) {
           return event;
         }
 


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI_frontend/pull/2229 now directly call Sentry endpoint in the frontend. The electron API for Sentry reporting can be dropped.