### PR TITLE
[Cleanup] Remove unnecessary async annotation

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -94,8 +94,7 @@ export class PathHandlers {
      */
     ipcMain.handle(
       IPC_CHANNELS.VALIDATE_COMFYUI_SOURCE,
-      // eslint-disable-next-line @typescript-eslint/require-await
-      async (event, path: string): Promise<{ isValid: boolean; error?: string }> => {
+      (event, path: string): { isValid: boolean; error?: string } => {
         const isValid = ComfyConfigManager.isComfyUIDirectory(path);
         return {
           isValid,

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -110,9 +110,7 @@ export class ComfyDesktopApp {
         }
       }
     );
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    ipcMain.handle(IPC_CHANNELS.GET_BASE_PATH, async (): Promise<string> => {
+    ipcMain.handle(IPC_CHANNELS.GET_BASE_PATH, (): string => {
       return this.basePath;
     });
     ipcMain.handle(IPC_CHANNELS.IS_FIRST_TIME_SETUP, () => {


### PR DESCRIPTION
Remove unnecessary async wrapping as nothing in the function body is async.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-610-Cleanup-Remove-unnecessary-async-annotation-17b6d73d3650819faa9ce414c07af4b9) by [Unito](https://www.unito.io)
