### PR TITLE
Fix numpy CPU numpy version does not match gpu

### DIFF
--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -140,7 +140,7 @@ networkx==3.4.2
     #   --override assets/override.txt
     #   torch
     # from https://pypi.org/simple
-numpy==2.1.3
+numpy==1.26.4
     # via
     #   --override assets/override.txt
     #   scipy


### PR DESCRIPTION
- #468 added compiled requirements for CPU mode
- numpy package version does not match the other compiled requirements
- Changes CPU to match existing numpy constraints

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-612-Fix-numpy-CPU-numpy-version-does-not-match-gpu-17b6d73d365081e6b187fdc206004426) by [Unito](https://www.unito.io)
