### PR TITLE
Add double-click restores ComfyUI from system tray

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -306,6 +306,7 @@ export class AppWindow {
     const tray = new Tray(trayImage);
 
     tray.setToolTip('ComfyUI');
+    tray.on('double-click', () => this.show());
 
     // For Mac you can have a separate icon when you press.
     // The current design language for Mac Eco System is White or Black icon then when you click it is in color


### PR DESCRIPTION
#### Current
- Double-click on the tray icon has no effect

#### Proposed
- Double-click shows the ComfyUI window if hidden

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-614-Add-double-click-restores-ComfyUI-from-system-tray-17b6d73d3650815d9325e830e5b09f4d) by [Unito](https://www.unito.io)
