### PR TITLE
Add installation validation

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain } from 'electron';
+import { app, dialog, ipcMain } from 'electron';
 import log from 'electron-log/main';
 
 import { IPC_CHANNELS } from '../constants';
@@ -21,32 +21,99 @@ export class InstallationManager {
    * Ensures that ComfyUI is installed and ready to run.
    *
    * First checks for an existing installation and validates it. If missing or invalid, a fresh install is started.
+   * Will not resolve until the installation is valid.
    * @returns A valid {@link ComfyInstallation} object.
    */
   async ensureInstalled(): Promise<ComfyInstallation> {
     const installation = ComfyInstallation.fromConfig();
-    log.verbose(`Install state: ${installation?.state ?? 'not installed'}`);
+    log.info(`Install state: ${installation?.state ?? 'not installed'}`);
 
     // Fresh install
     if (!installation) return await this.freshInstall();
 
-    // Validate installation
-    const state = await installation.validate();
-    log.verbose(`Validated install state: ${state}`);
-    if (state !== 'installed') await this.resumeInstallation(installation);
+    try {
+      // Send updates to renderer
+      this.#setupIpc(installation);
 
-    // Resolve issues and re-run validation
-    if (installation.issues.size > 0) {
-      await this.resolveIssues(installation);
-      await installation.validate();
+      // Validate installation
+      const state = await installation.validate();
+      if (state !== 'installed') await this.resumeInstallation(installation);
+
+      // Resolve issues and re-run validation
+      if (installation.hasIssues) {
+        while (!(await this.resolveIssues(installation))) {
+          // Re-run validation
+          log.verbose('Re-validating installation.');
+        }
+      }
+
+      // Return validated installation
+      return installation;
+    } finally {
+      delete installation.onUpdate;
+      this.#removeIpcHandlers();
     }
+  }
 
-    // TODO: Confirm this is no longer possible after resolveIssues and remove.
-    if (!installation.basePath) throw new Error('Base path was invalid after installation validation.');
-    if (installation.issues.size > 0) throw new Error('Installation issues remain after validation.');
+  /** Removes all handlers created by {@link #setupIpc} */
+  #removeIpcHandlers() {
+    ipcMain.removeHandler(IPC_CHANNELS.GET_VALIDATION_STATE);
+    ipcMain.removeHandler(IPC_CHANNELS.VALIDATE_INSTALLATION);
+    ipcMain.removeHandler(IPC_CHANNELS.UV_INSTALL_REQUIREMENTS);
+    ipcMain.removeHandler(IPC_CHANNELS.UV_CLEAR_CACHE);
+    ipcMain.removeHandler(IPC_CHANNELS.UV_RESET_VENV);
+  }
 
-    // Return validated installation
-    return installation;
+  /** Set to `true` the first time an error is found during validation. @todo Move to app state singleton once impl. */
+  #onMaintenancePage = false;
+
+  /** Creates IPC handlers for the installation instance. */
+  #setupIpc(installation: ComfyInstallation) {
+    this.#onMaintenancePage = false;
+    installation.onUpdate = (data) => {
+      this.appWindow.send(IPC_CHANNELS.VALIDATION_UPDATE, data);
+
+      // Load maintenance page the first time any error is found.
+      if (!this.#onMaintenancePage && Object.values(data).includes('error')) {
+        this.#onMaintenancePage = true;
+
+        log.info('Validation error - loading maintenance page.');
+        this.appWindow.loadRenderer('maintenance').catch((error) => {
+          log.error('Error loading maintenance page.', error);
+          const message = `An error was detected with your installation, and the maintenance page could not be loaded to resolve it. The app will close now. Please reinstall if this issue persists.\n\nError message:\n\n${error}`;
+          dialog.showErrorBox('Critical Error', message);
+          app.quit();
+        });
+      }
+    };
+    const sendLogIpc = (data: string) => this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
+
+    ipcMain.handle(IPC_CHANNELS.GET_VALIDATION_STATE, () => {
+      installation.onUpdate?.(installation.validation);
+      return installation.validation;
+    });
+    ipcMain.handle(IPC_CHANNELS.VALIDATE_INSTALLATION, async () => await installation.validate());
+    ipcMain.handle(IPC_CHANNELS.UV_INSTALL_REQUIREMENTS, () =>
+      installation.virtualEnvironment.reinstallRequirements(sendLogIpc)
+    );
+    ipcMain.handle(IPC_CHANNELS.UV_CLEAR_CACHE, async () => await installation.virtualEnvironment.clearUvCache());
+    ipcMain.handle(IPC_CHANNELS.UV_RESET_VENV, async (): Promise<boolean> => {
+      const venv = installation.virtualEnvironment;
+      const deleted = await venv.removeVenvDirectory();
+      if (!deleted) return false;
+
+      const created = await venv.createVenv(sendLogIpc);
+      if (!created) return false;
+
+      return await venv.upgradePip({ onStdout: sendLogIpc, onStderr: sendLogIpc });
+    });
+
+    // Replace the reinstall IPC handler.
+    ipcMain.removeHandler(IPC_CHANNELS.REINSTALL);
+    ipcMain.handle(IPC_CHANNELS.REINSTALL, async () => {
+      log.info('Reinstalling...');
+      await InstallationManager.reinstall(installation);
+    });
   }
 
   /**
@@ -135,40 +202,35 @@ export class InstallationManager {
     return filePaths[0];
   }
 
-  /** Notify user that the provided base apth is not valid. */
-  async #showInvalidBasePathMessage() {
-    await this.appWindow.showMessageBox({
-      title: 'Invalid base path',
-      message:
-        'ComfyUI needs a valid directory set as its base path.  Inside, models, custom nodes, etc will be stored.\n\nClick OK, then selected a new base path.',
-      type: 'error',
-    });
-  }
-
   /**
    * Resolves any issues found during installation validation.
    * @param installation The installation to resolve issues for
    * @throws If the base path is invalid or cannot be saved
    */
   async resolveIssues(installation: ComfyInstallation) {
-    const issues = [...installation.issues];
-    for (const issue of issues) {
-      switch (issue) {
-        // TODO: Other issues (uv mising, venv etc)
-        case 'invalidBasePath': {
-          // TODO: Add IPC listeners and proper UI for this
-          await this.#showInvalidBasePathMessage();
+    log.verbose('Resolving issues - awaiting user response:', installation.validation);
 
-          const path = await this.showBasePathPicker();
-          if (!path) return;
+    // Await user close window request, validate if any errors remain
+    const isValid = await new Promise<boolean>((resolve) => {
+      ipcMain.handleOnce(IPC_CHANNELS.COMPLETE_VALIDATION, async (): Promise<boolean> => {
+        log.verbose('Attempting to close validation window');
+        // Check if issues have been resolved externally
+        if (!installation.isValid) await installation.validate();
 
-          const success = await installation.updateBasePath(path);
-          if (!success) throw new Error('No base path selected or failed to save in config.');
+        // Resolve main thread & renderer
+        const { isValid } = installation;
+        resolve(isValid);
+        return isValid;
+      });
+    });
 
-          installation.issues.delete('invalidBasePath');
-          break;
-        }
-      }
-    }
+    log.verbose('Resolution complete:', installation.validation);
+    return isValid;
+  }
+
+  static async reinstall(installation: ComfyInstallation): Promise<void> {
+    await installation.uninstall();
+    app.relaunch();
+    app.quit();
   }
 }

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -183,7 +183,7 @@ export class InstallationManager {
       useDesktopConfig().set('migrateCustomNodesFrom', installWizard.migrationSource);
     }
 
-    const installation = new ComfyInstallation('installed', installWizard.basePath, device);
+    const installation = new ComfyInstallation('installed', installWizard.basePath, this.telemetry, device);
     installation.setState('installed');
     return installation;
   }

--- a/src/main-process/comfyInstallation.ts
+++ b/src/main-process/comfyInstallation.ts
@@ -1,15 +1,13 @@
 import log from 'electron-log/main';
+import { rm } from 'node:fs/promises';
 
 import { ComfyServerConfig } from '../config/comfyServerConfig';
-import type { TorchDeviceType } from '../preload';
+import type { InstallValidation, TorchDeviceType } from '../preload';
 import { getTelemetry } from '../services/telemetry';
 import { useDesktopConfig } from '../store/desktopConfig';
 import type { DesktopSettings } from '../store/desktopSettings';
-import { containsDirectory, pathAccessible } from '../utils';
+import { canExecute, canExecuteShellCommand, pathAccessible } from '../utils';
 import { VirtualEnvironment } from '../virtualEnvironment';
-
-// TODO: | 'uvMissing' | 'venvMissing' | 'venvInvalid' | 'noPyTorch';
-export type ValidationIssue = 'invalidBasePath';
 
 type InstallState = Exclude<DesktopSettings['installState'], undefined>;
 
@@ -19,11 +17,18 @@ type InstallState = Exclude<DesktopSettings['installState'], undefined>;
  */
 export class ComfyInstallation {
   /** Installation issues, such as missing base path, no venv.  Populated by {@link validate}. */
-  readonly issues: Set<ValidationIssue> = new Set();
+  validation: InstallValidation = {
+    inProgress: false,
+    installState: 'started',
+  };
+
+  get hasIssues() {
+    return Object.values(this.validation).includes('error');
+  }
 
   /** Returns `true` if {@link state} is 'installed' and there are no issues, otherwise `false`. */
   get isValid() {
-    return this.state === 'installed' && this.issues.size === 0;
+    return this.state === 'installed' && !this.hasIssues;
   }
 
   virtualEnvironment: VirtualEnvironment;
@@ -38,6 +43,12 @@ export class ComfyInstallation {
     this._basePath = value;
     this.virtualEnvironment = new VirtualEnvironment(value, getTelemetry(), this.device);
   }
+
+  /**
+   * Called during/after each step of validation
+   * @param data The data to send to the renderer
+   */
+  onUpdate?: (data: InstallValidation) => void;
 
   constructor(
     /** Installation state, e.g. `started`, `installed`.  See {@link DesktopSettings}. */
@@ -54,6 +65,7 @@ export class ComfyInstallation {
   /**
    * Static factory method. Creates a ComfyInstallation object if previously saved config can be read.
    * @returns A ComfyInstallation (not validated) object if config is saved, otherwise `undefined`.
+   * @throws If YAML config is unreadable due to access restrictions
    */
   static fromConfig(): ComfyInstallation | undefined {
     const config = useDesktopConfig();
@@ -66,36 +78,94 @@ export class ComfyInstallation {
   /**
    * Validate the installation and add any results to {@link issues}.
    * @returns The validated installation state, along with a list of any issues detected.
+   * @throws When the YAML file is present but not readable (access denied, FS error, etc).
    */
   async validate(): Promise<InstallState> {
     log.info(`Validating installation. Recorded state: [${this.state}]`);
-
-    let { state } = this;
+    const validation: InstallValidation = {
+      inProgress: true,
+      installState: this.state,
+    };
+    this.validation = validation;
+    this.onUpdate?.(validation);
 
     // Upgraded from a version prior to 0.3.18
     // TODO: Validate more than just the existence of one file
-    if (!state && ComfyServerConfig.exists()) {
+    if (!validation.installState && ComfyServerConfig.exists()) {
       log.info('Found extra_models_config.yaml but no recorded state - assuming upgrade from <= 0.3.18');
-      state = 'upgraded';
+      validation.installState = 'upgraded';
+      this.onUpdate?.(validation);
     }
 
     // Validate base path
     const basePath = await this.loadBasePath();
-    if (basePath === undefined || !(await pathAccessible(basePath))) {
-      log.warn('"base_path" is inaccessible or undefined.');
-      this.issues.add('invalidBasePath');
+    if (basePath && (await pathAccessible(basePath))) {
+      validation.basePath = 'OK';
+      this.onUpdate?.(validation);
+
+      const venv = new VirtualEnvironment(basePath, getTelemetry(), this.device);
+      if (await venv.exists()) {
+        validation.venvDirectory = 'OK';
+        this.onUpdate?.(validation);
+
+        // Python interpreter
+        validation.pythonInterpreter = (await canExecute(venv.pythonInterpreterPath)) ? 'OK' : 'error';
+        if (validation.pythonInterpreter !== 'OK') log.warn('Python interpreter is missing or not executable.');
+        this.onUpdate?.(validation);
+
+        // uv
+        if (await canExecute(venv.uvPath)) {
+          validation.uv = 'OK';
+          this.onUpdate?.(validation);
+
+          // Python packages
+          try {
+            validation.pythonPackages = (await venv.hasRequirements()) ? 'OK' : 'error';
+            if (validation.pythonPackages !== 'OK') log.error('Virtual environment is incomplete.');
+          } catch (error) {
+            log.error('Failed to read venv packages.', error);
+            validation.pythonPackages = 'error';
+          }
+        } else {
+          log.warn('uv is missing or not executable.');
+          validation.uv = 'error';
+        }
+      } else {
+        log.warn('Virtual environment is missing.');
+        validation.venvDirectory = 'error';
+      }
+    } else {
+      log.error('"base_path" is inaccessible or undefined.');
+      validation.basePath = 'error';
     }
+    this.onUpdate?.(validation);
 
-    // TODO: Validate python, venv, etc.
+    // Git
+    validation.git = (await canExecuteShellCommand('git --help')) ? 'OK' : 'error';
+    if (validation.git !== 'OK') log.warn('git not found in path.');
+    this.onUpdate?.(validation);
 
-    log.info(`Validation result: isValid:${this.isValid}, state:${state}, issues:${this.issues.size}`);
-    return state;
+    if (process.platform === 'win32') {
+      const vcDllPath = `${process.env.SYSTEMROOT}\\System32\\vcruntime140.dll`;
+      validation.vcRedist = (await pathAccessible(vcDllPath)) ? 'OK' : 'error';
+      if (validation.vcRedist !== 'OK') log.warn(`Visual C++ Redistributable was not found [${vcDllPath}]`);
+    } else {
+      validation.vcRedist = 'skipped';
+    }
+    this.onUpdate?.(validation);
+
+    // Complete
+    validation.inProgress = false;
+    log.info(`Validation result: isValid:${this.isValid}, state:${validation.installState}`, validation);
+    this.onUpdate?.(validation);
+
+    return validation.installState;
   }
 
   /**
    * Loads the base path from YAML config. If it is unreadable, warns the user and quits.
    * @returns The base path if read successfully, or `undefined`
-   * @throws If the config file is unreadable
+   * @throws If the config file is present but not readable
    */
   async loadBasePath(): Promise<string | undefined> {
     const readResult = await ComfyServerConfig.readBasePathFromConfig(ComfyServerConfig.configPath);
@@ -129,28 +199,12 @@ If this problem persists, back up and delete the config file, then restart the a
   upgradeConfig() {
     log.verbose(`Upgrading config to latest format.  Current state: [${this.state}]`);
     // Migrate config
-    if (!this.issues.has('invalidBasePath')) {
+    if (this.validation.basePath !== 'error') {
       useDesktopConfig().set('basePath', this.basePath);
     } else {
       log.warn('Skipping save of basePath.');
     }
     this.setState('installed');
-  }
-
-  /**
-   * Set a new base path in the YAML config file.
-   * @param newBasePath The new base path to use.
-   * @returns `true` if the new base path is valid and can be written to the config file, otherwise `false`
-   */
-  async updateBasePath(newBasePath: string): Promise<boolean> {
-    if (!newBasePath) return false;
-
-    // TODO: Allow creation of new venv
-    if (!(await containsDirectory(newBasePath, '.venv'))) return false;
-
-    this.basePath = newBasePath;
-    // TODO: SoC violation
-    return await ComfyServerConfig.setBasePathInDefaultConfig(newBasePath);
   }
 
   /**
@@ -160,5 +214,14 @@ If this problem persists, back up and delete the config file, then restart the a
   setState(state: InstallState) {
     this.state = state;
     useDesktopConfig().set('installState', state);
+  }
+
+  /**
+   * Removes the config files. Clean up is not yet impl.
+   * @todo Allow normal removal of the app and its effects.
+   */
+  async uninstall(): Promise<void> {
+    await rm(ComfyServerConfig.configPath);
+    await useDesktopConfig().permanentlyDeleteConfigFile();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,8 +108,6 @@ async function startApp() {
       // Install / validate installation is complete
       const installManager = new InstallationManager(appWindow, telemetry);
       const installation = await installManager.ensureInstalled();
-      if (!installation.isValid)
-        throw new Error(`Fatal: Could not validate installation: [${installation.state}/${installation.issues.size}]`);
 
       // Initialize app
       const comfyDesktopApp = new ComfyDesktopApp(installation, appWindow, telemetry);

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -2,6 +2,7 @@ import { app } from 'electron';
 import log from 'electron-log/main';
 import pty from 'node-pty';
 import { ChildProcess, spawn } from 'node:child_process';
+import { rm } from 'node:fs/promises';
 import os, { EOL } from 'node:os';
 import path from 'node:path';
 
@@ -184,12 +185,9 @@ export class VirtualEnvironment implements HasTelemetry {
 
   @trackEvent('install_flow:virtual_environment_ensurepip')
   public async ensurePip(callbacks?: ProcessCallbacks): Promise<void> {
-    const { exitCode: ensurepipExitCode } = await this.runPythonCommandAsync(
-      ['-m', 'ensurepip', '--upgrade'],
-      callbacks
-    );
-    if (ensurepipExitCode !== 0) {
-      throw new Error(`Failed to upgrade pip: exit code ${ensurepipExitCode}`);
+    const { exitCode } = await this.runPythonCommandAsync(['-m', 'ensurepip', '--upgrade'], callbacks);
+    if (exitCode !== 0) {
+      throw new Error(`Failed to upgrade pip: exit code ${exitCode}`);
     }
   }
 
@@ -338,12 +336,12 @@ export class VirtualEnvironment implements HasTelemetry {
     env: Record<string, string>,
     callbacks?: ProcessCallbacks,
     cwd?: string
-  ): Promise<{ exitCode: number | null }> {
+  ): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }> {
     return new Promise((resolve, reject) => {
       const childProcess = this.runCommand(command, args, env, callbacks, cwd);
 
-      childProcess.on('close', (code) => {
-        resolve({ exitCode: code });
+      childProcess.on('close', (code, signal) => {
+        resolve({ exitCode: code, signal });
       });
 
       childProcess.on('error', (error) => {
@@ -419,7 +417,131 @@ export class VirtualEnvironment implements HasTelemetry {
     }
   }
 
-  private async exists(): Promise<boolean> {
+  async exists(): Promise<boolean> {
     return await pathAccessible(this.venvPath);
+  }
+
+  /**
+   * Checks if the virtual environment has all the required packages of ComfyUI core.
+   *
+   * Parses the text output of `uv pip install --dry-run -r requirements.txt`.
+   * @returns `true` if pip install does not detect any missing packages, otherwise `false`
+   */
+  async hasRequirements() {
+    const args = ['pip', 'install', '--dry-run', '-r', this.comfyUIRequirementsPath];
+    log.info(`Running direct process command: ${args.join(' ')}`);
+
+    // Get packages as json string
+    let output = '';
+    const callbacks: ProcessCallbacks = {
+      onStdout: (data) => (output += data.toString()),
+      onStderr: (data) => (output += data.toString()),
+    };
+    const result = await this.runCommandAsync(
+      this.uvPath,
+      args,
+      { PYTHONIOENCODING: 'utf8' },
+      callbacks,
+      this.venvRootPath
+    );
+
+    if (result.exitCode !== 0)
+      throw new Error(`Failed to get packages: Exit code ${result.exitCode}, signal ${result.signal}`);
+    if (!output) throw new Error('Failed to get packages: uv output was empty');
+
+    const venvOk = output.search(/\bWould make no changes\s+$/) !== -1;
+    if (!venvOk) log.warn(output);
+
+    return venvOk;
+  }
+
+  async clearUvCache(): Promise<boolean> {
+    return await this.#rmdir(this.cacheDir, 'uv cache');
+  }
+
+  async removeVenvDirectory(): Promise<boolean> {
+    return await this.#rmdir(this.venvPath, '.venv directory');
+  }
+
+  async #rmdir(dir: string, logName: string): Promise<boolean> {
+    if (await pathAccessible(dir)) {
+      log.info(`Removing ${logName} [${dir}]`);
+      try {
+        await rm(dir, { recursive: true });
+      } catch (error) {
+        log.error(`Error removing ${logName}: ${error}`);
+        return false;
+      }
+    } else {
+      log.warn(`Attempted to remove ${logName}, but directory does not exist [${dir}]`);
+    }
+    return true;
+  }
+
+  /**
+   * Reinstalls the required packages for ComfyUI core.
+   */
+  async reinstallRequirements(onData: (data: string) => void) {
+    const callbacks = { onStdout: onData };
+
+    try {
+      await this.#using(() => this.manualInstall(callbacks));
+    } catch (error) {
+      log.error(`Failed to reinstall requirements: ${error}`);
+
+      const created = await this.createVenv(onData);
+      if (!created) return false;
+
+      const pipEnsured = await this.upgradePip(callbacks);
+      if (!pipEnsured) return false;
+
+      await this.#using(() => this.manualInstall(callbacks));
+    }
+    return true;
+  }
+
+  /**
+   * Upgrades pip in the virtual environment.
+   * @returns `true` if the virtual environment was created successfully, otherwise `false`
+   */
+  async upgradePip(callbacks?: ProcessCallbacks): Promise<boolean> {
+    try {
+      await this.#using(() => this.ensurePip(callbacks));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Create virtual environment using uv
+   * @returns `true` if the virtual environment was created successfully, otherwise `false`
+   */
+  async createVenv(onData: ((data: string) => void) | undefined): Promise<boolean> {
+    try {
+      const callbacks: ProcessCallbacks = { onStdout: onData };
+      await this.#using(() => this.createVenvWithPython(callbacks));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Similar to `using` functionality, this ensures that {@link uvPty} is terminated after the command has run.
+   * @param command The command to run
+   * @returns The result of the command
+   * @todo Refactor to `using`
+   */
+  async #using<T>(command: () => Promise<T>): Promise<T> {
+    try {
+      return await command();
+    } finally {
+      const pid = this.uvPty?.pid;
+      if (pid) {
+        process.kill(pid);
+        this.uvPty = undefined;
+      }
+    }
   }
 }


### PR DESCRIPTION
### Installation validation

Requires:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/2253
- Any validation errors require a user response (which requires 2253).

Validates the following on startup:

- Installation base path
- Virtual environment
- Python functionality
- Required python packages
- git
- VC redistributable

Adds maintenance tasks available through IPC:

- Reset virtual environment (clears the .venv dir)
- Clear uv cache

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-616-Add-installation-validation-17b6d73d36508176891ce05bd03c70e5) by [Unito](https://www.unito.io)
