### PR TITLE
Add optional usage metrics for installation / onboarding.

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "dotenv": "^16.4.5",
     "electron-log": "^5.2.0",
     "electron-store": "8.2.0",
+    "mixpanel": "^0.18.0",
     "node-pty": "^1.0.0",
     "systeminformation": "^5.24.8",
     "tar": "^7.4.3",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export const IPC_CHANNELS = {
   GET_GPU: 'get-gpu',
   SET_WINDOW_STYLE: 'set-window-style',
   GET_WINDOW_STYLE: 'get-window-style',
+  TRACK_EVENT: 'track-event',
 } as const;
 
 export enum ProgressStatus {

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -5,6 +5,7 @@ import { InstallOptions } from '../preload';
 import { DEFAULT_SETTINGS, type ComfySettingsData } from '../config/comfySettings';
 import { ComfyServerConfig, ModelPaths } from '../config/comfyServerConfig';
 import { ComfyConfigManager } from '../config/comfyConfigManager';
+import { telemetry } from '../services/telemetry';
 
 export class InstallWizard {
   public migrationItemIds: Set<string> = new Set();
@@ -22,11 +23,13 @@ export class InstallWizard {
   }
 
   public async install() {
+    telemetry.track('desktop:install_wizard_start');
     // Setup the ComfyUI folder structure.
     ComfyConfigManager.createComfyDirectories(this.basePath);
     this.initializeUserFiles();
     this.initializeSettings();
     await this.initializeModelPaths();
+    telemetry.track('desktop:install_wizard_end');
   }
 
   /**

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -25,7 +25,7 @@ export class InstallWizard implements HasTelemetry {
     return this.installOptions.installPath;
   }
 
-  @trackEvent('desktop:install_wizard_install')
+  @trackEvent('install_flow:create_comfy_directories')
   public async install() {
     // Setup the ComfyUI folder structure.
     ComfyConfigManager.createComfyDirectories(this.basePath);

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -41,6 +41,7 @@ export class InstallWizard implements HasTelemetry {
     const shouldMigrateUserFiles = !!this.migrationSource && this.migrationItemIds.has('user_files');
     if (!shouldMigrateUserFiles) return;
 
+    this.telemetry.track('migrate_flow:migrate_user_files');
     // Copy user files from migration source to the new ComfyUI folder.
     const srcUserFilesDir = path.join(this.migrationSource, 'user');
     const destUserFilesDir = path.join(this.basePath, 'user');
@@ -87,6 +88,7 @@ export class InstallWizard implements HasTelemetry {
     const shouldMigrateModels = !!migrationSource && this.migrationItemIds.has('models');
 
     if (shouldMigrateModels) {
+      this.telemetry.track('migrate_flow:migrate_models');
       // The yaml file exists in migration source repo.
       const migrationServerConfigs = await ComfyServerConfig.getConfigFromRepoPath(migrationSource);
 

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -5,13 +5,18 @@ import { InstallOptions } from '../preload';
 import { DEFAULT_SETTINGS, type ComfySettingsData } from '../config/comfySettings';
 import { ComfyServerConfig, ModelPaths } from '../config/comfyServerConfig';
 import { ComfyConfigManager } from '../config/comfyConfigManager';
-import { telemetry } from '../services/telemetry';
+import { ITelemetry } from '../services/telemetry';
 
 export class InstallWizard {
   public migrationItemIds: Set<string> = new Set();
+  private telemetry: ITelemetry;
 
-  constructor(public installOptions: InstallOptions) {
+  constructor(
+    public installOptions: InstallOptions,
+    telemetry: ITelemetry
+  ) {
     this.migrationItemIds = new Set(installOptions.migrationItemIds ?? []);
+    this.telemetry = telemetry;
   }
 
   get migrationSource(): string | undefined {
@@ -23,13 +28,13 @@ export class InstallWizard {
   }
 
   public async install() {
-    telemetry.track('desktop:install_wizard_start');
+    this.telemetry.track('desktop:install_wizard_start');
     // Setup the ComfyUI folder structure.
     ComfyConfigManager.createComfyDirectories(this.basePath);
     this.initializeUserFiles();
     this.initializeSettings();
     await this.initializeModelPaths();
-    telemetry.track('desktop:install_wizard_end');
+    this.telemetry.track('desktop:install_wizard_end');
   }
 
   /**

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -5,18 +5,16 @@ import { InstallOptions } from '../preload';
 import { DEFAULT_SETTINGS, type ComfySettingsData } from '../config/comfySettings';
 import { ComfyServerConfig, ModelPaths } from '../config/comfyServerConfig';
 import { ComfyConfigManager } from '../config/comfyConfigManager';
-import { ITelemetry } from '../services/telemetry';
+import { HasTelemetry, ITelemetry, trackEvent } from '../services/telemetry';
 
-export class InstallWizard {
+export class InstallWizard implements HasTelemetry {
   public migrationItemIds: Set<string> = new Set();
-  private telemetry: ITelemetry;
 
   constructor(
     public installOptions: InstallOptions,
-    telemetry: ITelemetry
+    readonly telemetry: ITelemetry
   ) {
     this.migrationItemIds = new Set(installOptions.migrationItemIds ?? []);
-    this.telemetry = telemetry;
   }
 
   get migrationSource(): string | undefined {
@@ -27,14 +25,13 @@ export class InstallWizard {
     return this.installOptions.installPath;
   }
 
+  @trackEvent('desktop:install_wizard_install')
   public async install() {
-    this.telemetry.track('desktop:install_wizard_start');
     // Setup the ComfyUI folder structure.
     ComfyConfigManager.createComfyDirectories(this.basePath);
     this.initializeUserFiles();
     this.initializeSettings();
     await this.initializeModelPaths();
-    this.telemetry.track('desktop:install_wizard_end');
   }
 
   /**

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -91,6 +91,8 @@ export class InstallationManager {
     this.telemetry.track('desktop:install_options_received', {
       gpuType: installOptions.device,
       autoUpdate: installOptions.autoUpdate,
+      allowMetrics: installOptions.allowMetrics,
+      migrationItemIds: installOptions.migrationItemIds,
     });
 
     const installWizard = new InstallWizard(installOptions, this.telemetry);

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -64,7 +64,6 @@ export class InstallationManager {
    */
   async freshInstall(): Promise<ComfyInstallation> {
     log.info('Starting installation.');
-    this.telemetry.track('desktop:fresh_install_start');
     const config = useDesktopConfig();
     config.set('installState', 'started');
 

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -140,6 +140,7 @@ export class AppWindow {
   public async loadComfyUI(serverArgs: ServerArgs) {
     const host = serverArgs.host === '0.0.0.0' ? 'localhost' : serverArgs.host;
     const url = this.devUrlOverride ?? `http://${host}:${serverArgs.port}`;
+    log.info(`Loading ComfyUI at ${url}`);
     await this.window.loadURL(url);
   }
 

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -140,7 +140,6 @@ export class AppWindow {
   public async loadComfyUI(serverArgs: ServerArgs) {
     const host = serverArgs.host === '0.0.0.0' ? 'localhost' : serverArgs.host;
     const url = this.devUrlOverride ?? `http://${host}:${serverArgs.port}`;
-    log.info(`Loading ComfyUI at ${url}`);
     await this.window.loadURL(url);
   }
 

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -17,16 +17,16 @@ import { Terminal } from '../shell/terminal';
 import { DesktopConfig, useDesktopConfig } from '../store/desktopConfig';
 import { CmCli } from '../services/cmCli';
 import { rm } from 'node:fs/promises';
-import { telemetry } from '../services/telemetry';
+import { ITelemetry } from '../services/telemetry';
 
 export class ComfyDesktopApp {
   public comfyServer: ComfyServer | null = null;
   private terminal: Terminal | null = null; // Only created after server starts.
-
   constructor(
     public basePath: string,
     public comfySettings: ComfySettings,
-    public appWindow: AppWindow
+    public appWindow: AppWindow,
+    private readonly telemetry: ITelemetry
   ) {}
 
   get pythonInstallPath() {
@@ -151,7 +151,7 @@ export class ComfyDesktopApp {
 
     const config = useDesktopConfig();
     const selectedDevice = config.get('selectedDevice');
-    const virtualEnvironment = new VirtualEnvironment(this.basePath, selectedDevice);
+    const virtualEnvironment = new VirtualEnvironment(this.basePath, this.telemetry, selectedDevice);
 
     const processCallbacks: ProcessCallbacks = {
       onStdout: (data) => {
@@ -169,12 +169,12 @@ export class ComfyDesktopApp {
 
     this.appWindow.sendServerStartProgress(ProgressStatus.STARTING_SERVER);
     this.comfyServer = new ComfyServer(this.basePath, serverArgs, virtualEnvironment, this.appWindow);
-    telemetry.track('desktop:comfy_server_start');
+    this.telemetry.track('desktop:comfy_server_start');
     await this.comfyServer.start().catch((error) => {
-      telemetry.track('desktop:comfy_server_start_error', { error: error.message });
+      this.telemetry.track('desktop:comfy_server_start_error', { error: error.message });
       throw error;
     });
-    telemetry.track('desktop:comfy_server_start_success');
+    this.telemetry.track('desktop:comfy_server_start_success');
     this.initializeTerminal(virtualEnvironment);
 
     if (customNodeMigrationError) {
@@ -188,7 +188,7 @@ export class ComfyDesktopApp {
 
   /** @returns `undefined` if successful, or an error `string` on failure. */
   async migrateCustomNodes(config: DesktopConfig, virtualEnvironment: VirtualEnvironment, callbacks: ProcessCallbacks) {
-    telemetry.track('desktop:migrate_custom_nodes_start');
+    this.telemetry.track('desktop:migrate_custom_nodes_start');
     const fromPath = config.get('migrateCustomNodesFrom');
     if (!fromPath) return;
 
@@ -196,10 +196,10 @@ export class ComfyDesktopApp {
     try {
       const cmCli = new CmCli(virtualEnvironment);
       await cmCli.restoreCustomNodes(fromPath, callbacks);
-      telemetry.track('desktop:migrate_custom_nodes_end');
+      this.telemetry.track('desktop:migrate_custom_nodes_end');
     } catch (error) {
       log.error('Error migrating custom nodes:', error);
-      telemetry.track('desktop:migrate_custom_nodes_error');
+      this.telemetry.track('desktop:migrate_custom_nodes_error');
       // TODO: Replace with IPC callback to handle i18n (SoC).
       return error?.toString?.() ?? 'Error migrating custom nodes.';
     } finally {
@@ -208,8 +208,8 @@ export class ComfyDesktopApp {
     }
   }
 
-  static create(appWindow: AppWindow, basePath: string): ComfyDesktopApp {
-    return new ComfyDesktopApp(basePath, new ComfySettings(basePath), appWindow);
+  static create(appWindow: AppWindow, basePath: string, telemetry: ITelemetry): ComfyDesktopApp {
+    return new ComfyDesktopApp(basePath, new ComfySettings(basePath), appWindow, telemetry);
   }
 
   async uninstall(): Promise<void> {

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -182,14 +182,13 @@ export class ComfyDesktopApp implements HasTelemetry {
   }
 
   /** @returns `undefined` if successful, or an error `string` on failure. */
-  @trackEvent('migrate_flow:migrate_custom_nodes')
   async migrateCustomNodes(config: DesktopConfig, virtualEnvironment: VirtualEnvironment, callbacks: ProcessCallbacks) {
     const fromPath = config.get('migrateCustomNodesFrom');
     if (!fromPath) return;
 
     log.info('Migrating custom nodes from:', fromPath);
     try {
-      const cmCli = new CmCli(virtualEnvironment);
+      const cmCli = new CmCli(virtualEnvironment, virtualEnvironment.telemetry);
       await cmCli.restoreCustomNodes(fromPath, callbacks);
     } catch (error) {
       log.error('Error migrating custom nodes:', error);

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -182,7 +182,7 @@ export class ComfyDesktopApp implements HasTelemetry {
   }
 
   /** @returns `undefined` if successful, or an error `string` on failure. */
-  @trackEvent('desktop:migrate_custom_nodes')
+  @trackEvent('migrate_flow:migrate_custom_nodes')
   async migrateCustomNodes(config: DesktopConfig, virtualEnvironment: VirtualEnvironment, callbacks: ProcessCallbacks) {
     const fromPath = config.get('migrateCustomNodesFrom');
     if (!fromPath) return;

--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -98,7 +98,7 @@ export class ComfyServer implements HasTelemetry {
     });
   }
 
-  @trackEvent('desktop:comfy_server_start')
+  @trackEvent('comfyui:server_start')
   async start() {
     await rotateLogFiles(app.getPath('logs'), 'comfyui', 50);
     return new Promise<void>((resolve, reject) => {

--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -9,8 +9,9 @@ import { ComfyServerConfig } from '../config/comfyServerConfig';
 import { AppWindow } from './appWindow';
 import waitOn from 'wait-on';
 import { ChildProcess } from 'node:child_process';
+import { HasTelemetry, ITelemetry, trackEvent } from '../services/telemetry';
 
-export class ComfyServer {
+export class ComfyServer implements HasTelemetry {
   /**
    * The maximum amount of time to wait for the server to start.
    * Installing custom nodes dependencies like ffmpeg can take a long time,
@@ -29,7 +30,8 @@ export class ComfyServer {
     public basePath: string,
     public serverArgs: ServerArgs,
     public virtualEnvironment: VirtualEnvironment,
-    public appWindow: AppWindow
+    public appWindow: AppWindow,
+    readonly telemetry: ITelemetry
   ) {}
 
   get baseUrl() {
@@ -96,6 +98,7 @@ export class ComfyServer {
     });
   }
 
+  @trackEvent('desktop:comfy_server_start')
   async start() {
     await rotateLogFiles(app.getPath('logs'), 'comfyui', 50);
     return new Promise<void>((resolve, reject) => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,6 +3,7 @@ import { IPC_CHANNELS, ELECTRON_BRIDGE_API, ProgressStatus, DownloadStatus } fro
 import type { DownloadState } from './models/DownloadManager';
 import path from 'node:path';
 import type { DesktopSettings } from './store/desktopSettings';
+import { PropertyDict } from 'mixpanel';
 
 /**
  * Open a folder in the system's default file explorer.
@@ -282,6 +283,9 @@ const electronAPI = {
     },
     getWindowStyle: (): Promise<DesktopSettings['windowStyle']> => {
       return ipcRenderer.invoke(IPC_CHANNELS.GET_WINDOW_STYLE);
+    },
+    trackEvent: (eventName: string, properties?: PropertyDict): void => {
+      ipcRenderer.send(IPC_CHANNELS.TRACK_EVENT, eventName, properties);
     },
   },
   /** Restart the python server without restarting desktop. */

--- a/src/services/cmCli.ts
+++ b/src/services/cmCli.ts
@@ -3,12 +3,16 @@ import path from 'node:path';
 import { getAppResourcesPath } from '../install/resourcePaths';
 import { ProcessCallbacks, VirtualEnvironment } from '../virtualEnvironment';
 import { fileSync } from 'tmp';
+import { trackEvent, HasTelemetry, ITelemetry } from './telemetry';
 
-export class CmCli {
+export class CmCli implements HasTelemetry {
   private cliPath: string;
   private virtualEnvironment: VirtualEnvironment;
 
-  constructor(virtualEnvironment: VirtualEnvironment) {
+  constructor(
+    virtualEnvironment: VirtualEnvironment,
+    readonly telemetry: ITelemetry
+  ) {
     this.virtualEnvironment = virtualEnvironment;
     this.cliPath = path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes', 'ComfyUI-Manager', 'cm-cli.py');
   }
@@ -59,6 +63,7 @@ export class CmCli {
     return output;
   }
 
+  @trackEvent('migrate_flow:migrate_custom_nodes')
   public async restoreCustomNodes(fromComfyDir: string, callbacks: ProcessCallbacks) {
     const tmpFile = fileSync({ postfix: '.json' });
     try {

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -32,7 +32,6 @@ export class MixpanelTelemetry {
     this.distinctId = this.getOrCreateDistinctId(this.storageFile);
     this.queue = [];
     ipcMain.once(IPC_CHANNELS.INSTALL_COMFYUI, (_event, installOptions: InstallOptions) => {
-      log.verbose('Received INSTALL_COMFYUI.');
       if (installOptions.allowMetrics) {
         this.hasConsent = true;
       }
@@ -51,7 +50,7 @@ export class MixpanelTelemetry {
       return newId;
     } catch (error) {
       log.error('Failed to manage distinct ID:', error);
-      return randomUUID(); // Fallback to temporary ID
+      return '';
     }
   }
 

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -16,7 +16,7 @@ export interface ITelemetry {
   registerHandlers(): void;
 }
 
-const MIXPANEL_TOKEN = '246a5311a264a5d3bc99835b28d564c5';
+const MIXPANEL_TOKEN = '6a7f9f6ae2084b4e7ff7ced98a6b5988';
 export class MixpanelTelemetry {
   public hasConsent: boolean = false;
   private distinctId: string;

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,0 +1,105 @@
+import mixpanel, { PropertyDict } from 'mixpanel';
+import { randomUUID } from 'crypto';
+import { app, ipcMain } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs';
+import log from 'electron-log/main';
+import { IPC_CHANNELS } from '../constants';
+import { InstallOptions } from '../preload';
+
+const MIXPANEL_TOKEN = '6a7f9f6ae2084b4e7ff7ced98a6b5988';
+export class MixpanelTelemetry {
+  public hasConsent: boolean = false;
+  private distinctId: string;
+  private readonly storageFile: string;
+  private queue: { eventName: string; properties: PropertyDict }[] = [];
+  constructor() {
+    mixpanel.init(MIXPANEL_TOKEN);
+    // Store the distinct ID in a file in the user data directory for easy access.
+    this.storageFile = path.join(app.getPath('userData'), 'telemetry.txt');
+    this.distinctId = this.getOrCreateDistinctId(this.storageFile);
+    this.queue = [];
+    ipcMain.once(IPC_CHANNELS.INSTALL_COMFYUI, (_event, installOptions: InstallOptions) => {
+      log.verbose('Received INSTALL_COMFYUI.');
+      if (installOptions.allowMetrics) {
+        this.hasConsent = true;
+      }
+    });
+  }
+
+  private getOrCreateDistinctId(filePath: string): string {
+    try {
+      // Try to read existing ID
+      if (fs.existsSync(filePath)) {
+        return fs.readFileSync(filePath, 'utf8');
+      }
+
+      // Generate new ID if none exists
+      const newId = randomUUID();
+      fs.writeFileSync(filePath, newId);
+      return newId;
+    } catch (error) {
+      log.error('Failed to manage distinct ID:', error);
+      return randomUUID(); // Fallback to temporary ID
+    }
+  }
+
+  /**
+   * Track an event. If consent is not given, the event is queued for later.
+   * @param eventName
+   * @param properties
+   */
+  track(eventName: string, properties?: PropertyDict): void {
+    if (!this.hasConsent) {
+      log.debug(`Queueing event ${eventName} with properties ${JSON.stringify(properties)}`);
+      this.queue.push({
+        eventName,
+        properties: {
+          ...properties,
+          time: new Date(),
+          distinct_id: this.distinctId,
+        },
+      });
+      return;
+    }
+
+    this.flush();
+
+    try {
+      const enrichedProperties = {
+        ...properties,
+        distinct_id: this.distinctId,
+      };
+      this.mixpanelTrack(eventName, enrichedProperties);
+    } catch (error) {
+      log.error('Failed to track event:', error);
+    }
+  }
+
+  /**
+   * Empty the queue and send all events to Mixpanel.
+   */
+  flush(): void {
+    while (this.queue.length > 0) {
+      const { eventName, properties } = this.queue.pop()!;
+      this.mixpanelTrack(eventName, properties);
+    }
+  }
+
+  registerHandlers(): void {
+    ipcMain.on(IPC_CHANNELS.TRACK_EVENT, (event, eventName: string, properties?: PropertyDict) => {
+      this.track(eventName, properties);
+    });
+  }
+
+  private mixpanelTrack(eventName: string, properties: PropertyDict): void {
+    if (app.isPackaged) {
+      mixpanel.track(eventName, properties);
+    } else {
+      log.info(`Would have tracked ${eventName} with properties ${JSON.stringify(properties)}`);
+    }
+  }
+}
+
+// Export a singleton instance
+export const telemetry = new MixpanelTelemetry();

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -25,8 +25,6 @@ export class MixpanelTelemetry {
   private mixpanelClient: mixpanel.Mixpanel;
   constructor(mixpanelClass: mixpanel.Mixpanel) {
     this.mixpanelClient = mixpanelClass.init(MIXPANEL_TOKEN, {
-      debug: true,
-      verbose: true,
       geolocate: true,
     });
     // Store the distinct ID in a file in the user data directory for easy access.
@@ -136,7 +134,7 @@ export class MixpanelTelemetry {
   }
 
   private mixpanelTrack(eventName: string, properties: PropertyDict): void {
-    if (!app.isPackaged) {
+    if (app.isPackaged) {
       log.info(`Tracking ${eventName} with properties ${JSON.stringify(properties)}`);
       this.mixpanelClient.track(eventName, properties);
     } else {

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -116,8 +116,6 @@ export class VirtualEnvironment implements HasTelemetry {
   public async create(callbacks?: ProcessCallbacks): Promise<void> {
     try {
       await this.createEnvironment(callbacks);
-    } catch (error) {
-      throw error;
     } finally {
       const pid = this.uvPty?.pid;
       if (pid) process.kill(pid);

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -137,7 +137,7 @@ export class VirtualEnvironment implements HasTelemetry {
     throw new Error(`Unsupported platform: ${process.platform}`);
   }
 
-  @trackEvent('desktop:virtual_environment_create')
+  @trackEvent('install_flow:virtual_environment_create')
   private async createEnvironment(callbacks?: ProcessCallbacks): Promise<void> {
     if (this.selectedDevice === 'unsupported') {
       log.info('User elected to manually configure their environment.  Skipping python configuration.');
@@ -161,7 +161,7 @@ export class VirtualEnvironment implements HasTelemetry {
     await this.installRequirements(callbacks);
   }
 
-  @trackEvent('desktop:virtual_environment_create_python')
+  @trackEvent('install_flow:virtual_environment_create_python')
   public async createVenvWithPython(callbacks?: ProcessCallbacks): Promise<void> {
     log.info(`Creating virtual environment at ${this.venvPath} with python ${this.pythonVersion}`);
     const args = ['venv', '--python', this.pythonVersion];
@@ -172,7 +172,7 @@ export class VirtualEnvironment implements HasTelemetry {
     }
   }
 
-  @trackEvent('desktop:virtual_environment_create_ensurepip')
+  @trackEvent('install_flow:virtual_environment_create_ensurepip')
   public async ensurePip(callbacks?: ProcessCallbacks): Promise<void> {
     const { exitCode: ensurepipExitCode } = await this.runPythonCommandAsync(
       ['-m', 'ensurepip', '--upgrade'],
@@ -183,7 +183,7 @@ export class VirtualEnvironment implements HasTelemetry {
     }
   }
 
-  @trackEvent('desktop:virtual_environment_install_requirements')
+  @trackEvent('install_flow:virtual_environment_install_requirements')
   public async installRequirements(callbacks?: ProcessCallbacks): Promise<void> {
     // pytorch nightly is required for MPS
     if (process.platform === 'darwin') {

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MixpanelTelemetry } from '../../src/services/telemetry';
+import * as fs from 'fs';
+import * as path from 'path';
+import { IPC_CHANNELS } from '/src/constants';
+import { ipcMain, IpcMainEvent } from 'electron';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/mock/user/data'),
+    isPackaged: true,
+  },
+  ipcMain: {
+    on: vi.fn(),
+    once: vi.fn(),
+  },
+}));
+
+vi.mock('fs');
+vi.mock('mixpanel', () => ({
+  default: {
+    init: vi.fn(),
+    track: vi.fn(),
+  },
+}));
+
+describe('MixpanelTelemetry', () => {
+  let telemetry: MixpanelTelemetry;
+  const mockMixpanelClient = {
+    init: vi.fn(),
+    track: vi.fn(),
+    default: {
+      init: vi.fn(),
+      track: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('distinct ID management', () => {
+    it('should read existing distinct ID from file', () => {
+      const existingId = 'existing-uuid';
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(existingId);
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      expect(fs.readFileSync).toHaveBeenCalledWith(path.join('/mock/user/data', 'telemetry.txt'), 'utf8');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should create new distinct ID if file does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      const writtenId = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(typeof writtenId).toBe('string');
+      expect(writtenId.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('event queueing and consent', () => {
+    it('should queue events when consent is not given', () => {
+      const eventName = 'test_event';
+      const properties = { foo: 'bar' };
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      telemetry.track(eventName, properties);
+
+      expect(telemetry['queue'].length).toBe(1);
+      expect(telemetry['queue'][0].eventName).toBe(eventName);
+      expect(telemetry['queue'][0].properties).toMatchObject({
+        ...properties,
+        distinct_id: expect.any(String),
+        time: expect.any(Date),
+      });
+    });
+
+    it('should flush queue when consent is given', () => {
+      const eventName = 'test_event';
+
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      telemetry.track(eventName);
+
+      // Simulate receiving consent
+      const installOptionsHandler = vi.mocked(ipcMain.once).mock.calls[0][1];
+      const mockIpcEvent = {} as IpcMainEvent;
+      installOptionsHandler(mockIpcEvent, { allowMetrics: true });
+
+      // Track a new event which should trigger flush
+      telemetry.track('another_event');
+
+      expect(telemetry['queue'].length).toBe(0);
+      expect(mockMixpanelClient.track).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('IPC event handling', () => {
+    it('should handle INSTALL_COMFYUI event and update consent', () => {
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      const mockIpcEvent = {} as IpcMainEvent;
+      const installOptionsHandler = vi.mocked(ipcMain.once).mock.calls[0][1];
+      installOptionsHandler(mockIpcEvent, { allowMetrics: true });
+      expect(telemetry.hasConsent).toBe(true);
+    });
+
+    it('should register ipc handler for TRACK_EVENT', () => {
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      telemetry.registerHandlers();
+
+      expect(ipcMain.on).toHaveBeenCalledWith(IPC_CHANNELS.TRACK_EVENT, expect.any(Function));
+    });
+
+    it('should handle TRACK_EVENT messages', () => {
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      telemetry.registerHandlers();
+      const trackEventHandler = vi.mocked(ipcMain.on).mock.calls[0][1];
+
+      // Simulate receiving a track event
+      const mockIpcEvent = {} as IpcMainEvent;
+      trackEventHandler(mockIpcEvent, 'test_event', { foo: 'bar' });
+
+      // Since consent is false by default, it should be queued
+      expect(telemetry['queue'].length).toBe(1);
+    });
+  });
+});

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -26,13 +26,15 @@ vi.mock('mixpanel', () => ({
 
 describe('MixpanelTelemetry', () => {
   let telemetry: MixpanelTelemetry;
-  const mockMixpanelClient = {
-    init: vi.fn(),
+  const mockInitializedMixpanelClient = {
     track: vi.fn(),
     default: {
       init: vi.fn(),
       track: vi.fn(),
     },
+  };
+  const mockMixpanelClient = {
+    init: vi.fn().mockReturnValue(mockInitializedMixpanelClient),
   };
 
   beforeEach(() => {
@@ -92,7 +94,7 @@ describe('MixpanelTelemetry', () => {
       telemetry.track('another_event');
 
       expect(telemetry['queue'].length).toBe(0);
-      expect(mockMixpanelClient.track).toHaveBeenCalledTimes(2);
+      expect(mockInitializedMixpanelClient.track).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -124,5 +126,24 @@ describe('MixpanelTelemetry', () => {
       // Since consent is false by default, it should be queued
       expect(telemetry['queue'].length).toBe(1);
     });
+  });
+});
+
+describe('MixpanelTelemetry', () => {
+  it('should properly initialize mixpanel client', () => {
+    // Create a mock mixpanel client
+    const mockInitializedClient = { track: vi.fn(), people: { set: vi.fn() } };
+    const mockMixpanelClient = {
+      init: vi.fn().mockReturnValue(mockInitializedClient),
+    };
+
+    // Create telemetry instance with mock client
+    const telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+
+    // Verify init was called
+    expect(mockMixpanelClient.init).toHaveBeenCalled();
+
+    // This will fail because the initialized client isn't being assigned
+    expect(telemetry['mixpanelClient']).toBe(mockInitializedClient);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "outDir": "dist",
     "moduleResolution": "node10",
     "resolveJsonModule": true,
+    "experimentalDecorators": true,
     "paths": {
       "/*": ["./*"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,6 +311,7 @@ __metadata:
     globals: "npm:^15.13.0"
     husky: "npm:^9.1.6"
     lint-staged: "npm:^15.2.10"
+    mixpanel: "npm:^0.18.0"
     node-pty: "npm:^1.0.0"
     prettier: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"
@@ -7242,6 +7243,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"https-proxy-agent@npm:5.0.0":
+  version: 5.0.0
+  resolution: "https-proxy-agent@npm:5.0.0"
+  dependencies:
+    agent-base: "npm:6"
+    debug: "npm:4"
+  checksum: 10c0/670c04f7f0effb5a449c094ea037cbcfb28a5ab93ed22e8c343095202cc7288027869a5a21caf4ee3b8ea06f9624ef1e1fc9044669c0fd92617654ff39f30806
+  languageName: node
+  linkType: hard
+
 "https-proxy-agent@npm:^5.0.0":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
@@ -8961,6 +8972,15 @@ __metadata:
     minipass: "npm:^7.0.4"
     rimraf: "npm:^5.0.5"
   checksum: 10c0/82f8bf70da8af656909a8ee299d7ed3b3372636749d29e105f97f20e88971be31f5ed7642f2e898f00283b68b701cc01307401cdc209b0efc5dd3818220e5093
+  languageName: node
+  linkType: hard
+
+"mixpanel@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "mixpanel@npm:0.18.0"
+  dependencies:
+    https-proxy-agent: "npm:5.0.0"
+  checksum: 10c0/690f9fcf95bcd0d76dc50bb49bcbdcc7ea8be952d53138e28ffea305267fdac4df1f0bc8e59b012a9d3d8597e47c0c74d98c400b75676b3b3a78a53c859991b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Queue up events until we know if user opts in or not
- Store unique id in a file on disk
- expose electron api for tracking events

- [ ] Add pop up for existing users asking if they want to opt in
- [x] Audit full events list

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-617-Draft-Add-optional-usage-metrics-for-installation-onboarding-17b6d73d36508156bce8d82c4a93d0f9) by [Unito](https://www.unito.io)
