### PR TITLE
[Cleanup] Remove unused file env.mjs

### DIFF
--- a/scripts/env.mjs
+++ b/scripts/env.mjs
@@ -1,7 +1,0 @@
-import fs from 'node:fs/promises';
-
-const envContent = `# env vars picked up by the ComfyUI executable on startup
-COMFYUI_CPU_ONLY=true
-`;
-
-await fs.writeFile('ComfyUI/.env', envContent);


### PR DESCRIPTION
`env.mjs` is not referenced anywhere in the project.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-621-Cleanup-Remove-unused-file-env-mjs-17b6d73d365081b38123c6609a7a480c) by [Unito](https://www.unito.io)
