### PR TITLE
[Cleanup] Remove COMFYUI_CPU_ONLY env var

### DIFF
--- a/.github/actions/build/linux/app/action.yml
+++ b/.github/actions/build/linux/app/action.yml
@@ -65,7 +65,6 @@ runs:
         DEBUG: electron-forge:*
         PUBLISH: ${{ inputs.sign-and-publish }}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        COMFYUI_CPU_ONLY: ${{inputs.sign-and-publish != 'true'}}
       run: |
         set -x
         yarn ${{inputs.sign-and-publish == true && 'publish' || 'make'}}

--- a/.github/actions/build/windows/app/action.yml
+++ b/.github/actions/build/windows/app/action.yml
@@ -51,7 +51,6 @@ runs:
         DIGICERT_FINGERPRINT: ${{ inputs.DIGICERT_FINGERPRINT }}
         DEBUG: electron-forge:*
         PUBLISH: ${{ inputs.sign-and-publish }}
-        COMFYUI_CPU_ONLY: ${{inputs.build-gpu == 'cpu'}}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: yarn run make
     - name: Print SignLogs

--- a/.github/workflows/debug_linux.yml
+++ b/.github/workflows/debug_linux.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           build-gpu: 'cpu'
           sign-and-publish: false
-          COMFYUI_CPU_ONLY: true
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Upload Build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/debug_macos.yml
+++ b/.github/workflows/debug_macos.yml
@@ -29,7 +29,6 @@ jobs:
         env:
           PUBLISH: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMFYUI_CPU_ONLY: true
         run: yarn run make
       - name: Upload Build
         uses: actions/upload-artifact@v4

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,11 +99,11 @@ async function startApp() {
 
       // Construct core launch args
       const useDevServer = !app.isPackaged && process.env.DEV_SERVER_URL;
-      const cpuOnly: Record<string, string> = process.env.COMFYUI_CPU_ONLY === 'true' ? { cpu: '' } : {};
-      const extraServerArgs: Record<string, string> = {
-        ...comfyDesktopApp.comfySettings.get('Comfy.Server.LaunchArgs'),
-        ...cpuOnly,
-      };
+      // Shallow-clone the setting launch args to avoid mutation.
+      const extraServerArgs: Record<string, string> = Object.assign(
+        {},
+        comfyDesktopApp.comfySettings.get('Comfy.Server.LaunchArgs')
+      );
       const host = extraServerArgs.listen ?? DEFAULT_SERVER_ARGS.host;
       const targetPort = Number(extraServerArgs.port ?? DEFAULT_SERVER_ARGS.port);
       const port = useDevServer ? targetPort : await findAvailablePort(host, targetPort, targetPort + 1000);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,6 @@ export default defineConfig((env) => {
     ],
     define: {
       VITE_NAME: JSON.stringify('COMFY'),
-      'process.env.COMFYUI_CPU_ONLY': `"${process.env.COMFYUI_CPU_ONLY}"`,
       'process.env.PUBLISH': `"${process.env.PUBLISH}"`,
     },
     resolve: {


### PR DESCRIPTION
https://github.com/Comfy-Org/desktop/pull/468 made device selection decided upon install. This PR removes the build-time device logic on COMFYUI_CPU_ONLY

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-622-Cleanup-Remove-COMFYUI_CPU_ONLY-env-var-17b6d73d365081f99f15d3e3fa110d5d) by [Unito](https://www.unito.io)
