### PR TITLE
Remove mix-panel dependency on types library

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,7 +3,6 @@ import { IPC_CHANNELS, ELECTRON_BRIDGE_API, ProgressStatus, DownloadStatus } fro
 import type { DownloadState } from './models/DownloadManager';
 import path from 'node:path';
 import type { DesktopSettings } from './store/desktopSettings';
-import { PropertyDict } from 'mixpanel';
 
 /**
  * Open a folder in the system's default file explorer.
@@ -284,7 +283,7 @@ const electronAPI = {
     getWindowStyle: (): Promise<DesktopSettings['windowStyle']> => {
       return ipcRenderer.invoke(IPC_CHANNELS.GET_WINDOW_STYLE);
     },
-    trackEvent: (eventName: string, properties?: PropertyDict): void => {
+    trackEvent: (eventName: string, properties?: Record<string, unknown>): void => {
       ipcRenderer.send(IPC_CHANNELS.TRACK_EVENT, eventName, properties);
     },
   },


### PR DESCRIPTION
Inline `PropertyDict` type def to avoid introducing mix-panel dependency for type library.

```
export interface PropertyDict {
  [key: string]: any;
}
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-626-Remove-mix-panel-dependency-on-types-library-17c6d73d365081619421f49b428f734f) by [Unito](https://www.unito.io)
