### PR TITLE
Add increment user property electron API.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,7 @@ export const IPC_CHANNELS = {
   SET_WINDOW_STYLE: 'set-window-style',
   GET_WINDOW_STYLE: 'get-window-style',
   TRACK_EVENT: 'track-event',
+  INCREMENT_USER_PROPERTY: 'increment-user-property',
 } as const;
 
 export enum ProgressStatus {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -283,8 +283,14 @@ const electronAPI = {
     getWindowStyle: (): Promise<DesktopSettings['windowStyle']> => {
       return ipcRenderer.invoke(IPC_CHANNELS.GET_WINDOW_STYLE);
     },
+  },
+  Events: {
     trackEvent: (eventName: string, properties?: Record<string, unknown>): void => {
       ipcRenderer.send(IPC_CHANNELS.TRACK_EVENT, eventName, properties);
+    },
+
+    incrementUserProperty: (propertyName: string, number: number): void => {
+      ipcRenderer.send(IPC_CHANNELS.INCREMENT_USER_PROPERTY, propertyName, number);
     },
   },
   /** Restart the python server without restarting desktop. */

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -106,6 +106,10 @@ export class MixpanelTelemetry {
     ipcMain.on(IPC_CHANNELS.TRACK_EVENT, (event, eventName: string, properties?: PropertyDict) => {
       this.track(eventName, properties);
     });
+
+    ipcMain.on(IPC_CHANNELS.INCREMENT_USER_PROPERTY, (event, propertyName: string, number: number) => {
+      this.mixpanelClient.people.increment(this.distinctId, propertyName, number);
+    });
   }
 
   private async identify(): Promise<void> {

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -21,6 +21,9 @@ vi.mock('mixpanel', () => ({
   default: {
     init: vi.fn(),
     track: vi.fn(),
+    people: {
+      increment: vi.fn(),
+    },
   },
 }));
 
@@ -28,9 +31,9 @@ describe('MixpanelTelemetry', () => {
   let telemetry: MixpanelTelemetry;
   const mockInitializedMixpanelClient = {
     track: vi.fn(),
-    default: {
-      init: vi.fn(),
-      track: vi.fn(),
+    people: {
+      set: vi.fn(),
+      increment: vi.fn(),
     },
   };
   const mockMixpanelClient = {
@@ -125,6 +128,32 @@ describe('MixpanelTelemetry', () => {
 
       // Since consent is false by default, it should be queued
       expect(telemetry['queue'].length).toBe(1);
+    });
+
+    it('should register ipc handler for INCREMENT_USER_PROPERTY', () => {
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      telemetry.registerHandlers();
+
+      expect(ipcMain.on).toHaveBeenCalledWith(IPC_CHANNELS.INCREMENT_USER_PROPERTY, expect.any(Function));
+    });
+
+    it('should handle INCREMENT_USER_PROPERTY messages', () => {
+      telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
+      telemetry.registerHandlers();
+      // Get the callback that was registered
+      const [channel, callback] = (ipcMain.on as any).mock.calls.find(
+        ([channel]: any) => channel === IPC_CHANNELS.INCREMENT_USER_PROPERTY
+      );
+
+      // Simulate IPC call
+      callback({}, 'test_property', 5);
+
+      // Verify mixpanel client was called correctly
+      expect(mockInitializedMixpanelClient.people.increment).toHaveBeenCalledWith(
+        telemetry['distinctId'],
+        'test_property',
+        5
+      );
     });
   });
 });


### PR DESCRIPTION
- if the user property doesn't exist, it will increment from 0
- A negative number will decrement the user property

Can be used to keep a counter belonging to the user.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-630-Add-increment-user-property-electron-API-17d6d73d3650819db901f59438c19653) by [Unito](https://www.unito.io)
