### PR TITLE
Minimise brief flash of white on startup

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -178,7 +178,6 @@ export class AppWindow {
     const { devUrlOverride } = this;
     if (devUrlOverride) {
       const url = `${devUrlOverride}/${urlPath}`;
-      this.rendererReady = true; // TODO: Look into why dev server ready event is not being sent to main process.
       log.info(`Loading development server ${url}`);
       await this.window.loadURL(url);
       this.window.webContents.openDevTools();


### PR DESCRIPTION
- Reduces the time the flash of white is displayed on startup.
  https://www.electronjs.org/docs/latest/api/browser-window/#using-the-ready-to-show-event
- Fixes dev regression - dev tools opens when loading in dev mode

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-645-Minimise-brief-flash-of-white-on-startup-17d6d73d3650810a959debaf2cd584c1) by [Unito](https://www.unito.io)
