### PR TITLE
Revert workaround removal for dev server

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -178,6 +178,7 @@ export class AppWindow {
     const { devUrlOverride } = this;
     if (devUrlOverride) {
       const url = `${devUrlOverride}/${urlPath}`;
+      this.rendererReady = true; // TODO: Look into why dev server ready event is not being sent to main process.
       log.info(`Loading development server ${url}`);
       await this.window.loadURL(url);
       this.window.webContents.openDevTools();

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -178,7 +178,13 @@ export class AppWindow {
     const { devUrlOverride } = this;
     if (devUrlOverride) {
       const url = `${devUrlOverride}/${urlPath}`;
-      this.rendererReady = true; // TODO: Look into why dev server ready event is not being sent to main process.
+      /**
+       * rendererReady should be set by the frontend via electronAPI. However,
+       * for some reason, the event is not being received if we load the app
+       * from the external server.
+       * TODO: Look into why dev server ready event is not being received.
+       */
+      this.rendererReady = true;
       log.info(`Loading development server ${url}`);
       await this.window.loadURL(url);
       this.window.webContents.openDevTools();


### PR DESCRIPTION
The line of code was accidentally removed in #600. This PR adds it back.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-649-Revert-workaround-removal-for-dev-server-17d6d73d3650814ea444dbef3db9e546) by [Unito](https://www.unito.io)
