### PR TITLE
Fix regression: uv termianl cannot be restarted

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -119,7 +119,10 @@ export class VirtualEnvironment implements HasTelemetry {
       await this.createEnvironment(callbacks);
     } finally {
       const pid = this.uvPty?.pid;
-      if (pid) process.kill(pid);
+      if (pid) {
+        process.kill(pid);
+        this.uvPty = undefined;
+      }
     }
   }
 

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -259,7 +259,7 @@ export class VirtualEnvironment implements HasTelemetry {
    * @param args
    * @returns
    */
-  public async runUvCommandAsync(args: string[], callbacks?: ProcessCallbacks): Promise<{ exitCode: number | null }> {
+  private async runUvCommandAsync(args: string[], callbacks?: ProcessCallbacks): Promise<{ exitCode: number | null }> {
     const uvCommand = os.platform() === 'win32' ? `& "${this.uvPath}"` : this.uvPath;
     log.info(`Running uv command: ${uvCommand} ${args.join(' ')}`);
     return this.runPtyCommandAsync(`${uvCommand} ${args.map((a) => `"${a}"`).join(' ')}`, callbacks?.onStdout);

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -34,6 +34,7 @@ export class VirtualEnvironment implements HasTelemetry {
   readonly selectedDevice?: string;
   uvPty: pty.IPty | undefined;
 
+  /** @todo Refactor to `using` */
   get uvPtyInstance() {
     if (!this.uvPty) {
       const shell = getDefaultShell();


### PR DESCRIPTION
Issue has no impact on prod, but is a regression.

This is a pre-requisite for validation, which can start and terminate a host shell process multiple times.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-650-Fix-regression-uv-termianl-cannot-be-restarted-17d6d73d3650812dad00ec88dea90f48) by [Unito](https://www.unito.io)
