### PR TITLE
Fix PowerShell terminal output alignment

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -288,9 +288,7 @@ export class VirtualEnvironment implements HasTelemetry {
               }
             }
             dataReader.dispose();
-            res({
-              exitCode,
-            });
+            res({ exitCode });
             break;
           }
         }

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -265,7 +265,7 @@ export class VirtualEnvironment implements HasTelemetry {
     const id = Date.now();
     return new Promise((res) => {
       const endMarker = `_-end-${id}:`;
-      const input = `clear${EOL}${command}${EOL}echo "${endMarker}$?"`;
+      const input = `${command}\recho "${endMarker}$?"`;
       const dataReader = this.uvPtyInstance.onData((data) => {
         const lines = data.split(/(\r\n|\n)/);
         for (const line of lines) {
@@ -296,7 +296,7 @@ export class VirtualEnvironment implements HasTelemetry {
         }
         onData?.(data);
       });
-      this.uvPtyInstance.write(`${input}${EOL}`);
+      this.uvPtyInstance.write(`${input}\r`);
     });
   }
 

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -267,12 +267,11 @@ export class VirtualEnvironment implements HasTelemetry {
       const endMarker = `_-end-${id}:`;
       const input = `${command}\recho "${endMarker}$?"`;
       const dataReader = this.uvPtyInstance.onData((data) => {
-        const lines = data.split(/(\r\n|\n)/);
+        // Remove ansi sequences to see if this the exit marker
+        const lines = data.replaceAll(/\u001B\[[\d;?]*[A-Za-z]/g, '').split(/(\r\n|\n)/);
         for (const line of lines) {
-          // Remove ansi sequences to see if this the exit marker
-          const clean = line.replaceAll(/\u001B\[[\d;?]*[A-Za-z]/g, '');
-          if (clean.startsWith(endMarker)) {
-            const exit = clean.substring(endMarker.length).trim();
+          if (line.startsWith(endMarker)) {
+            const exit = line.substring(endMarker.length).trim();
             let exitCode: number;
             // Powershell outputs True / False for success
             if (exit === 'True') {


### PR DESCRIPTION
EOL is causing cursor placement / minor line overlap issues.

Examples use `\r`:
https://github.com/microsoft/node-pty#example-usage

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-651-Fix-PowerShell-terminal-output-alignment-17d6d73d3650811fa324e8a511b43a6b) by [Unito](https://www.unito.io)
