### PR TITLE
[Refactor] Move venv as child of installation (SoC)

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -115,7 +115,7 @@ export class InstallationManager {
       useDesktopConfig().set('migrateCustomNodesFrom', installWizard.migrationSource);
     }
 
-    const installation = new ComfyInstallation('installed', installWizard.basePath);
+    const installation = new ComfyInstallation('installed', installWizard.basePath, device);
     installation.setState('installed');
     return installation;
   }

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -157,10 +157,6 @@ export class ComfyDesktopApp implements HasTelemetry {
 
     this.appWindow.sendServerStartProgress(ProgressStatus.PYTHON_SETUP);
 
-    const config = useDesktopConfig();
-    const selectedDevice = config.get('selectedDevice');
-    const virtualEnvironment = new VirtualEnvironment(this.basePath, this.telemetry, selectedDevice);
-
     const processCallbacks: ProcessCallbacks = {
       onStdout: (data) => {
         log.info(data.replaceAll(ansiCodes, ''));
@@ -171,8 +167,10 @@ export class ComfyDesktopApp implements HasTelemetry {
         this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
       },
     };
+    const { virtualEnvironment } = this.installation;
     await virtualEnvironment.create(processCallbacks);
 
+    const config = useDesktopConfig();
     const customNodeMigrationError = await this.migrateCustomNodes(config, virtualEnvironment, processCallbacks);
 
     this.appWindow.sendServerStartProgress(ProgressStatus.STARTING_SERVER);


### PR DESCRIPTION
Resolves separation of concerns issue: `VirtualEnvironment` is now a property of `ComfyInstallation`, rather than being created immediately prior to server startup.

NB: The venv object is re-instantiated in the `ComfyInstallation.basePath` setter.  If this is cause for concern, setting of basePath can be refactored to an explicit method.  Plan to refactor this into a cleaner configuration once the app restrucuring nears completeion.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-654-Refactor-Move-venv-as-child-of-installation-SoC-17e6d73d365081a594a2d6c9f63ca736) by [Unito](https://www.unito.io)
