### PR TITLE
Add base path management API

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const IPC_CHANNELS = {
   GET_ALL_DOWNLOADS: 'get-all-downloads',
   GET_ELECTRON_VERSION: 'get-electron-version',
   GET_BASE_PATH: 'get-base-path',
+  SET_BASE_PATH: 'set-base-path',
   GET_MODEL_CONFIG_PATH: 'get-model-config-path',
   OPEN_PATH: 'open-path',
   OPEN_LOGS_PATH: 'open-logs-path',

--- a/src/handlers/appInfoHandlers.ts
+++ b/src/handlers/appInfoHandlers.ts
@@ -24,10 +24,6 @@ export class AppInfoHandlers {
       return useDesktopConfig().get('basePath');
     });
 
-    ipcMain.handle(IPC_CHANNELS.GET_BASE_PATH, (): string | undefined => {
-      return useDesktopConfig().get('basePath');
-    });
-
     ipcMain.handle(IPC_CHANNELS.SET_BASE_PATH, async (): Promise<boolean> => {
       const currentBasePath = useDesktopConfig().get('basePath');
 

--- a/src/handlers/appInfoHandlers.ts
+++ b/src/handlers/appInfoHandlers.ts
@@ -1,6 +1,7 @@
 import { app, ipcMain } from 'electron';
 
 import { IPC_CHANNELS } from '../constants';
+import type { AppWindow } from '../main-process/appWindow';
 import type { TorchDeviceType } from '../preload';
 import { useDesktopConfig } from '../store/desktopConfig';
 import type { DesktopSettings } from '../store/desktopSettings';
@@ -16,6 +17,10 @@ export class AppInfoHandlers {
 
     ipcMain.handle(IPC_CHANNELS.GET_ELECTRON_VERSION, () => {
       return app.getVersion();
+    });
+
+    ipcMain.handle(IPC_CHANNELS.GET_BASE_PATH, (): string | undefined => {
+      return useDesktopConfig().get('basePath');
     });
 
     // Config

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -119,9 +119,6 @@ export class ComfyDesktopApp implements HasTelemetry {
         }
       }
     );
-    ipcMain.handle(IPC_CHANNELS.GET_BASE_PATH, (): string => {
-      return this.basePath;
-    });
     ipcMain.handle(IPC_CHANNELS.IS_FIRST_TIME_SETUP, () => {
       return !ComfyServerConfig.exists();
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ async function startApp() {
 
     // Register basic handlers that are necessary during app's installation.
     new PathHandlers().registerHandlers();
-    new AppInfoHandlers().registerHandlers();
+    new AppInfoHandlers().registerHandlers(appWindow);
     ipcMain.handle(IPC_CHANNELS.OPEN_DIALOG, (event, options: Electron.OpenDialogOptions) => {
       log.debug('Open dialog');
       return dialog.showOpenDialogSync({

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -126,6 +126,12 @@ const electronAPI = {
   getBasePath: (): Promise<string> => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_BASE_PATH);
   },
+  /**
+   * Opens a directory picker, saves the result as the base path if not cancelled.
+   * @returns `true` if a new base path was selected and set successfully, otherwise `false`
+   */
+  setBasePath: (): Promise<boolean> => ipcRenderer.invoke(IPC_CHANNELS.SET_BASE_PATH),
+
   getModelConfigPath: (): Promise<string> => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_MODEL_CONFIG_PATH);
   },

--- a/tests/unit/handlers/appinfoHandlers.test.ts
+++ b/tests/unit/handlers/appinfoHandlers.test.ts
@@ -15,7 +15,7 @@ describe('AppInfoHandlers', () => {
   let handler: AppInfoHandlers;
   beforeEach(() => {
     handler = new AppInfoHandlers();
-    handler.registerHandlers();
+    handler.registerHandlers(null!);
   });
 
   it('should register all expected handle channels', () => {


### PR DESCRIPTION
- Move the get base path to app info handler to make it available during the entire app lifecycle
  - Previously required that ComfyDesktopApp was instantiated.
- Add set base path, allowing change of the application path via API
  - Frontend impl. will be added as part of startup validation

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-657-Add-base-path-management-API-17e6d73d3650810385c4f5b441fbbef0) by [Unito](https://www.unito.io)
