### PR TITLE
Show basic loading screen on app start

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,7 @@ async function startApp() {
       app.quit();
     });
 
-    // Load start screen - basic progress bar, no updates
+    // Load start screen - basic spinner
     try {
       await appWindow.loadRenderer('desktop-start');
     } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,14 @@ async function startApp() {
       app.quit();
     });
 
+    // Load start screen - basic progress bar, no updates
+    try {
+      await appWindow.loadRenderer('desktop-start');
+    } catch (error) {
+      dialog.showErrorBox('Startup failed', `Unknown error whilst loading start screen.\n\n${error}`);
+      return app.quit();
+    }
+
     // Register basic handlers that are necessary during app's installation.
     new PathHandlers().registerHandlers();
     new AppInfoHandlers().registerHandlers();


### PR DESCRIPTION
### Desktop loading screen

- Requires https://github.com/Comfy-Org/ComfyUI_frontend/pull/2274
- Loads a basic static page with an indeterminate progress bar
- Reduces total time spent being tortured by Chromium's ludicrously bright pre-load window background

![image](https://github.com/user-attachments/assets/d7273f29-0d8a-413b-85c4-051da5e74fb4)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-660-Show-basic-loading-screen-on-app-start-17e6d73d365081a59fc5cfdad3eb3ca5) by [Unito](https://www.unito.io)
