### PR TITLE
Add app quit API to allow a frontend quit keybind

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const IPC_CHANNELS = {
   RENDERER_READY: 'renderer-ready',
   RESTART_APP: 'restart-app',
   REINSTALL: 'reinstall',
+  QUIT: 'quit',
   LOG_MESSAGE: 'log-message',
   OPEN_DIALOG: 'open-dialog',
   DOWNLOAD_PROGRESS: 'download-progress',

--- a/src/handlers/AppHandlers.ts
+++ b/src/handlers/AppHandlers.ts
@@ -1,9 +1,13 @@
 import { app, ipcMain } from 'electron';
+import log from 'electron-log/main';
 
 import { IPC_CHANNELS } from '../constants';
 
 export class AppHandlers {
   registerHandlers() {
-    ipcMain.handle(IPC_CHANNELS.QUIT, () => app.quit());
+    ipcMain.handle(IPC_CHANNELS.QUIT, () => {
+      log.info('Received quit IPC request. Quitting app...');
+      app.quit();
+    });
   }
 }

--- a/src/handlers/AppHandlers.ts
+++ b/src/handlers/AppHandlers.ts
@@ -1,0 +1,9 @@
+import { app, ipcMain } from 'electron';
+
+import { IPC_CHANNELS } from '../constants';
+
+export class AppHandlers {
+  registerHandlers() {
+    ipcMain.handle(IPC_CHANNELS.QUIT, () => app.quit());
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { LevelOption } from 'electron-log';
 import log from 'electron-log/main';
 
 import { DEFAULT_SERVER_ARGS, IPC_CHANNELS, ProgressStatus } from './constants';
+import { AppHandlers } from './handlers/AppHandlers';
 import { AppInfoHandlers } from './handlers/appInfoHandlers';
 import { PathHandlers } from './handlers/pathHandlers';
 import { InstallationManager } from './install/installationManager';
@@ -95,6 +96,7 @@ async function startApp() {
     // Register basic handlers that are necessary during app's installation.
     new PathHandlers().registerHandlers();
     new AppInfoHandlers().registerHandlers(appWindow);
+    new AppHandlers().registerHandlers();
     ipcMain.handle(IPC_CHANNELS.OPEN_DIALOG, (event, options: Electron.OpenDialogOptions) => {
       log.debug('Open dialog');
       return dialog.showOpenDialogSync({

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -130,6 +130,8 @@ const electronAPI = {
     console.log('Sending restarting app message to main process with custom message:', customMessage);
     ipcRenderer.send(IPC_CHANNELS.RESTART_APP, { customMessage, delay });
   },
+  /** Exits the application gracefully. */
+  quit: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.QUIT),
   /** @todo Move to {@link electronAPI.Validation} */
   reinstall: (): Promise<void> => {
     return ipcRenderer.invoke(IPC_CHANNELS.REINSTALL);


### PR DESCRIPTION
Add app quit API to allow a frontend quit keybind

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-667-Add-app-quit-API-to-allow-a-frontend-quit-keybind-17f6d73d36508198b7d6d2f6226d963a) by [Unito](https://www.unito.io)
