### PR TITLE
Write metrics consent change to comfy settings file

### DIFF
--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import waitOn from 'wait-on';
 
 import { ComfyServerConfig } from '../config/comfyServerConfig';
+import { ComfySettings } from '../config/comfySettings';
 import { IPC_CHANNELS, ServerArgs } from '../constants';
 import { getAppResourcesPath } from '../install/resourcePaths';
 import { HasTelemetry, ITelemetry, trackEvent } from '../services/telemetry';
@@ -101,6 +102,7 @@ export class ComfyServer implements HasTelemetry {
 
   @trackEvent('comfyui:server_start')
   async start() {
+    ComfySettings.lockWrites();
     await rotateLogFiles(app.getPath('logs'), 'comfyui', 50);
     return new Promise<void>((resolve, reject) => {
       const comfyUILog = log.create({ logId: 'comfyui' });

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,8 +120,6 @@ async function startApp() {
       const allowMetrics = await promptMetricsConsent(store, appWindow, comfyDesktopApp);
       telemetry.hasConsent = allowMetrics;
       if (allowMetrics) telemetry.flush();
-      comfyDesktopApp.comfySettings.set('Comfy-Desktop.SendStatistics', allowMetrics);
-      await comfyDesktopApp.comfySettings.saveSettings();
 
       // Construct core launch args
       const useExternalServer = devOverride('USE_EXTERNAL_SERVER') === 'true';

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,8 @@ async function startApp() {
       const allowMetrics = await promptMetricsConsent(store, appWindow, comfyDesktopApp);
       telemetry.hasConsent = allowMetrics;
       if (allowMetrics) telemetry.flush();
+      comfyDesktopApp.comfySettings.set('Comfy-Desktop.SendStatistics', allowMetrics);
+      await comfyDesktopApp.comfySettings.saveSettings();
 
       // Construct core launch args
       const useExternalServer = devOverride('USE_EXTERNAL_SERVER') === 'true';

--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -30,7 +30,7 @@ describe('ComfySettings', () => {
     vi.clearAllMocks();
   });
 
-  describe('Write locking', () => {
+  describe('write locking', () => {
     it('should allow writes before being locked', async () => {
       await settings.saveSettings();
       expect(vi.mocked(fs).writeFile).toHaveBeenCalled();
@@ -62,16 +62,15 @@ describe('ComfySettings', () => {
       expect(() => settings2.set('Comfy-Desktop.AutoUpdate', false)).toThrow('Settings are locked');
     });
 
-    it('should log error when attempting to save while locked', async () => {
+    it('should log error when saving locked settings', async () => {
       ComfySettings.lockWrites();
-      await expect(settings.saveSettings()).rejects.toThrow();
+      await expect(settings.saveSettings()).rejects.toThrow('Settings are locked');
       const log = await import('electron-log/main');
-      await expect(settings.saveSettings()).rejects.toThrow();
       expect(vi.mocked(log.default.error)).toHaveBeenCalled();
     });
   });
 
-  describe('File operations', () => {
+  describe('file operations', () => {
     it('should use correct file path', () => {
       expect(settings.filePath).toBe(path.join(testBasePath, 'user', 'default', 'comfy.settings.json'));
     });

--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ComfySettings, type ComfySettingsData } from '../../src/config/comfySettings';
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    access: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+}));
+
+describe('ComfySettings', () => {
+  let settings: ComfySettings;
+  const testBasePath = '/test/path';
+
+  beforeEach(() => {
+    settings = new ComfySettings(testBasePath);
+    // Reset static state between tests
+    ComfySettings['writeLocked'] = false;
+    vi.clearAllMocks();
+  });
+
+  describe('Write locking', () => {
+    it('should allow writes before being locked', async () => {
+      await settings.saveSettings();
+      expect(vi.mocked(fs).writeFile).toHaveBeenCalled();
+    });
+
+    it('should prevent writes after being locked', async () => {
+      ComfySettings.lockWrites();
+      await expect(settings.saveSettings()).rejects.toThrow('Settings are locked');
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should prevent modifications after being locked', () => {
+      ComfySettings.lockWrites();
+      expect(() => settings.set('Comfy-Desktop.AutoUpdate', false)).toThrow('Settings are locked');
+    });
+
+    it('should allow reads after being locked', () => {
+      ComfySettings.lockWrites();
+      expect(() => settings.get('Comfy-Desktop.AutoUpdate')).not.toThrow();
+    });
+
+    it('should share lock state across instances', () => {
+      const settings1 = new ComfySettings('/path1');
+      const settings2 = new ComfySettings('/path2');
+
+      ComfySettings.lockWrites();
+
+      expect(() => settings1.set('Comfy-Desktop.AutoUpdate', false)).toThrow('Settings are locked');
+      expect(() => settings2.set('Comfy-Desktop.AutoUpdate', false)).toThrow('Settings are locked');
+    });
+  });
+
+  describe('File operations', () => {
+    it('should use correct file path', () => {
+      expect(settings.filePath).toBe(path.join(testBasePath, 'user', 'default', 'comfy.settings.json'));
+    });
+
+    it('should load settings from file when available', async () => {
+      const mockSettings: ComfySettingsData = {
+        'Comfy-Desktop.AutoUpdate': false,
+        'Comfy-Desktop.SendStatistics': false,
+        'Comfy.Server.LaunchArgs': { test: 'value' },
+      };
+
+      vi.mocked(fs.access).mockResolvedValue();
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockSettings));
+
+      await settings.loadSettings();
+      expect(settings.get('Comfy-Desktop.AutoUpdate')).toBe(false);
+      expect(settings.get('Comfy.Server.LaunchArgs')).toEqual({ test: 'value' });
+      expect(settings.get('Comfy-Desktop.SendStatistics')).toBe(false);
+    });
+
+    it('should use default settings when file does not exist', async () => {
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+
+      await settings.loadSettings();
+      expect(settings.get('Comfy-Desktop.AutoUpdate')).toBe(true);
+      expect(settings.get('Comfy-Desktop.SendStatistics')).toBe(true);
+    });
+  });
+});

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -191,7 +191,7 @@ describe('MixpanelTelemetry', () => {
 describe('promptMetricsConsent', () => {
   let store: { get: Mock; set: Mock };
   let appWindow: { loadRenderer: Mock };
-  let comfyDesktopApp: { comfySettings: { get: Mock } };
+  let comfyDesktopApp: { comfySettings: { get: Mock; set: Mock; saveSettings: Mock } };
 
   const versionBeforeUpdate = '0.4.1';
   const versionAfterUpdate = '1.0.1';
@@ -200,7 +200,7 @@ describe('promptMetricsConsent', () => {
     vi.clearAllMocks();
     store = { get: vi.fn(), set: vi.fn() };
     appWindow = { loadRenderer: vi.fn() };
-    comfyDesktopApp = { comfySettings: { get: vi.fn() } };
+    comfyDesktopApp = { comfySettings: { get: vi.fn(), set: vi.fn(), saveSettings: vi.fn() } };
   });
 
   const runTest = async ({


### PR DESCRIPTION
If metrics consent changes during pre-startup prompt process, write associated setting to comfy settings file, as the server will not have started yet. 

Adds `set` and `saveSettings` methods to `ComfySettings`, which are locked after the server starts.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-669-Write-metrics-consent-change-to-comfy-settings-file-1806d73d365081f298afd846641b9a70) by [Unito](https://www.unito.io)
