### PR TITLE
[Dev] Build preload project before yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "publish:staging": "yarn run vite:compile && todesktop build --config=./todesktop.staging.json --async",
     "reset-install": "node scripts/resetInstall.js",
     "sign": "node debug/sign.js",
-    "start": "vite build --watch",
+    "start": "vite build --config vite.preload.config.ts && vite build --watch",
     "test:e2e": "npx playwright test",
     "test:unit": "vitest run",
     "test:update-snapshots": "npx playwright test --update-snapshots",


### PR DESCRIPTION
Ensures the preload script is up to date when `yarn start`ing.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-673-Dev-Build-preload-project-before-yarn-start-1816d73d365081b2bad3f06ff585079e) by [Unito](https://www.unito.io)
