### PR TITLE
[Test] Add ComfyServerConfig unit tests

### DIFF
--- a/tests/assets/extra_models_paths/legacy-format.yaml
+++ b/tests/assets/extra_models_paths/legacy-format.yaml
@@ -1,5 +1,5 @@
 # Legacy format with root 'comfyui' key
 comfyui:
-  base_path: "/old/style/path"
-  checkpoints: "/old/style/path/models/checkpoints/"
-  custom_nodes: "/old/style/path/custom_nodes/" 
+  base_path: /old/style/path
+  checkpoints: /old/style/path/models/checkpoints/
+  custom_nodes: /old/style/path/custom_nodes/

--- a/tests/assets/extra_models_paths/legacy-format.yaml
+++ b/tests/assets/extra_models_paths/legacy-format.yaml
@@ -1,0 +1,5 @@
+# Legacy format with root 'comfyui' key
+comfyui:
+  base_path: "/old/style/path"
+  checkpoints: "/old/style/path/models/checkpoints/"
+  custom_nodes: "/old/style/path/custom_nodes/" 

--- a/tests/assets/extra_models_paths/malformed.yaml
+++ b/tests/assets/extra_models_paths/malformed.yaml
@@ -1,0 +1,4 @@
+comfyui_desktop:
+  base_path: 
+    - this is malformed
+  - incorrect indentation 

--- a/tests/assets/extra_models_paths/missing-base-path.yaml
+++ b/tests/assets/extra_models_paths/missing-base-path.yaml
@@ -1,0 +1,3 @@
+comfyui_desktop:
+  checkpoints: models/checkpoints/
+  loras: models/loras/ 

--- a/tests/assets/extra_models_paths/multiple-sections.yaml
+++ b/tests/assets/extra_models_paths/multiple-sections.yaml
@@ -1,0 +1,12 @@
+# Config with multiple sections and edge cases
+comfyui_desktop:
+  base_path: "/primary/path"
+  checkpoints: "/primary/path/models/checkpoints/"
+  empty_path: ""
+  null_path: null
+comfyui_migration:
+  base_path: "/migration/path"
+  models: "/migration/path/models/"
+unknown_section:
+  some_key: "some_value"
+  another_key: 123 

--- a/tests/assets/extra_models_paths/multiple-sections.yaml
+++ b/tests/assets/extra_models_paths/multiple-sections.yaml
@@ -1,12 +1,12 @@
 # Config with multiple sections and edge cases
 comfyui_desktop:
-  base_path: "/primary/path"
-  checkpoints: "/primary/path/models/checkpoints/"
+  base_path: /primary/path
+  checkpoints: /primary/path/models/checkpoints/
   empty_path: ""
   null_path: null
 comfyui_migration:
-  base_path: "/migration/path"
-  models: "/migration/path/models/"
+  base_path: /migration/path
+  models: /migration/path/models/
 unknown_section:
-  some_key: "some_value"
+  some_key: some_value
   another_key: 123 

--- a/tests/assets/extra_models_paths/valid-config.yaml
+++ b/tests/assets/extra_models_paths/valid-config.yaml
@@ -1,0 +1,8 @@
+# Test ComfyUI config
+comfyui_desktop:
+  base_path: /test/path
+  checkpoints: /test/path/models/checkpoints/
+  loras: /test/path/models/loras/
+comfyui_migration:
+  base_path: /other/path
+  models: /other/path/models/ 

--- a/tests/assets/extra_models_paths/wrong-type.yaml
+++ b/tests/assets/extra_models_paths/wrong-type.yaml
@@ -1,0 +1,2 @@
+comfyui_desktop:
+  base_path: [/path1, /path2]

--- a/tests/unit/comfyServerConfig.test.ts
+++ b/tests/unit/comfyServerConfig.test.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -16,6 +16,7 @@ vi.mock('electron', () => ({
 vi.mock('electron-log/main', () => ({
   default: {
     info: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn(),
   },
 }));
@@ -23,6 +24,11 @@ vi.mock('electron-log/main', () => ({
 async function createTmpDir() {
   const prefix = path.join(tmpdir(), 'vitest-');
   return await mkdtemp(prefix);
+}
+
+async function copyFixture(fixturePath: string, targetPath: string) {
+  const content = await readFile(path.join('tests/assets/extra_models_paths', fixturePath), 'utf8');
+  await writeFile(targetPath, content, 'utf8');
 }
 
 describe('ComfyServerConfig', () => {
@@ -55,16 +61,6 @@ describe('ComfyServerConfig', () => {
     beforeAll(async () => {
       tmpdir = await createTmpDir();
       testConfigPath = path.join(tmpdir, 'test_config.yaml');
-
-      // Create a test YAML file
-      const testConfig = `# Test ComfyUI config
-comfyui:
-  base_path: ~/test/comfyui
-  is_default: true
-  checkpoints: models/checkpoints/
-  loras: models/loras/`;
-
-      await writeFile(testConfigPath, testConfig, 'utf8');
     });
 
     afterAll(async () => {
@@ -72,9 +68,10 @@ comfyui:
     });
 
     it('should read base_path from valid config file', async () => {
+      await copyFixture('valid-config.yaml', testConfigPath);
       const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
       expect(result.status).toBe('success');
-      expect(result.path).toBe('~/test/comfyui');
+      expect(result.path).toBe('/test/path');
     });
 
     it('should detect non-existent file', async () => {
@@ -83,15 +80,185 @@ comfyui:
       expect(result.path).toBeUndefined();
     });
 
-    it('should detect invalid config file', async () => {
-      const invalidConfigPath = path.join(tmpdir, 'invalid_config.yaml');
-      await writeFile(invalidConfigPath, 'invalid: yaml: content:', 'utf8');
-
-      const result = await ComfyServerConfig.readBasePathFromConfig(invalidConfigPath);
+    it('should handle missing base path', async () => {
+      await copyFixture('missing-base-path.yaml', testConfigPath);
+      const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
       expect(result.status).toBe('invalid');
       expect(result.path).toBeUndefined();
+    });
 
-      await rm(invalidConfigPath);
+    it('should handle wrong base path type', async () => {
+      await copyFixture('wrong-type.yaml', testConfigPath);
+      const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
+      expect(result.status).toBe('invalid');
+      expect(result.path).toBeDefined();
+    });
+
+    it('should handle malformed YAML', async () => {
+      await copyFixture('malformed.yaml', testConfigPath);
+      const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
+      expect(result.status).toBe('invalid');
+      expect(result.path).toBeUndefined();
+    });
+  });
+
+  describe('generateConfigFileContent', () => {
+    const originalPlatform = process.platform;
+
+    afterAll(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('should generate valid YAML with model paths', () => {
+      const testConfig = {
+        comfyui_desktop: {
+          base_path: '/test/path',
+          checkpoints: '/test/path/models/checkpoints/',
+          loras: '/test/path/models/loras/',
+        },
+      };
+
+      const result = ComfyServerConfig.generateConfigFileContent(testConfig);
+
+      expect(result).toContain(`# ComfyUI extra_model_paths.yaml for ${process.platform}`);
+      expect(result).toContain('comfyui_desktop:');
+      expect(result).toContain('  base_path: /test/path');
+      expect(result).toContain('  checkpoints: /test/path/models/checkpoints/');
+      expect(result).toContain('  loras: /test/path/models/loras/');
+    });
+
+    it.each(['win32', 'darwin', 'linux'] as const)('should include platform-specific header for %s', (platform) => {
+      Object.defineProperty(process, 'platform', { value: platform });
+      const testConfig = { test: { path: '/test' } };
+      const result = ComfyServerConfig.generateConfigFileContent(testConfig);
+      expect(result).toContain(`# ComfyUI extra_model_paths.yaml for ${platform}`);
+    });
+
+    it('should handle empty configs', () => {
+      const result = ComfyServerConfig.generateConfigFileContent({});
+      expect(result).toContain(`# ComfyUI extra_model_paths.yaml for ${process.platform}`);
+      // The rest should just be an empty object
+      expect(result.split('\n')[1]).toBe('{}');
+    });
+  });
+
+  describe('getBaseModelPathsFromRepoPath', () => {
+    it('should generate correct paths for all known model types', () => {
+      const repoPath = '/test/repo';
+      const result = ComfyServerConfig.getBaseModelPathsFromRepoPath(repoPath);
+
+      expect(result.checkpoints).toBe(path.join(repoPath, 'models', 'checkpoints') + path.sep);
+      expect(result.loras).toBe(path.join(repoPath, 'models', 'loras') + path.sep);
+      expect(result.vae).toBe(path.join(repoPath, 'models', 'vae') + path.sep);
+      expect(result.controlnet).toBe(path.join(repoPath, 'models', 'controlnet') + path.sep);
+
+      for (const modelPath of Object.values(result)) {
+        expect(modelPath).toContain(path.join(repoPath, 'models'));
+        expect(modelPath.endsWith(path.sep)).toBe(true);
+      }
+    });
+
+    it('should handle empty repo path', () => {
+      const result = ComfyServerConfig.getBaseModelPathsFromRepoPath('');
+
+      // Paths should be relative to models directory
+      expect(result.checkpoints).toBe(path.join('models', 'checkpoints') + path.sep);
+      expect(result.loras).toBe(path.join('models', 'loras') + path.sep);
+    });
+  });
+
+  describe('getBaseConfig', () => {
+    const originalPlatform = process.platform;
+
+    afterAll(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it.each([
+      {
+        platform: 'win32',
+      },
+      {
+        platform: 'darwin',
+      },
+      {
+        platform: 'linux',
+      },
+    ])('should return platform-specific config for $platform', ({ platform }) => {
+      Object.defineProperty(process, 'platform', { value: platform });
+      const result = ComfyServerConfig.getBaseConfig();
+
+      // All platforms should have these common paths
+      expect(result.checkpoints).toContain('models/checkpoints');
+      expect(result.loras).toContain('models/loras');
+      expect(result.custom_nodes).toBe('custom_nodes/');
+      expect(result.is_default).toBe('true');
+    });
+
+    it('should throw for unknown platforms', () => {
+      Object.defineProperty(process, 'platform', { value: 'invalid' });
+      expect(() => ComfyServerConfig.getBaseConfig()).toThrow('No base config found for invalid');
+    });
+  });
+
+  describe('readConfigFile', () => {
+    let tmpdir = '';
+    const originalPlatform = process.platform;
+
+    beforeAll(async () => {
+      tmpdir = await createTmpDir();
+    });
+
+    afterAll(async () => {
+      await rm(tmpdir, { recursive: true });
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('should handle missing files', async () => {
+      const result = await ComfyServerConfig.readConfigFile('/non/existent/path.yaml');
+      expect(result).toBeNull();
+    });
+
+    it('should handle invalid YAML', async () => {
+      const configPath = path.join(tmpdir, 'invalid_config.yaml');
+      await copyFixture('malformed.yaml', configPath);
+      const result = await ComfyServerConfig.readConfigFile(configPath);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('readConfigFile edge cases', () => {
+    let tmpdir = '';
+    const originalPlatform = process.platform;
+    const originalEnv = process.env;
+
+    beforeAll(async () => {
+      tmpdir = await createTmpDir();
+    });
+
+    afterAll(async () => {
+      await rm(tmpdir, { recursive: true });
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+      process.env = originalEnv;
+    });
+
+    it('should handle legacy format config', async () => {
+      const configPath = path.join(tmpdir, 'legacy-format.yaml');
+      await copyFixture('legacy-format.yaml', configPath);
+      const result = await ComfyServerConfig.readBasePathFromConfig(configPath);
+
+      expect(result.status).toBe('success');
+      expect(result.path).toBe('/old/style/path');
+    });
+
+    it('should handle multiple sections and special values', async () => {
+      const configPath = path.join(tmpdir, 'multiple-sections.yaml');
+      await copyFixture('multiple-sections.yaml', configPath);
+      const result = await ComfyServerConfig.readConfigFile(configPath);
+
+      expect(result).not.toBeNull();
+      expect(result!.comfyui_desktop.base_path).toBe('/primary/path');
+      expect(result!.comfyui_migration.base_path).toBe('/migration/path');
     });
   });
 });

--- a/tests/unit/comfyServerConfig.test.ts
+++ b/tests/unit/comfyServerConfig.test.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { ComfyServerConfig } from '../../src/config/comfyServerConfig';
 
@@ -32,6 +32,10 @@ async function copyFixture(fixturePath: string, targetPath: string) {
 }
 
 describe('ComfyServerConfig', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('configPath', () => {
     it('should return the correct path', () => {
       // Mock the userData path
@@ -44,10 +48,10 @@ describe('ComfyServerConfig', () => {
       });
 
       // Access the static property
-      const result = ComfyServerConfig.configPath;
+      const configPath = ComfyServerConfig.configPath;
 
       // Verify the path is correctly joined
-      expect(result).toBe(path.join(mockUserDataPath, 'extra_models_config.yaml'));
+      expect(configPath).toBe(path.join(mockUserDataPath, 'extra_models_config.yaml'));
 
       // Verify app.getPath was called with correct argument
       expect(app.getPath).toHaveBeenCalledWith('userData');
@@ -55,50 +59,50 @@ describe('ComfyServerConfig', () => {
   });
 
   describe('readBasePathFromConfig', () => {
-    let tmpdir = '';
+    let tempDir = '';
     let testConfigPath = '';
 
     beforeAll(async () => {
-      tmpdir = await createTmpDir();
-      testConfigPath = path.join(tmpdir, 'test_config.yaml');
+      tempDir = await createTmpDir();
+      testConfigPath = path.join(tempDir, 'test_config.yaml');
     });
 
     afterAll(async () => {
-      await rm(tmpdir, { recursive: true });
+      await rm(tempDir, { recursive: true });
     });
 
     it('should read base_path from valid config file', async () => {
       await copyFixture('valid-config.yaml', testConfigPath);
-      const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
-      expect(result.status).toBe('success');
-      expect(result.path).toBe('/test/path');
+      const readResult = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
+      expect(readResult.status).toBe('success');
+      expect(readResult.path).toBe('/test/path');
     });
 
     it('should detect non-existent file', async () => {
-      const result = await ComfyServerConfig.readBasePathFromConfig('non_existent_file.yaml');
-      expect(result.status).toBe('notFound');
-      expect(result.path).toBeUndefined();
+      const readResult = await ComfyServerConfig.readBasePathFromConfig('non_existent_file.yaml');
+      expect(readResult.status).toBe('notFound');
+      expect(readResult.path).toBeUndefined();
     });
 
     it('should handle missing base path', async () => {
       await copyFixture('missing-base-path.yaml', testConfigPath);
-      const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
-      expect(result.status).toBe('invalid');
-      expect(result.path).toBeUndefined();
+      const readResult = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
+      expect(readResult.status).toBe('invalid');
+      expect(readResult.path).toBeUndefined();
     });
 
     it('should handle wrong base path type', async () => {
       await copyFixture('wrong-type.yaml', testConfigPath);
-      const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
-      expect(result.status).toBe('invalid');
-      expect(result.path).toBeDefined();
+      const readResult = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
+      expect(readResult.status).toBe('invalid');
+      expect(readResult.path).toBeDefined();
     });
 
     it('should handle malformed YAML', async () => {
       await copyFixture('malformed.yaml', testConfigPath);
-      const result = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
-      expect(result.status).toBe('invalid');
-      expect(result.path).toBeUndefined();
+      const readResult = await ComfyServerConfig.readBasePathFromConfig(testConfigPath);
+      expect(readResult.status).toBe('invalid');
+      expect(readResult.path).toBeUndefined();
     });
   });
 
@@ -110,7 +114,7 @@ describe('ComfyServerConfig', () => {
     });
 
     it('should generate valid YAML with model paths', () => {
-      const testConfig = {
+      const testModelConfig = {
         comfyui_desktop: {
           base_path: '/test/path',
           checkpoints: '/test/path/models/checkpoints/',
@@ -118,52 +122,67 @@ describe('ComfyServerConfig', () => {
         },
       };
 
-      const result = ComfyServerConfig.generateConfigFileContent(testConfig);
+      const generatedYaml = ComfyServerConfig.generateConfigFileContent(testModelConfig);
 
-      expect(result).toContain(`# ComfyUI extra_model_paths.yaml for ${process.platform}`);
-      expect(result).toContain('comfyui_desktop:');
-      expect(result).toContain('  base_path: /test/path');
-      expect(result).toContain('  checkpoints: /test/path/models/checkpoints/');
-      expect(result).toContain('  loras: /test/path/models/loras/');
+      expect(generatedYaml).toContain(`# ComfyUI extra_model_paths.yaml for ${process.platform}`);
+      expect(generatedYaml).toContain('comfyui_desktop:');
+      expect(generatedYaml).toContain('  base_path: /test/path');
+      expect(generatedYaml).toContain('  checkpoints: /test/path/models/checkpoints/');
+      expect(generatedYaml).toContain('  loras: /test/path/models/loras/');
     });
 
     it.each(['win32', 'darwin', 'linux'] as const)('should include platform-specific header for %s', (platform) => {
       Object.defineProperty(process, 'platform', { value: platform });
       const testConfig = { test: { path: '/test' } };
-      const result = ComfyServerConfig.generateConfigFileContent(testConfig);
-      expect(result).toContain(`# ComfyUI extra_model_paths.yaml for ${platform}`);
+      const generatedYaml = ComfyServerConfig.generateConfigFileContent(testConfig);
+      expect(generatedYaml).toContain(`# ComfyUI extra_model_paths.yaml for ${platform}`);
     });
 
     it('should handle empty configs', () => {
-      const result = ComfyServerConfig.generateConfigFileContent({});
-      expect(result).toContain(`# ComfyUI extra_model_paths.yaml for ${process.platform}`);
+      const generatedYaml = ComfyServerConfig.generateConfigFileContent({});
+      expect(generatedYaml).toContain(`# ComfyUI extra_model_paths.yaml for ${process.platform}`);
       // The rest should just be an empty object
-      expect(result.split('\n')[1]).toBe('{}');
+      expect(generatedYaml.split('\n')[1]).toBe('{}');
     });
   });
 
   describe('getBaseModelPathsFromRepoPath', () => {
     it('should generate correct paths for all known model types', () => {
       const repoPath = '/test/repo';
-      const result = ComfyServerConfig.getBaseModelPathsFromRepoPath(repoPath);
+      const modelPaths = ComfyServerConfig.getBaseModelPathsFromRepoPath(repoPath);
 
-      expect(result.checkpoints).toBe(path.join(repoPath, 'models', 'checkpoints') + path.sep);
-      expect(result.loras).toBe(path.join(repoPath, 'models', 'loras') + path.sep);
-      expect(result.vae).toBe(path.join(repoPath, 'models', 'vae') + path.sep);
-      expect(result.controlnet).toBe(path.join(repoPath, 'models', 'controlnet') + path.sep);
+      expect(modelPaths.checkpoints).toBe(path.join(repoPath, 'models', 'checkpoints') + path.sep);
+      expect(modelPaths.loras).toBe(path.join(repoPath, 'models', 'loras') + path.sep);
+      expect(modelPaths.vae).toBe(path.join(repoPath, 'models', 'vae') + path.sep);
+      expect(modelPaths.controlnet).toBe(path.join(repoPath, 'models', 'controlnet') + path.sep);
 
-      for (const modelPath of Object.values(result)) {
+      for (const modelPath of Object.values(modelPaths)) {
         expect(modelPath).toContain(path.join(repoPath, 'models'));
         expect(modelPath.endsWith(path.sep)).toBe(true);
       }
     });
 
-    it('should handle empty repo path', () => {
-      const result = ComfyServerConfig.getBaseModelPathsFromRepoPath('');
+    it('should handle paths with special characters', () => {
+      const repoPath = '/test/repo with spaces/and#special@chars';
+      const modelPaths = ComfyServerConfig.getBaseModelPathsFromRepoPath(repoPath);
 
-      // Paths should be relative to models directory
-      expect(result.checkpoints).toBe(path.join('models', 'checkpoints') + path.sep);
-      expect(result.loras).toBe(path.join('models', 'loras') + path.sep);
+      expect(modelPaths.checkpoints).toBe(path.join(repoPath, 'models', 'checkpoints') + path.sep);
+      expect(modelPaths.loras).toBe(path.join(repoPath, 'models', 'loras') + path.sep);
+    });
+
+    it('should handle relative paths', () => {
+      const repoPath = './relative/path';
+      const modelPaths = ComfyServerConfig.getBaseModelPathsFromRepoPath(repoPath);
+
+      expect(modelPaths.checkpoints).toBe(path.join(repoPath, 'models', 'checkpoints') + path.sep);
+      expect(modelPaths.loras).toBe(path.join(repoPath, 'models', 'loras') + path.sep);
+    });
+
+    it('should handle empty paths', () => {
+      const modelPaths = ComfyServerConfig.getBaseModelPathsFromRepoPath('');
+
+      expect(modelPaths.checkpoints).toBe(path.join('models', 'checkpoints') + path.sep);
+      expect(modelPaths.loras).toBe(path.join('models', 'loras') + path.sep);
     });
   });
 
@@ -186,13 +205,13 @@ describe('ComfyServerConfig', () => {
       },
     ])('should return platform-specific config for $platform', ({ platform }) => {
       Object.defineProperty(process, 'platform', { value: platform });
-      const result = ComfyServerConfig.getBaseConfig();
+      const platformConfig = ComfyServerConfig.getBaseConfig();
 
       // All platforms should have these common paths
-      expect(result.checkpoints).toContain('models/checkpoints');
-      expect(result.loras).toContain('models/loras');
-      expect(result.custom_nodes).toBe('custom_nodes/');
-      expect(result.is_default).toBe('true');
+      expect(platformConfig.checkpoints).toContain('models/checkpoints');
+      expect(platformConfig.loras).toContain('models/loras');
+      expect(platformConfig.custom_nodes).toBe('custom_nodes/');
+      expect(platformConfig.is_default).toBe('true');
     });
 
     it('should throw for unknown platforms', () => {
@@ -202,63 +221,63 @@ describe('ComfyServerConfig', () => {
   });
 
   describe('readConfigFile', () => {
-    let tmpdir = '';
+    let tempDir = '';
     const originalPlatform = process.platform;
 
     beforeAll(async () => {
-      tmpdir = await createTmpDir();
+      tempDir = await createTmpDir();
     });
 
     afterAll(async () => {
-      await rm(tmpdir, { recursive: true });
+      await rm(tempDir, { recursive: true });
       Object.defineProperty(process, 'platform', { value: originalPlatform });
     });
 
     it('should handle missing files', async () => {
-      const result = await ComfyServerConfig.readConfigFile('/non/existent/path.yaml');
-      expect(result).toBeNull();
+      const configContent = await ComfyServerConfig.readConfigFile('/non/existent/path.yaml');
+      expect(configContent).toBeNull();
     });
 
     it('should handle invalid YAML', async () => {
-      const configPath = path.join(tmpdir, 'invalid_config.yaml');
-      await copyFixture('malformed.yaml', configPath);
-      const result = await ComfyServerConfig.readConfigFile(configPath);
-      expect(result).toBeNull();
+      const invalidConfigPath = path.join(tempDir, 'invalid_config.yaml');
+      await copyFixture('malformed.yaml', invalidConfigPath);
+      const configContent = await ComfyServerConfig.readConfigFile(invalidConfigPath);
+      expect(configContent).toBeNull();
     });
   });
 
   describe('readConfigFile edge cases', () => {
-    let tmpdir = '';
+    let tempDir = '';
     const originalPlatform = process.platform;
     const originalEnv = process.env;
 
     beforeAll(async () => {
-      tmpdir = await createTmpDir();
+      tempDir = await createTmpDir();
     });
 
     afterAll(async () => {
-      await rm(tmpdir, { recursive: true });
+      await rm(tempDir, { recursive: true });
       Object.defineProperty(process, 'platform', { value: originalPlatform });
       process.env = originalEnv;
     });
 
     it('should handle legacy format config', async () => {
-      const configPath = path.join(tmpdir, 'legacy-format.yaml');
-      await copyFixture('legacy-format.yaml', configPath);
-      const result = await ComfyServerConfig.readBasePathFromConfig(configPath);
+      const legacyConfigPath = path.join(tempDir, 'legacy-format.yaml');
+      await copyFixture('legacy-format.yaml', legacyConfigPath);
+      const readResult = await ComfyServerConfig.readBasePathFromConfig(legacyConfigPath);
 
-      expect(result.status).toBe('success');
-      expect(result.path).toBe('/old/style/path');
+      expect(readResult.status).toBe('success');
+      expect(readResult.path).toBe('/old/style/path');
     });
 
     it('should handle multiple sections and special values', async () => {
-      const configPath = path.join(tmpdir, 'multiple-sections.yaml');
-      await copyFixture('multiple-sections.yaml', configPath);
-      const result = await ComfyServerConfig.readConfigFile(configPath);
+      const multiSectionConfigPath = path.join(tempDir, 'multiple-sections.yaml');
+      await copyFixture('multiple-sections.yaml', multiSectionConfigPath);
+      const configContent = await ComfyServerConfig.readConfigFile(multiSectionConfigPath);
 
-      expect(result).not.toBeNull();
-      expect(result!.comfyui_desktop.base_path).toBe('/primary/path');
-      expect(result!.comfyui_migration.base_path).toBe('/migration/path');
+      expect(configContent).not.toBeNull();
+      expect(configContent!.comfyui_desktop.base_path).toBe('/primary/path');
+      expect(configContent!.comfyui_migration.base_path).toBe('/migration/path');
     });
   });
 });


### PR DESCRIPTION
Extends unit tests on `ComfyServerConfig` to include methods:

- `generateConfigFileContent`
- `getBaseModelPathFromRepoPath`
- `getBaseConfig`
- `readConfigFile`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-679-Test-Add-ComfyServerConfig-unit-tests-1826d73d365081678f6af5b168f3111f) by [Unito](https://www.unito.io)
