### PR TITLE
Prevent custom window from being used

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -290,11 +290,10 @@ export class AppWindow {
   }
 
   changeTheme(options: TitleBarOverlayOptions): void {
-    if (!this.customWindowEnabled) return;
-
-    options.height &&= Math.round(options.height);
-    if (!options.height) delete options.height;
-    this.window.setTitleBarOverlay(options);
+    // if (!this.customWindowEnabled) return;
+    // options.height &&= Math.round(options.height);
+    // if (!options.height) delete options.height;
+    // this.window.setTitleBarOverlay(options);
   }
 
   showSystemContextMenu(options?: ElectronContextMenuOptions): void {


### PR DESCRIPTION
Temporary workaround until the feature has been fully implemented and tested.

Comments code; does not require API re-publish.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-680-Prevent-custom-window-from-being-used-1826d73d365081a89bb7e8bb2a634e5c) by [Unito](https://www.unito.io)
