### PR TITLE
Track quitting and virtual env skip events.

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -18,7 +18,6 @@ import path from 'node:path';
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { getAppResourcesPath } from '../install/resourcePaths';
 import type { ElectronContextMenuOptions } from '../preload';
-import { ITelemetry } from '../services/telemetry';
 import { AppWindowSettings } from '../store/AppWindowSettings';
 import { useDesktopConfig } from '../store/desktopConfig';
 
@@ -49,7 +48,7 @@ export class AppWindow {
     if (!app.isPackaged) return process.env.DEV_SERVER_URL;
   }
 
-  public constructor(readonly telemetry: ITelemetry) {
+  public constructor() {
     const installed = useDesktopConfig().get('installState') === 'installed';
     const primaryDisplay = screen.getPrimaryDisplay();
     const { width, height } = installed ? primaryDisplay.workAreaSize : { width: 1024, height: 768 };
@@ -341,7 +340,6 @@ export class AppWindow {
       {
         label: 'Quit Comfy',
         click: () => {
-          this.telemetry.track('desktop:app_quit');
           app.quit();
         },
       },

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -18,6 +18,7 @@ import path from 'node:path';
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { getAppResourcesPath } from '../install/resourcePaths';
 import type { ElectronContextMenuOptions } from '../preload';
+import { ITelemetry } from '../services/telemetry';
 import { AppWindowSettings } from '../store/AppWindowSettings';
 import { useDesktopConfig } from '../store/desktopConfig';
 
@@ -48,7 +49,7 @@ export class AppWindow {
     if (!app.isPackaged) return process.env.DEV_SERVER_URL;
   }
 
-  public constructor() {
+  public constructor(readonly telemetry: ITelemetry) {
     const installed = useDesktopConfig().get('installState') === 'installed';
     const primaryDisplay = screen.getPrimaryDisplay();
     const { width, height } = installed ? primaryDisplay.workAreaSize : { width: 1024, height: 768 };
@@ -340,6 +341,7 @@ export class AppWindow {
       {
         label: 'Quit Comfy',
         click: () => {
+          this.telemetry.track('desktop:app_quit');
           app.quit();
         },
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,7 @@ async function startApp() {
 
   try {
     // Create native window
-    const appWindow = new AppWindow();
+    const appWindow = new AppWindow(telemetry);
     appWindow.onClose(() => log.info('App window closed.'));
 
     // Load start screen - basic spinner

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,13 @@ app.on('before-quit', () => {
   quitting = true;
 });
 
+app.on('quit', (event, exitCode) => {
+  telemetry.track('desktop:app_quit', {
+    reason: event,
+    exitCode,
+  });
+});
+
 // Sentry needs to be initialized at the top level.
 log.verbose('Initializing Sentry');
 SentryLogging.init();
@@ -73,7 +80,7 @@ async function startApp() {
 
   try {
     // Create native window
-    const appWindow = new AppWindow(telemetry);
+    const appWindow = new AppWindow();
     appWindow.onClose(() => log.info('App window closed.'));
 
     // Load start screen - basic spinner


### PR DESCRIPTION
Utilize a single `install_flow:virtual_environment_create_end` event with properties indicating what the reason was.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-689-Track-quitting-and-virtual-env-skip-events-1826d73d365081078e84f18bcd251e1d) by [Unito](https://www.unito.io)
