### PR TITLE
Fixed: Quit app on mac when windows are closed.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,11 +28,8 @@ const telemetry = getTelemetry();
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
-  log.info('Window all closed');
-  if (process.platform !== 'darwin') {
-    log.info('Quitting ComfyUI because window all closed');
-    app.quit();
-  }
+  log.info('Quitting ComfyUI because window all closed');
+  app.quit();
 });
 
 // Suppress unhandled exception dialog when already quitting.


### PR DESCRIPTION
Currently, when we close the app window you can re-open it from the mac doc. Which shows this error since the AppWindow is already destroyed.

<img width="259" alt="Screenshot 2025-01-21 at 3 30 20 PM" src="https://github.com/user-attachments/assets/d5fb1906-6fca-4f47-a3ec-332a4c7fa83e" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-690-Fixed-Quit-app-on-mac-when-windows-are-closed-1826d73d365081ea8916ca5304a75797) by [Unito](https://www.unito.io)
