### PR TITLE
[Test] Add unit tests for 100% coverage of comfySettings

### DIFF
--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -163,5 +163,21 @@ describe('ComfySettings', () => {
       await expectLogError();
       expect(settings.get('Comfy-Desktop.AutoUpdate')).toBe(DEFAULT_SETTINGS['Comfy-Desktop.AutoUpdate']);
     });
+
+    it('should return immediately when trying to save undefined settings', async () => {
+      const saveSettingsSpy = vi.spyOn(settings, 'saveSettings');
+      // @ts-expect-error: settings are undefined prior to loading
+      settings['settings'] = undefined;
+      await settings.saveSettings();
+
+      expect(saveSettingsSpy).toHaveReturned();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should log and throw error on save settings write error', async () => {
+      vi.mocked(fs.writeFile).mockRejectedValue(new Error('Permission denied'));
+      await expect(settings.saveSettings()).rejects.toThrow('Permission denied');
+      await expectLogError();
+    });
   });
 });

--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -164,17 +164,17 @@ describe('ComfySettings', () => {
       expect(settings.get('Comfy-Desktop.AutoUpdate')).toBe(DEFAULT_SETTINGS['Comfy-Desktop.AutoUpdate']);
     });
 
-    it('should return immediately when trying to save undefined settings', async () => {
+    it('should handle attempts to save null settings', async () => {
       const saveSettingsSpy = vi.spyOn(settings, 'saveSettings');
-      // @ts-expect-error: settings are undefined prior to loading
-      settings['settings'] = undefined;
+      // @ts-expect-error: explicitly setting settings to null
+      settings['settings'] = null;
       await settings.saveSettings();
 
       expect(saveSettingsSpy).toHaveReturned();
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
-    it('should log and throw error on save settings write error', async () => {
+    it('should log and throw error on write error during saveSettings', async () => {
       vi.mocked(fs.writeFile).mockRejectedValue(new Error('Permission denied'));
       await expect(settings.saveSettings()).rejects.toThrow('Permission denied');
       await expectLogError();


### PR DESCRIPTION
This PR adds unit tests on remaining branches in `comfySettings`, bringing it to 100% coverage:


![Selection_788](https://github.com/user-attachments/assets/7af41615-b231-4050-b0af-6d70e946b6c5)

The remaining tests are on the error handling and null check in `saveSettings` (added here https://github.com/Comfy-Org/desktop/pull/669)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-692-Test-Add-unit-tests-for-100-coverage-of-comfySettings-1826d73d3650814ab5d9ddc46ec1874a) by [Unito](https://www.unito.io)
