### PR TITLE
[Test] Add unit tests for 100% coverage of comfyConfigManager

### DIFF
--- a/tests/unit/comfyConfigManager.test.ts
+++ b/tests/unit/comfyConfigManager.test.ts
@@ -91,6 +91,18 @@ describe('ComfyConfigManager', () => {
       expect(fs.mkdirSync).toHaveBeenCalledWith(path.normalize('/fake/path/ComfyUI/output'), { recursive: true });
       expect(fs.mkdirSync).toHaveBeenCalledWith(path.normalize('/fake/path/ComfyUI/custom_nodes'), { recursive: true });
     });
+
+    it('should catch and log errors when creating directories', async () => {
+      vi.mocked(fs.mkdirSync).mockImplementationOnce(() => {
+        throw new Error('Permission denied');
+      });
+
+      const log = await import('electron-log/main');
+      ComfyConfigManager.createComfyDirectories('/fake/path/ComfyUI');
+
+      expect(fs.mkdirSync).toHaveBeenCalled();
+      expect(vi.mocked(log.default.error)).toHaveBeenCalledWith(expect.stringContaining('Permission denied'));
+    });
   });
 
   describe('createNestedDirectories', () => {


### PR DESCRIPTION
This PR adds unit tests on remaining branches in `comfyConfigManager`, bringing to 100% coverage:

![Selection_789](https://github.com/user-attachments/assets/3aba6808-8922-4e25-b680-691bed6fae70)

The last untested branch was handling `fs.mkdirSync` errors in `createComfyDirectories` method.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-693-Test-Add-unit-tests-for-100-coverage-of-comfyConfigManager-1826d73d3650811c811ff8d6bd1b64cb) by [Unito](https://www.unito.io)
