### PR TITLE
Mark readonly fields as readonly

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -26,17 +26,17 @@ import { useDesktopConfig } from '../store/desktopConfig';
  * Closes the application when the window is closed.
  */
 export class AppWindow {
-  private window: BrowserWindow;
+  private readonly window: BrowserWindow;
   /** Volatile store containing window config - saves window state between launches. */
-  private store: Store<AppWindowSettings>;
-  private messageQueue: Array<{ channel: string; data: unknown }> = [];
+  private readonly store: Store<AppWindowSettings>;
+  private readonly messageQueue: Array<{ channel: string; data: unknown }> = [];
   private rendererReady: boolean = false;
   /** Default dark mode config for system window overlay (min/max/close window). */
-  private darkOverlay = { color: '#00000000', symbolColor: '#ddd' };
+  private readonly darkOverlay = { color: '#00000000', symbolColor: '#ddd' };
   /** Default light mode config for system window overlay (min/max/close window). */
-  private lightOverlay = { ...this.darkOverlay, symbolColor: '#333' };
+  private readonly lightOverlay = { ...this.darkOverlay, symbolColor: '#333' };
   /** The application menu. */
-  private menu: Electron.Menu | null;
+  private readonly menu: Electron.Menu | null;
   /** The "edit" menu - cut/copy/paste etc. */
   private editMenu?: Menu;
   /** Whether this window was created with title bar overlay enabled. When `false`, Electron throws when calling {@link BrowserWindow.setTitleBarOverlay}. */

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -28,9 +28,9 @@ export interface DownloadState {
  */
 export class DownloadManager {
   private static instance: DownloadManager;
-  private downloads: Map<string, Download>;
-  private mainWindow: AppWindow;
-  private modelsDirectory: string;
+  private readonly downloads: Map<string, Download>;
+  private readonly mainWindow: AppWindow;
+  private readonly modelsDirectory: string;
   private constructor(mainWindow: AppWindow, modelsDirectory: string) {
     this.downloads = new Map();
     this.mainWindow = mainWindow;

--- a/src/services/cmCli.ts
+++ b/src/services/cmCli.ts
@@ -7,8 +7,8 @@ import { ProcessCallbacks, VirtualEnvironment } from '../virtualEnvironment';
 import { HasTelemetry, ITelemetry, trackEvent } from './telemetry';
 
 export class CmCli implements HasTelemetry {
-  private cliPath: string;
-  private virtualEnvironment: VirtualEnvironment;
+  private readonly cliPath: string;
+  private readonly virtualEnvironment: VirtualEnvironment;
 
   constructor(
     virtualEnvironment: VirtualEnvironment,

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -31,10 +31,10 @@ interface GpuInfo {
 const MIXPANEL_TOKEN = '6a7f9f6ae2084b4e7ff7ced98a6b5988';
 export class MixpanelTelemetry implements ITelemetry {
   public hasConsent: boolean = false;
-  private distinctId: string;
+  private readonly distinctId: string;
   private readonly storageFile: string;
-  private queue: { eventName: string; properties: PropertyDict }[] = [];
-  private mixpanelClient: mixpanel.Mixpanel;
+  private readonly queue: { eventName: string; properties: PropertyDict }[] = [];
+  private readonly mixpanelClient: mixpanel.Mixpanel;
   private cachedGpuInfo: GpuInfo[] | null = null;
   constructor(mixpanelClass: mixpanel.Mixpanel) {
     this.mixpanelClient = mixpanelClass.init(MIXPANEL_TOKEN, {

--- a/src/shell/terminal.ts
+++ b/src/shell/terminal.ts
@@ -7,9 +7,9 @@ import { getDefaultShell } from './util';
 
 export class Terminal {
   #pty: pty.IPty | undefined;
-  #window: AppWindow | undefined;
-  #cwd: string | undefined;
-  #uvPath: string | undefined;
+  readonly #window: AppWindow | undefined;
+  readonly #cwd: string | undefined;
+  readonly #uvPath: string | undefined;
 
   readonly sessionBuffer: string[] = [];
   readonly size = { cols: 80, rows: 30 };

--- a/src/store/desktopConfig.ts
+++ b/src/store/desktopConfig.ts
@@ -17,7 +17,7 @@ export function useDesktopConfig() {
 
 /** Handles loading of electron-store config, pre-window errors, and provides a non-null interface for the store. */
 export class DesktopConfig {
-  #store: ElectronStore<DesktopSettings>;
+  readonly #store: ElectronStore<DesktopSettings>;
 
   private constructor(store: ElectronStore<DesktopSettings>) {
     this.#store = store;


### PR DESCRIPTION
Closes https://github.com/Comfy-Org/desktop/issues/648. Marks private fields only assigned in the constructor as `readonly`. [Linting rule](https://next.sonarqube.com/sonarqube/coding_rules?open=typescript%3AS2933&rule_key=typescript%3AS2933)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-697-Mark-readonly-fields-as-readonly-1836d73d36508179b07fecc0315329ba) by [Unito](https://www.unito.io)
