### PR TITLE
[chore] Update frontend to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.8.2",
+    "frontendVersion": "1.8.4",
     "comfyVersion": "0.3.12",
     "managerCommit": "b4e52e65ec87978fc6294e82d55e1b91c5b02d55",
     "uvVersion": "0.5.11"


### PR DESCRIPTION
Automated frontend update to 1.8.4

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-700-chore-Update-frontend-to-1-8-4-1836d73d365081e9a92ed15220505501) by [Unito](https://www.unito.io)
