### PR TITLE
Add first time user setting to comfy settings

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -12,10 +12,16 @@ import { InstallWizard } from './installWizard';
 
 /** High-level / UI control over the installation of ComfyUI server. */
 export class InstallationManager {
+  private _isFreshInstall = false;
+
   constructor(
     public readonly appWindow: AppWindow,
     private readonly telemetry: ITelemetry
   ) {}
+
+  get isFreshInstall(): boolean {
+    return this._isFreshInstall;
+  }
 
   /**
    * Ensures that ComfyUI is installed and ready to run.
@@ -29,7 +35,10 @@ export class InstallationManager {
     log.info(`Install state: ${installation?.state ?? 'not installed'}`);
 
     // Fresh install
-    if (!installation) return await this.freshInstall();
+    if (!installation) {
+      this._isFreshInstall = true;
+      return await this.freshInstall();
+    }
 
     try {
       // Send updates to renderer

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -12,16 +12,10 @@ import { InstallWizard } from './installWizard';
 
 /** High-level / UI control over the installation of ComfyUI server. */
 export class InstallationManager {
-  private _isFreshInstall = false;
-
   constructor(
     public readonly appWindow: AppWindow,
     private readonly telemetry: ITelemetry
   ) {}
-
-  get isFreshInstall(): boolean {
-    return this._isFreshInstall;
-  }
 
   /**
    * Ensures that ComfyUI is installed and ready to run.
@@ -36,7 +30,6 @@ export class InstallationManager {
 
     // Fresh install
     if (!installation) {
-      this._isFreshInstall = true;
       return await this.freshInstall();
     }
 
@@ -196,6 +189,7 @@ export class InstallationManager {
 
     const installation = new ComfyInstallation('installed', installWizard.basePath, this.telemetry, device);
     installation.setState('installed');
+    installation.isFreshInstall = true;
     return installation;
   }
 

--- a/src/main-process/comfyInstallation.ts
+++ b/src/main-process/comfyInstallation.ts
@@ -22,6 +22,15 @@ export class ComfyInstallation {
     inProgress: false,
     installState: 'started',
   };
+  private _isFreshInstall: boolean = false;
+
+  get isFreshInstall() {
+    return this._isFreshInstall;
+  }
+
+  set isFreshInstall(value) {
+    this._isFreshInstall = value;
+  }
 
   get hasIssues() {
     return Object.values(this.validation).includes('error');

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { app, dialog, ipcMain, shell } from 'electron';
 import { LevelOption } from 'electron-log';
 import log from 'electron-log/main';
 
+import { ComfyServerConfig } from './config/comfyServerConfig';
 import { DEFAULT_SERVER_ARGS, IPC_CHANNELS, ProgressStatus } from './constants';
 import { registerAppHandlers } from './handlers/AppHandlers';
 import { registerAppInfoHandlers } from './handlers/appInfoHandlers';
@@ -105,6 +106,8 @@ async function startApp() {
     });
 
     try {
+      const isNewUser = !ComfyServerConfig.exists();
+
       // Install / validate installation is complete
       const installManager = new InstallationManager(appWindow, telemetry);
       const installation = await installManager.ensureInstalled();
@@ -118,6 +121,11 @@ async function startApp() {
       const allowMetrics = await promptMetricsConsent(store, appWindow, comfyDesktopApp);
       telemetry.hasConsent = allowMetrics;
       if (allowMetrics) telemetry.flush();
+
+      if (isNewUser) {
+        comfyDesktopApp.comfySettings.set('Comfy.TutorialCompleted', false);
+        await comfyDesktopApp.comfySettings.saveSettings();
+      }
 
       // Construct core launch args
       const useExternalServer = devOverride('USE_EXTERNAL_SERVER') === 'true';

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ async function startApp() {
       telemetry.hasConsent = allowMetrics;
       if (allowMetrics) telemetry.flush();
 
-      if (installManager.isFreshInstall) {
+      if (installation.isFreshInstall) {
         comfyDesktopApp.comfySettings.set('Comfy.TutorialCompleted', false);
         await comfyDesktopApp.comfySettings.saveSettings();
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import { app, dialog, ipcMain, shell } from 'electron';
 import { LevelOption } from 'electron-log';
 import log from 'electron-log/main';
 
-import { ComfyServerConfig } from './config/comfyServerConfig';
 import { DEFAULT_SERVER_ARGS, IPC_CHANNELS, ProgressStatus } from './constants';
 import { registerAppHandlers } from './handlers/AppHandlers';
 import { registerAppInfoHandlers } from './handlers/appInfoHandlers';
@@ -106,8 +105,6 @@ async function startApp() {
     });
 
     try {
-      const isNewUser = !ComfyServerConfig.exists();
-
       // Install / validate installation is complete
       const installManager = new InstallationManager(appWindow, telemetry);
       const installation = await installManager.ensureInstalled();
@@ -122,7 +119,7 @@ async function startApp() {
       telemetry.hasConsent = allowMetrics;
       if (allowMetrics) telemetry.flush();
 
-      if (isNewUser) {
+      if (installManager.isFreshInstall) {
         comfyDesktopApp.comfySettings.set('Comfy.TutorialCompleted', false);
         await comfyDesktopApp.comfySettings.saveSettings();
       }


### PR DESCRIPTION
Adds setting to new users' comfy settings indicating that they have not completed the tutorial.

In the associated frontend PR, this setting is checked on setup to determine whether to load the tutorial workflow:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/2315

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-701-Add-first-time-user-setting-to-comfy-settings-1836d73d36508115a9c6d2aca697ca38) by [Unito](https://www.unito.io)
