### PR TITLE
Update ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default tseslint.config(
       'no-control-regex': 'off',
 
       '@typescript-eslint/restrict-template-expressions': 'off',
+      '@typescript-eslint/prefer-readonly': 'warn',
     },
   },
 
@@ -69,6 +70,11 @@ export default tseslint.config(
     rules: {
       'unicorn/prefer-module': 'off',
       '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
     },
   }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,7 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
     },
   }

--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -107,11 +107,9 @@ describe('ComfySettings', () => {
       await settings.saveSettings();
 
       const writeCall = vi.mocked(fs).writeFile.mock.calls[0];
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const savedJson = JSON.parse(writeCall[1] as string);
 
       expect(writeCall[0]).toBe(settings.filePath);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(savedJson['Comfy-Desktop.AutoUpdate']).toBe(false);
     });
 

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -141,6 +141,7 @@ describe('MixpanelTelemetry', () => {
     it('should handle INCREMENT_USER_PROPERTY messages', () => {
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       telemetry.registerHandlers();
+      // Get the callback that was registered
       const [, callback] = (ipcMain.on as any).mock.calls.find(
         ([channel]: any) => channel === IPC_CHANNELS.INCREMENT_USER_PROPERTY
       );

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -52,7 +52,6 @@ describe('MixpanelTelemetry', () => {
       const existingId = 'existing-uuid';
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(existingId);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       expect(fs.readFileSync).toHaveBeenCalledWith(path.join('/mock/user/data', 'telemetry.txt'), 'utf8');
       expect(fs.writeFileSync).not.toHaveBeenCalled();
@@ -60,7 +59,6 @@ describe('MixpanelTelemetry', () => {
 
     it('should create new distinct ID if file does not exist', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
 
       expect(fs.writeFileSync).toHaveBeenCalled();
@@ -74,7 +72,6 @@ describe('MixpanelTelemetry', () => {
     it('should queue events when consent is not given', () => {
       const eventName = 'test_event';
       const properties = { foo: 'bar' };
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       telemetry.track(eventName, properties);
 
@@ -82,16 +79,13 @@ describe('MixpanelTelemetry', () => {
       expect(telemetry['queue'][0].eventName).toBe(eventName);
       expect(telemetry['queue'][0].properties).toMatchObject({
         ...properties,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         distinct_id: expect.any(String),
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         time: expect.any(Date),
       });
     });
 
     it('should flush queue when consent is given', () => {
       const eventName = 'test_event';
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       telemetry.track(eventName);
 
@@ -110,7 +104,6 @@ describe('MixpanelTelemetry', () => {
 
   describe('IPC event handling', () => {
     it('should handle INSTALL_COMFYUI event and update consent', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       const mockIpcEvent = {} as IpcMainEvent;
       const installOptionsHandler = vi.mocked(ipcMain.once).mock.calls[0][1];
@@ -119,7 +112,6 @@ describe('MixpanelTelemetry', () => {
     });
 
     it('should register ipc handler for TRACK_EVENT', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       telemetry.registerHandlers();
 
@@ -127,7 +119,6 @@ describe('MixpanelTelemetry', () => {
     });
 
     it('should handle TRACK_EVENT messages', () => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       telemetry.registerHandlers();
       const trackEventHandler = vi.mocked(ipcMain.on).mock.calls[0][1];
@@ -150,8 +141,7 @@ describe('MixpanelTelemetry', () => {
     it('should handle INCREMENT_USER_PROPERTY messages', () => {
       telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
       telemetry.registerHandlers();
-      // Get the callback that was registered
-      const [channel, callback] = (ipcMain.on as any).mock.calls.find(
+      const [, callback] = (ipcMain.on as any).mock.calls.find(
         ([channel]: any) => channel === IPC_CHANNELS.INCREMENT_USER_PROPERTY
       );
 
@@ -177,7 +167,6 @@ describe('MixpanelTelemetry', () => {
     };
 
     // Create telemetry instance with mock client
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
     const telemetry = new MixpanelTelemetry(mockMixpanelClient as any);
 
     // Verify init was called

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -27,7 +27,6 @@ describe('validateHardware', () => {
     const result = await validateHardware();
     expect(result).toStrictEqual({
       isValid: false,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       error: expect.stringContaining('Intel-based Macs are not supported'),
     });
   });
@@ -52,7 +51,6 @@ describe('validateHardware', () => {
     const result = await validateHardware();
     expect(result).toStrictEqual({
       isValid: false,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       error: expect.stringContaining('No NVIDIA GPU was detected'),
     });
   });


### PR DESCRIPTION
Updates es-lint rules:

- Disable no-unsafe-* and no-explicit-any rules in test files as it is often necessary to mock objects and functions, which can require using any types or unsafe assignments/accesses
- Enable [prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly/) (ref: https://github.com/Comfy-Org/desktop/pull/697)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-702-Update-ESLint-rules-1846d73d36508193a94edad0127d7736) by [Unito](https://www.unito.io)
