### PR TITLE
[Dev] Make auto open of DevTools optional

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -13,6 +13,9 @@ USE_EXTERNAL_SERVER=false
 # to start a development server.
 DEV_SERVER_URL=http://192.168.2.20:5173
 
+# When DEV_SERVER_URL is set, whether to automatically open dev tools on app start.
+DEV_TOOLS_AUTO=false
+
 # The level of logging to use.
 LOG_LEVEL=debug
 

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -187,7 +187,7 @@ export class AppWindow {
       this.rendererReady = true;
       log.info(`Loading development server ${url}`);
       await this.window.loadURL(url);
-      this.window.webContents.openDevTools();
+      if (process.env.DEV_TOOLS_AUTO === 'true') this.window.webContents.openDevTools();
     } else {
       const appResourcesPath = getAppResourcesPath();
       const frontendPath = path.join(appResourcesPath, 'ComfyUI', 'web_custom_versions', 'desktop_app');


### PR DESCRIPTION
- By default, DevTools no longer opens on app start with using a dev server
- Now controlled via env var
- Added to `.env_example`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-704-Dev-Make-auto-open-of-DevTools-optional-1846d73d365081258578edf9f2b91fc5) by [Unito](https://www.unito.io)
