### PR TITLE
Add electronAPI.Network.canAccessUrl

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,7 @@ export const IPC_CHANNELS = {
   INCREMENT_USER_PROPERTY: 'increment-user-property',
   UV_CLEAR_CACHE: 'uv-clear-cache',
   UV_RESET_VENV: 'uv-delete-venv',
+  CAN_ACCESS_URL: 'can-access-url',
 } as const;
 
 export enum ProgressStatus {

--- a/src/handlers/networkHandlers.ts
+++ b/src/handlers/networkHandlers.ts
@@ -1,0 +1,15 @@
+import { ipcMain } from 'electron';
+
+import { IPC_CHANNELS } from '../constants';
+import { canAccessUrl } from '../utils';
+
+export class NetworkHandlers {
+  registerHandlers() {
+    ipcMain.handle(
+      IPC_CHANNELS.CAN_ACCESS_URL,
+      (event, url: string, options?: { timeout?: number }): Promise<boolean> => {
+        return canAccessUrl(url, options);
+      }
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import log from 'electron-log/main';
 import { DEFAULT_SERVER_ARGS, IPC_CHANNELS, ProgressStatus } from './constants';
 import { AppHandlers } from './handlers/AppHandlers';
 import { AppInfoHandlers } from './handlers/appInfoHandlers';
+import { NetworkHandlers } from './handlers/networkHandlers';
 import { PathHandlers } from './handlers/pathHandlers';
 import { InstallationManager } from './install/installationManager';
 import { AppWindow } from './main-process/appWindow';
@@ -93,6 +94,7 @@ async function startApp() {
 
     // Register basic handlers that are necessary during app's installation.
     new PathHandlers().registerHandlers();
+    new NetworkHandlers().registerHandlers();
     new AppInfoHandlers().registerHandlers(appWindow);
     new AppHandlers().registerHandlers();
     ipcMain.handle(IPC_CHANNELS.OPEN_DIALOG, (event, options: Electron.OpenDialogOptions) => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -326,6 +326,11 @@ const electronAPI = {
       ipcRenderer.send(IPC_CHANNELS.INCREMENT_USER_PROPERTY, propertyName, number);
     },
   },
+  NetWork: {
+    canAccessUrl: (url: string, options?: { timeout?: number }): Promise<boolean> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.CAN_ACCESS_URL, url, options);
+    },
+  },
   /** Restart the python server without restarting desktop. */
   restartCore: async (): Promise<void> => {
     console.log('Restarting core process');


### PR DESCRIPTION
The frontend won't be able to access remote mirrors because of CoRS policy. This PR exposes a electronAPI to check accessibility of url.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-711-Add-electronAPI-Network-canAccessUrl-1846d73d36508130a6cacfcf5e1d33bb) by [Unito](https://www.unito.io)
