### PR TITLE
[Test] Add install validation unit tests

### DIFF
--- a/tests/unit/install/installationManager.test.ts
+++ b/tests/unit/install/installationManager.test.ts
@@ -2,135 +2,198 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { IPC_CHANNELS } from '../../../src/constants';
 import { InstallationManager } from '../../../src/install/installationManager';
-import { AppWindow } from '../../../src/main-process/appWindow';
+import type { AppWindow } from '../../../src/main-process/appWindow';
 import { ComfyInstallation } from '../../../src/main-process/comfyInstallation';
 import type { InstallValidation } from '../../../src/preload';
-import { ITelemetry } from '../../../src/services/telemetry';
+import type { ITelemetry } from '../../../src/services/telemetry';
 
 vi.mock('electron', () => ({
   ipcMain: {
     handle: vi.fn(),
-    removeHandler: vi.fn(),
     handleOnce: vi.fn(),
+    removeHandler: vi.fn(),
+    once: vi.fn(),
   },
   app: {
     getPath: vi.fn(),
+    quit: vi.fn(),
+    relaunch: vi.fn(),
   },
   dialog: {
     showErrorBox: vi.fn(),
   },
 }));
-
 vi.mock('../../../src/main-process/comfyInstallation');
 vi.mock('../../../src/store/desktopConfig');
 vi.mock('electron-log/main');
 
+type ValidationStep = {
+  inProgress: boolean;
+  installState: string;
+  basePath?: 'OK' | 'error';
+  venvDirectory?: 'OK' | 'error';
+  pythonInterpreter?: 'OK' | 'error';
+};
+
+const commonValidationSteps: ValidationStep[] = [
+  {
+    inProgress: true,
+    installState: 'installed',
+    basePath: 'error',
+  },
+  {
+    inProgress: true,
+    installState: 'installed',
+    basePath: 'OK',
+    venvDirectory: 'error',
+  },
+  {
+    inProgress: true,
+    installState: 'installed',
+    basePath: 'OK',
+    venvDirectory: 'OK',
+    pythonInterpreter: 'error',
+  },
+];
+
+const createMockAppWindow = () => {
+  const mock = {
+    send: vi.fn(),
+    loadRenderer: vi.fn().mockResolvedValue(null),
+    showOpenDialog: vi.fn(),
+    maximize: vi.fn(),
+  };
+  return mock as unknown as AppWindow;
+};
+
+const createMockTelemetry = () => {
+  const mock = {
+    track: vi.fn(),
+  };
+  return mock as unknown as ITelemetry;
+};
+
+const createMockInstallation = (params: {
+  state?: string;
+  hasIssues?: boolean;
+  isValid?: boolean;
+  validationSteps?: ValidationStep[];
+}) => {
+  const { state = 'installed', hasIssues = false, isValid = true, validationSteps = [] } = params;
+
+  const mockInstallation = {
+    state,
+    validation: {} as InstallValidation,
+    hasIssues,
+    isValid,
+    validate: vi.fn().mockImplementation(() => {
+      // Simulate validation steps
+      if (mockInstallation.onUpdate) {
+        for (const step of validationSteps) {
+          mockInstallation.onUpdate(step as InstallValidation);
+        }
+      }
+      return state;
+    }),
+    onUpdate: undefined as ((data: InstallValidation) => void) | undefined,
+  };
+
+  return mockInstallation as unknown as ComfyInstallation;
+};
+
 describe('InstallationManager', () => {
   let manager: InstallationManager;
-  let mockAppWindow: AppWindow;
-  let mockTelemetry: ITelemetry;
+  let mockAppWindow: ReturnType<typeof createMockAppWindow>;
+  let validationUpdates: InstallValidation[];
 
   beforeEach(() => {
     vi.clearAllMocks();
+    validationUpdates = [];
 
-    mockAppWindow = {
-      send: vi.fn(),
-      loadRenderer: vi.fn().mockResolvedValue(null),
-      showOpenDialog: vi.fn(),
-      maximize: vi.fn(),
-    } as unknown as AppWindow;
+    mockAppWindow = createMockAppWindow();
+    manager = new InstallationManager(mockAppWindow, createMockTelemetry());
 
-    mockTelemetry = {
-      track: vi.fn(),
-    } as unknown as ITelemetry;
-
-    manager = new InstallationManager(mockAppWindow, mockTelemetry);
+    // Capture validation updates
+    vi.spyOn(mockAppWindow, 'send').mockImplementation((channel: string, data: unknown) => {
+      if (channel === IPC_CHANNELS.VALIDATION_UPDATE) {
+        validationUpdates.push({ ...(data as InstallValidation) });
+      }
+    });
   });
 
   describe('ensureInstalled', () => {
-    it('should return existing valid installation if one exists', async () => {
-      const mockInstallation = {
-        state: 'installed',
-        validate: vi.fn().mockResolvedValue('installed'),
-        hasIssues: false,
-      };
+    const validInstallation = {
+      state: 'installed',
+      hasIssues: false,
+      isValid: true,
+    } as const;
 
-      vi.spyOn(ComfyInstallation, 'fromConfig').mockReturnValue(mockInstallation as unknown as ComfyInstallation);
+    it('returns existing valid installation', async () => {
+      const mockInstallation = createMockInstallation(validInstallation);
+      vi.spyOn(mockInstallation, 'validate').mockResolvedValue('installed');
+      vi.spyOn(ComfyInstallation, 'fromConfig').mockImplementation(() => mockInstallation);
 
       const result = await manager.ensureInstalled();
 
-      expect(ComfyInstallation.fromConfig).toHaveBeenCalled();
-      expect(mockInstallation.validate).toHaveBeenCalled();
       expect(result).toBe(mockInstallation);
     });
 
-    it('should properly handle validation steps and send updates to renderer', async () => {
-      const validationUpdates: InstallValidation[] = [];
-      const mockInstallation = {
-        state: 'installed',
-        validation: {} as InstallValidation,
-        hasIssues: true,
-        isValid: false,
-        validate: vi.fn().mockImplementation(() => {
-          // Simulate validation steps
-          if (mockInstallation.onUpdate) {
-            mockInstallation.onUpdate({
-              inProgress: true,
-              installState: 'installed',
-              basePath: 'error',
-            });
-
-            mockInstallation.onUpdate({
-              inProgress: true,
-              installState: 'installed',
-              basePath: 'OK',
-              venvDirectory: 'error',
-            });
-
-            mockInstallation.onUpdate({
+    it.each([
+      {
+        scenario: 'validation errors trigger maintenance page',
+        installation: {
+          ...validInstallation,
+          hasIssues: true,
+          isValid: false,
+          validationSteps: commonValidationSteps,
+        },
+        expectMaintenancePage: true,
+      },
+      {
+        scenario: 'no errors skip maintenance page',
+        installation: {
+          ...validInstallation,
+          validationSteps: [
+            {
               inProgress: true,
               installState: 'installed',
               basePath: 'OK',
               venvDirectory: 'OK',
-              pythonInterpreter: 'error',
-            });
-          }
-          return 'installed';
-        }),
-        onUpdate: undefined as ((data: InstallValidation) => void) | undefined,
-      };
-
-      vi.spyOn(ComfyInstallation, 'fromConfig').mockReturnValue(mockInstallation as unknown as ComfyInstallation);
-
-      // Mock resolveIssues to succeed after first attempt
-      vi.spyOn(manager as unknown as { resolveIssues: () => Promise<boolean> }, 'resolveIssues').mockResolvedValueOnce(
-        true
-      );
-
-      // Spy on send to capture validation updates
-      vi.spyOn(mockAppWindow, 'send').mockImplementation((channel: string, data: unknown) => {
-        if (channel === IPC_CHANNELS.VALIDATION_UPDATE) {
-          validationUpdates.push({ ...(data as InstallValidation) });
-        }
-      });
+              pythonInterpreter: 'OK',
+            } satisfies ValidationStep,
+          ],
+        },
+        expectMaintenancePage: false,
+      },
+    ])('$scenario', async ({ installation, expectMaintenancePage }) => {
+      const mockInstallation = createMockInstallation(installation);
+      vi.spyOn(ComfyInstallation, 'fromConfig').mockImplementation(() => mockInstallation);
+      vi.spyOn(
+        manager as unknown as { resolveIssues: (installation: ComfyInstallation) => Promise<boolean> },
+        'resolveIssues'
+      ).mockResolvedValueOnce(true);
 
       await manager.ensureInstalled();
 
-      // Verify validation steps were performed in sequence
-      expect(validationUpdates).toHaveLength(3);
-      expect(validationUpdates[0].basePath).toBe('error');
-      expect(validationUpdates[1].venvDirectory).toBe('error');
-      expect(validationUpdates[2].pythonInterpreter).toBe('error');
+      // Verify validation sequence
+      expect(validationUpdates).toHaveLength(installation.validationSteps?.length ?? 0);
+      if (installation.validationSteps) {
+        for (const [index, expectedStep] of installation.validationSteps.entries()) {
+          const actualStep = validationUpdates[index];
+          for (const [key, value] of Object.entries(expectedStep)) {
+            expect(actualStep[key as keyof InstallValidation]).toBe(value);
+          }
+        }
+      }
 
-      // Verify each update built upon the previous one
-      expect(validationUpdates[1].basePath).toBe('OK');
-      expect(validationUpdates[2].venvDirectory).toBe('OK');
-
-      // Verify resolveIssues was called since there were issues
-      expect(manager['resolveIssues']).toHaveBeenCalledWith(mockInstallation);
-
-      // Verify maintenance page was loaded due to errors
-      expect(mockAppWindow.loadRenderer).toHaveBeenCalledWith('maintenance');
+      // Verify maintenance page behavior
+      if (expectMaintenancePage) {
+        expect(manager['resolveIssues']).toHaveBeenCalledWith(mockInstallation);
+        expect(mockAppWindow.loadRenderer).toHaveBeenCalledWith('maintenance');
+      } else {
+        expect(manager['resolveIssues']).not.toHaveBeenCalled();
+        expect(mockAppWindow.loadRenderer).not.toHaveBeenCalled();
+      }
     });
   });
 });

--- a/tests/unit/install/installationManager.test.ts
+++ b/tests/unit/install/installationManager.test.ts
@@ -88,7 +88,7 @@ const createMockInstallation = (params: {
     isValid,
     validate: vi.fn().mockImplementation(() => {
       // Simulate validation steps
-      if (mockInstallation.onUpdate) {
+      if (mockInstallation?.onUpdate) {
         for (const step of validationSteps) {
           mockInstallation.onUpdate(step as InstallValidation);
         }
@@ -128,12 +128,12 @@ describe('InstallationManager', () => {
       isValid: true,
     } as const;
 
-    it('returns existing valid installation', async () => {
+    it('returns existing valid installation', () => {
       const mockInstallation = createMockInstallation(validInstallation);
       vi.spyOn(mockInstallation, 'validate').mockResolvedValue('installed');
       vi.spyOn(ComfyInstallation, 'fromConfig').mockImplementation(() => mockInstallation);
 
-      const result = await manager.ensureInstalled();
+      const result = manager.ensureInstalled();
 
       expect(result).toBe(mockInstallation);
     });

--- a/tests/unit/install/installationManager.test.ts
+++ b/tests/unit/install/installationManager.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IPC_CHANNELS } from '../../../src/constants';
+import { InstallationManager } from '../../../src/install/installationManager';
+import { AppWindow } from '../../../src/main-process/appWindow';
+import { ComfyInstallation } from '../../../src/main-process/comfyInstallation';
+import type { InstallValidation } from '../../../src/preload';
+import { ITelemetry } from '../../../src/services/telemetry';
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+    handleOnce: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn(),
+  },
+  dialog: {
+    showErrorBox: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/main-process/comfyInstallation');
+vi.mock('../../../src/store/desktopConfig');
+vi.mock('electron-log/main');
+
+describe('InstallationManager', () => {
+  let manager: InstallationManager;
+  let mockAppWindow: AppWindow;
+  let mockTelemetry: ITelemetry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAppWindow = {
+      send: vi.fn(),
+      loadRenderer: vi.fn().mockResolvedValue(null),
+      showOpenDialog: vi.fn(),
+      maximize: vi.fn(),
+    } as unknown as AppWindow;
+
+    mockTelemetry = {
+      track: vi.fn(),
+    } as unknown as ITelemetry;
+
+    manager = new InstallationManager(mockAppWindow, mockTelemetry);
+  });
+
+  describe('ensureInstalled', () => {
+    it('should return existing valid installation if one exists', async () => {
+      const mockInstallation = {
+        state: 'installed',
+        validate: vi.fn().mockResolvedValue('installed'),
+        hasIssues: false,
+      };
+
+      vi.spyOn(ComfyInstallation, 'fromConfig').mockReturnValue(mockInstallation as unknown as ComfyInstallation);
+
+      const result = await manager.ensureInstalled();
+
+      expect(ComfyInstallation.fromConfig).toHaveBeenCalled();
+      expect(mockInstallation.validate).toHaveBeenCalled();
+      expect(result).toBe(mockInstallation);
+    });
+
+    it('should properly handle validation steps and send updates to renderer', async () => {
+      const validationUpdates: InstallValidation[] = [];
+      const mockInstallation = {
+        state: 'installed',
+        validation: {} as InstallValidation,
+        hasIssues: true,
+        isValid: false,
+        validate: vi.fn().mockImplementation(() => {
+          // Simulate validation steps
+          if (mockInstallation.onUpdate) {
+            mockInstallation.onUpdate({
+              inProgress: true,
+              installState: 'installed',
+              basePath: 'error',
+            });
+
+            mockInstallation.onUpdate({
+              inProgress: true,
+              installState: 'installed',
+              basePath: 'OK',
+              venvDirectory: 'error',
+            });
+
+            mockInstallation.onUpdate({
+              inProgress: true,
+              installState: 'installed',
+              basePath: 'OK',
+              venvDirectory: 'OK',
+              pythonInterpreter: 'error',
+            });
+          }
+          return 'installed';
+        }),
+        onUpdate: undefined as ((data: InstallValidation) => void) | undefined,
+      };
+
+      vi.spyOn(ComfyInstallation, 'fromConfig').mockReturnValue(mockInstallation as unknown as ComfyInstallation);
+
+      // Mock resolveIssues to succeed after first attempt
+      vi.spyOn(manager as unknown as { resolveIssues: () => Promise<boolean> }, 'resolveIssues').mockResolvedValueOnce(
+        true
+      );
+
+      // Spy on send to capture validation updates
+      vi.spyOn(mockAppWindow, 'send').mockImplementation((channel: string, data: unknown) => {
+        if (channel === IPC_CHANNELS.VALIDATION_UPDATE) {
+          validationUpdates.push({ ...(data as InstallValidation) });
+        }
+      });
+
+      await manager.ensureInstalled();
+
+      // Verify validation steps were performed in sequence
+      expect(validationUpdates).toHaveLength(3);
+      expect(validationUpdates[0].basePath).toBe('error');
+      expect(validationUpdates[1].venvDirectory).toBe('error');
+      expect(validationUpdates[2].pythonInterpreter).toBe('error');
+
+      // Verify each update built upon the previous one
+      expect(validationUpdates[1].basePath).toBe('OK');
+      expect(validationUpdates[2].venvDirectory).toBe('OK');
+
+      // Verify resolveIssues was called since there were issues
+      expect(manager['resolveIssues']).toHaveBeenCalledWith(mockInstallation);
+
+      // Verify maintenance page was loaded due to errors
+      expect(mockAppWindow.loadRenderer).toHaveBeenCalledWith('maintenance');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds unit tests on installationManager `ensureInstalled` method, testing various installation validation scenarios.

![Selection_809](https://github.com/user-attachments/assets/67030b4c-78d8-438b-803e-ad265bbe213f)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-712-Test-Add-install-validation-unit-tests-1856d73d365081ed9d07eaedacf76a17) by [Unito](https://www.unito.io)
