### PR TITLE
Add UV mirror settings

### DIFF
--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -10,12 +10,16 @@ export const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy.Workflow.WorkflowTabsPosition': 'Topbar',
   'Comfy.Workflow.ShowMissingModelsWarning': true,
   'Comfy.Server.LaunchArgs': {},
+  'Comfy-Desktop.PythonInstallMirror': '',
+  'Comfy-Desktop.PypiInstallMirror': '',
 } as const;
 
 export interface ComfySettingsData {
   'Comfy-Desktop.AutoUpdate': boolean;
   'Comfy-Desktop.SendStatistics': boolean;
   'Comfy.Server.LaunchArgs': Record<string, string>;
+  'Comfy-Desktop.PythonInstallMirror': string;
+  'Comfy-Desktop.PypiInstallMirror': string;
   [key: string]: unknown;
 }
 

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -64,6 +64,8 @@ export class InstallWizard implements HasTelemetry {
       ...existingSettings,
       'Comfy-Desktop.AutoUpdate': this.installOptions.autoUpdate,
       'Comfy-Desktop.SendStatistics': this.installOptions.allowMetrics,
+      'Comfy-Desktop.PythonInstallMirror': this.installOptions.pythonMirror,
+      'Comfy-Desktop.PypiInstallMirror': this.installOptions.pypiMirror,
     };
 
     if (this.installOptions.device === 'cpu') {

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -6,7 +6,6 @@ import path from 'node:path';
 import { graphics } from 'systeminformation';
 
 import { ComfyServerConfig } from '../config/comfyServerConfig';
-import { ComfySettings } from '../config/comfySettings';
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { InstallationManager } from '../install/installationManager';
 import { DownloadManager } from '../models/DownloadManager';
@@ -23,14 +22,15 @@ import { ComfyServer } from './comfyServer';
 
 export class ComfyDesktopApp implements HasTelemetry {
   public comfyServer: ComfyServer | null = null;
-  public comfySettings: ComfySettings;
   private terminal: Terminal | null = null; // Only created after server starts.
   constructor(
     public installation: ComfyInstallation,
     public appWindow: AppWindow,
     readonly telemetry: ITelemetry
-  ) {
-    this.comfySettings = new ComfySettings(installation.basePath);
+  ) {}
+
+  get comfySettings() {
+    return this.installation.comfySettings;
   }
 
   get basePath() {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -26,6 +26,9 @@ export interface InstallOptions {
   migrationItemIds?: string[];
   /** Torch compute device */
   device: TorchDeviceType;
+  /** UV python mirrors */
+  pythonMirror?: string; // UV_PYTHON_INSTALL_MIRROR
+  pypiMirror?: string; // UV_PYPI_INSTALL_MIRROR
 }
 
 export interface SystemPaths {

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -33,6 +33,9 @@ export class VirtualEnvironment implements HasTelemetry {
   readonly comfyUIRequirementsPath: string;
   readonly comfyUIManagerRequirementsPath: string;
   readonly selectedDevice?: string;
+  readonly telemetry: ITelemetry;
+  readonly pythonMirror?: string;
+  readonly pypiMirror?: string;
   uvPty: pty.IPty | undefined;
 
   /** @todo Refactor to `using` */
@@ -51,6 +54,8 @@ export class VirtualEnvironment implements HasTelemetry {
           UV_TOOL_BIN_DIR: this.cacheDir,
           UV_PYTHON_INSTALL_DIR: this.cacheDir,
           VIRTUAL_ENV: this.venvPath,
+          UV_PYTHON_INSTALL_MIRROR: this.pythonMirror,
+          UV_PYPI_INSTALL_MIRROR: this.pypiMirror,
         },
       });
     }
@@ -59,13 +64,26 @@ export class VirtualEnvironment implements HasTelemetry {
 
   constructor(
     venvPath: string,
-    readonly telemetry: ITelemetry,
-    selectedDevice: TorchDeviceType | undefined,
-    pythonVersion: string = '3.12.8'
+    {
+      telemetry,
+      selectedDevice,
+      pythonVersion,
+      pythonMirror,
+      pypiMirror,
+    }: {
+      telemetry: ITelemetry;
+      selectedDevice?: TorchDeviceType;
+      pythonVersion?: string;
+      pythonMirror?: string;
+      pypiMirror?: string;
+    }
   ) {
     this.venvRootPath = venvPath;
-    this.pythonVersion = pythonVersion;
+    this.telemetry = telemetry;
+    this.pythonVersion = pythonVersion ?? '3.12';
     this.selectedDevice = selectedDevice;
+    this.pythonMirror = pythonMirror;
+    this.pypiMirror = pypiMirror;
 
     // uv defaults to .venv
     this.venvPath = path.join(venvPath, '.venv');

--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -83,6 +83,8 @@ describe('ComfySettings', () => {
         'Comfy-Desktop.AutoUpdate': false,
         'Comfy-Desktop.SendStatistics': false,
         'Comfy.Server.LaunchArgs': { test: 'value' },
+        'Comfy-Desktop.PythonInstallMirror': '',
+        'Comfy-Desktop.PypiInstallMirror': '',
       };
 
       vi.mocked(fs.access).mockResolvedValue();


### PR DESCRIPTION
1. Added new settings for Python and PyPI mirrors:
   - Added `PythonInstallMirror` and `PypiInstallMirror` to `DEFAULT_SETTINGS` and `ComfySettingsData` interface
   - These settings allow configuring alternative mirrors for Python and PyPI package installations

2. Refactored `ComfyDesktopApp` and `ComfyInstallation`:
   - Moved `ComfySettings` management from `ComfyDesktopApp` to `ComfyInstallation`
   - Changed `ComfySettings` to be a property in `ComfyDesktopApp`

3. Enhanced `VirtualEnvironment`:
   - Refactored constructor to accept an options object instead of individual parameters
   - Added support for Python and PyPI mirrors through environment variables
   - Updated default Python version handling

4. Updated `InstallWizard` to include mirror settings in the installation options

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-713-Add-UV-mirror-settings-1856d73d3650819d8968cff4212e18e5) by [Unito](https://www.unito.io)
