### PR TITLE
Fix resumed install triggers maintenance screen

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -34,6 +34,7 @@ export class InstallationManager {
     // Resume installation
     if (installation.state === 'started') return await this.resumeInstallation();
 
+    // Validate the installation
     try {
       // Send updates to renderer
       this.#setupIpc(installation);


### PR DESCRIPTION
#### Current

- Resuming an app installation happens during the validation section of the code
- This can briefly display the maintenance screen with error messages

#### Proposed

- Check for unfinished installation prior to wiring up the maintenance IPC
- Early return

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-724-Fix-resumed-install-triggers-maintenance-screen-1856d73d3650816bb861f34c5dcdefdb) by [Unito](https://www.unito.io)
