### PR TITLE
[Dev] Open DevTools before loading the first URL

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -186,8 +186,8 @@ export class AppWindow {
        */
       this.rendererReady = true;
       log.info(`Loading development server ${url}`);
-      await this.window.loadURL(url);
       if (process.env.DEV_TOOLS_AUTO === 'true') this.window.webContents.openDevTools();
+      await this.window.loadURL(url);
     } else {
       const appResourcesPath = getAppResourcesPath();
       const frontendPath = path.join(appResourcesPath, 'ComfyUI', 'web_custom_versions', 'desktop_app');


### PR DESCRIPTION
#### Current

When using a dev server URL, wait for first browser page load to complete before opening DevTools.

#### Proposed

Open DevTools prior to the page loading, enabling diagnostics if somehow the page load blocked.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-725-Dev-Open-DevTools-before-loading-the-first-URL-1856d73d365081638392c1a16bc70550) by [Unito](https://www.unito.io)
