### PR TITLE
[DevExperience] Add @/ root path syntax support

### DIFF
--- a/scripts/resetInstall.js
+++ b/scripts/resetInstall.js
@@ -50,7 +50,7 @@ async function main() {
     if (fs.existsSync(configPath)) {
       const configContent = fs.readFileSync(configPath, 'utf8');
 
-      /** @type {import('../src/store/desktopSettings').DesktopSettings} */
+      /** @type {import('@/store/desktopSettings').DesktopSettings} */
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const parsed = JSON.parse(configContent);
       desktopBasePath = parsed?.basePath;

--- a/tests/unit/comfyConfigManager.test.ts
+++ b/tests/unit/comfyConfigManager.test.ts
@@ -2,7 +2,7 @@ import fs, { type PathLike } from 'node:fs';
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ComfyConfigManager, DirectoryStructure } from '../../src/config/comfyConfigManager';
+import { ComfyConfigManager, DirectoryStructure } from '@/config/comfyConfigManager';
 
 // Workaround for mock impls.
 const { normalize } = path;

--- a/tests/unit/comfyServer.test.ts
+++ b/tests/unit/comfyServer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ComfyServer } from '../../src/main-process/comfyServer';
+import { ComfyServer } from '@/main-process/comfyServer';
 
 describe('ComfyServer', () => {
   describe('buildLaunchArgs', () => {

--- a/tests/unit/comfyServerConfig.test.ts
+++ b/tests/unit/comfyServerConfig.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { ComfyServerConfig } from '../../src/config/comfyServerConfig';
+import { ComfyServerConfig } from '@/config/comfyServerConfig';
 
 vi.mock('electron', () => ({
   app: {

--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ComfySettings, type ComfySettingsData, DEFAULT_SETTINGS } from '../../src/config/comfySettings';
+import { ComfySettings, type ComfySettingsData, DEFAULT_SETTINGS } from '@/config/comfySettings';
 
 vi.mock('electron-log/main', () => ({
   default: {

--- a/tests/unit/handlers/AppHandlers.test.ts
+++ b/tests/unit/handlers/AppHandlers.test.ts
@@ -1,8 +1,8 @@
 import { app, ipcMain } from 'electron';
 import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IPC_CHANNELS } from '../../../src/constants';
-import { registerAppHandlers } from '../../../src/handlers/AppHandlers';
+import { IPC_CHANNELS } from '@/constants';
+import { registerAppHandlers } from '@/handlers/AppHandlers';
 
 vi.mock('electron', () => ({
   app: {

--- a/tests/unit/handlers/appinfoHandlers.test.ts
+++ b/tests/unit/handlers/appinfoHandlers.test.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron';
 import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IPC_CHANNELS } from '../../../src/constants';
-import { registerAppInfoHandlers } from '../../../src/handlers/appInfoHandlers';
+import { IPC_CHANNELS } from '@/constants';
+import { registerAppInfoHandlers } from '@/handlers/appInfoHandlers';
 
 const MOCK_WINDOW_STYLE = 'default';
 const MOCK_GPU_NAME = 'mock-gpu';
@@ -20,7 +20,7 @@ vi.mock('electron', () => ({
   },
 }));
 
-vi.mock('../../../src/store/desktopConfig', () => ({
+vi.mock('@/store/desktopConfig', () => ({
   useDesktopConfig: vi.fn().mockReturnValue({
     get: vi.fn().mockImplementation((key) => {
       if (key === 'basePath') return MOCK_BASE_PATH;
@@ -34,7 +34,7 @@ vi.mock('../../../src/store/desktopConfig', () => ({
   }),
 }));
 
-vi.mock('../../../src/config/comfyServerConfig', () => ({
+vi.mock('@/config/comfyServerConfig', () => ({
   ComfyServerConfig: {
     setBasePathInDefaultConfig: vi.fn().mockReturnValue(Promise.resolve(true)),
   },

--- a/tests/unit/handlers/pathHandler.test.ts
+++ b/tests/unit/handlers/pathHandler.test.ts
@@ -6,11 +6,11 @@ import path from 'node:path';
 import si from 'systeminformation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ComfyConfigManager } from '../../../src/config/comfyConfigManager';
-import { ComfyServerConfig } from '../../../src/config/comfyServerConfig';
-import { IPC_CHANNELS } from '../../../src/constants';
-import { REQUIRED_SPACE, registerPathHandlers } from '../../../src/handlers/pathHandlers';
-import type { SystemPaths } from '../../../src/preload';
+import { ComfyConfigManager } from '@/config/comfyConfigManager';
+import { ComfyServerConfig } from '@/config/comfyServerConfig';
+import { IPC_CHANNELS } from '@/constants';
+import { REQUIRED_SPACE, registerPathHandlers } from '@/handlers/pathHandlers';
+import type { SystemPaths } from '@/preload';
 
 const DEFAULT_FREE_SPACE = 20 * 1024 * 1024 * 1024; // 20GB
 const LOW_FREE_SPACE = 5 * 1024 * 1024 * 1024; // 5GB
@@ -57,14 +57,14 @@ vi.mock('electron', () => {
 
 vi.mock('systeminformation');
 vi.mock('node:fs');
-vi.mock('../../../src/config/comfyServerConfig', () => ({
+vi.mock('@/config/comfyServerConfig', () => ({
   ComfyServerConfig: {
     EXTRA_MODEL_CONFIG_PATH: 'extra_models_config.yaml',
     configPath: '/mock/user/data/extra_models_config.yaml',
   },
 }));
 
-vi.mock('../../../src/config/comfyConfigManager', () => ({
+vi.mock('@/config/comfyConfigManager', () => ({
   ComfyConfigManager: {
     isComfyUIDirectory: vi.fn(),
   },

--- a/tests/unit/install/installationManager.test.ts
+++ b/tests/unit/install/installationManager.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ComfyServerConfig } from '../../../src/config/comfyServerConfig';
-import { IPC_CHANNELS } from '../../../src/constants';
-import { InstallationManager } from '../../../src/install/installationManager';
-import type { AppWindow } from '../../../src/main-process/appWindow';
-import { ComfyInstallation } from '../../../src/main-process/comfyInstallation';
-import type { InstallValidation } from '../../../src/preload';
-import type { ITelemetry } from '../../../src/services/telemetry';
-import * as utils from '../../../src/utils';
+import { ComfyServerConfig } from '@/config/comfyServerConfig';
+import { IPC_CHANNELS } from '@/constants';
+import { InstallationManager } from '@/install/installationManager';
+import type { AppWindow } from '@/main-process/appWindow';
+import { ComfyInstallation } from '@/main-process/comfyInstallation';
+import type { InstallValidation } from '@/preload';
+import type { ITelemetry } from '@/services/telemetry';
+import * as utils from '@/utils';
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -32,11 +32,11 @@ vi.mock('node:fs/promises', () => ({
   rm: vi.fn(),
 }));
 
-vi.mock('../../../src/store/desktopConfig');
+vi.mock('@/store/desktopConfig');
 vi.mock('electron-log/main');
 
-vi.mock('../../../src/utils', async () => {
-  const actual = await vi.importActual<typeof utils>('../../../src/utils');
+vi.mock('@/utils', async () => {
+  const actual = await vi.importActual<typeof utils>('@/utils');
   return {
     ...actual,
     pathAccessible: vi.fn().mockImplementation((path: string) => {
@@ -47,7 +47,7 @@ vi.mock('../../../src/utils', async () => {
   };
 });
 
-vi.mock('../../../src/config/comfyServerConfig', () => {
+vi.mock('@/config/comfyServerConfig', () => {
   return {
     ComfyServerConfig: {
       configPath: 'valid/extra_models_config.yaml',
@@ -61,7 +61,7 @@ vi.mock('../../../src/config/comfyServerConfig', () => {
 });
 
 // Mock VirtualEnvironment with basic implementation
-vi.mock('../../../src/virtualEnvironment', () => {
+vi.mock('@/virtualEnvironment', () => {
   return {
     VirtualEnvironment: vi.fn().mockImplementation(() => ({
       exists: vi.fn().mockResolvedValue(true),

--- a/tests/unit/store/desktopConfig.test.ts
+++ b/tests/unit/store/desktopConfig.test.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DesktopConfig, useDesktopConfig } from '../../../src/store/desktopConfig';
+import { DesktopConfig, useDesktopConfig } from '@/store/desktopConfig';
 
 vi.mock('electron', () => ({
   app: {

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { IPC_CHANNELS } from '../../src/constants';
 import { MixpanelTelemetry, promptMetricsConsent } from '../../src/services/telemetry';
-import { IPC_CHANNELS } from '/src/constants';
 
 vi.mock('electron', () => ({
   app: {

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IPC_CHANNELS } from '../../src/constants';
-import { MixpanelTelemetry, promptMetricsConsent } from '../../src/services/telemetry';
+import { IPC_CHANNELS } from '@/constants';
+import { MixpanelTelemetry, promptMetricsConsent } from '@/services/telemetry';
 
 vi.mock('electron', () => ({
   app: {

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -2,7 +2,7 @@ import type { Systeminformation } from 'systeminformation';
 import si from 'systeminformation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { validateHardware } from '../../src/utils';
+import { validateHardware } from '@/utils';
 
 vi.mock('systeminformation');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "paths": {
-      "/*": ["./*"]
+      "@/*": ["src/*"]
     }
   },
   "exclude": [".history", ".vite", "assets", "dist", "node_modules", "out"],

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -29,5 +29,11 @@ export function getBuildConfig(env: ConfigEnv): UserConfig {
       __COMFYUI_VERSION__: JSON.stringify(pkg.config.comfyVersion),
       __COMFYUI_DESKTOP_VERSION__: JSON.stringify(process.env.npm_package_version),
     },
+
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
   };
 }


### PR DESCRIPTION
Avoids the relative path syntax. Replacing them with `@/`.

Follow-up: cleanup deep relative imports in the codebase.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-729-DevExperience-Add-root-path-syntax-support-1856d73d3650817885ddc1692f272f0c) by [Unito](https://www.unito.io)
