### PR TITLE
Allow app to check the current browser location

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -14,6 +14,7 @@ import {
 import log from 'electron-log/main';
 import Store from 'electron-store';
 import path from 'node:path';
+import { URL } from 'node:url';
 
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { getAppResourcesPath } from '../install/resourcePaths';
@@ -21,7 +22,7 @@ import type { ElectronContextMenuOptions } from '../preload';
 import { AppWindowSettings } from '../store/AppWindowSettings';
 import { useDesktopConfig } from '../store/desktopConfig';
 
-/** A frontend page that can be loaded by the app. */
+/** A frontend page that can be loaded by the app. Must be a valid entry in the frontend router. @see {@link AppWindow.isOnPage} */
 type Page = 'desktop-start' | 'welcome' | 'not-supported' | 'metrics-consent' | 'server-start' | '' | 'maintenance';
 
 /**
@@ -175,6 +176,20 @@ export class AppWindow {
 
   public maximize(): void {
     this.window.maximize();
+  }
+
+  /**
+   * Checks if the window is currently on the specified page by parsing the browser URL.
+   * @param page The frontend route portion of the URL to match against
+   * @returns `true` if the window is currently on the specified page, otherwise `false`
+   */
+  isOnPage(page: Page): boolean {
+    const rawUrl = this.window.webContents.getURL();
+    const url = URL.parse(rawUrl);
+    if (!url) return page === '';
+
+    const prefixedPage = url.protocol === 'file:' ? url.hash : url.pathname;
+    return page === prefixedPage.slice(1);
   }
 
   /**


### PR DESCRIPTION
#### Current

- Classes in the app have no way to determine what page the browser is currently showing
- If we want to ensure we're on a specific page, we need to force navigate to the URL (awful UX, usually resets something)

#### Proposed

- A type-safe check to determine if a page is already the current window URL

#### Alternative

- Save the last requested page: frontend uses redirects, rendering this inaccurate

N.B. Split from larger PR on venv move.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-730-Allow-app-to-check-the-current-browser-location-1856d73d3650813c9cdeec66eb4661f0) by [Unito](https://www.unito.io)
