### PR TITLE
Use node v20 for macos builds

### DIFF
--- a/.github/workflows/debug_macos.yml
+++ b/.github/workflows/debug_macos.yml
@@ -14,10 +14,10 @@ jobs:
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
         shell: bash
-      - name: Use Node.js 22.x
+      - name: Use Node.js 20.x
         uses: JP250552/setup-node@feature/corepack
         with:
-          node-version: '22.x'
+          node-version: '20.x'
           corepack: true
       - run: yarn install
       - name: Build Comfy

--- a/.github/workflows/publish_macos.yml
+++ b/.github/workflows/publish_macos.yml
@@ -21,10 +21,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2 # Where the S3 bucket lives
-      - name: Use Node.js 22.x
+      - name: Use Node.js 20.x
         uses: JP250552/setup-node@feature/corepack
         with:
-          node-version: '22.x'
+          node-version: '20.x'
           corepack: true
       - run: yarn install
       - name: Get package version


### PR DESCRIPTION
Use consistent node version (v20) for all builds.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-734-Use-node-v20-for-macos-builds-1856d73d365081d7abf6f88aced9e1bc) by [Unito](https://www.unito.io)
