### PR TITLE
Add Sentry URL to mixpanel error events

### DIFF
--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -3,6 +3,22 @@ import { app, dialog } from 'electron';
 
 import { SENTRY_URL_ENDPOINT } from '../constants';
 import { ComfyDesktopApp } from '../main-process/comfyDesktopApp';
+import { getTelemetry } from './telemetry';
+
+const createSentryUrl = (eventId: string) =>
+  `https://comfy-org.sentry.io/issues/6245490990/events/${eventId}/?project=4508007940685824`;
+
+const queueMixPanelEvents = (event: Sentry.Event) => {
+  const mixpanel = getTelemetry();
+
+  while (mixpanel.hasPendingSentryEvents()) {
+    const { eventName, properties } = mixpanel.popSentryEvent()!;
+    mixpanel.track(eventName, {
+      sentry_url: createSentryUrl(event.event_id!),
+      ...properties,
+    });
+  }
+};
 
 class SentryLogging {
   comfyDesktopApp: ComfyDesktopApp | undefined;
@@ -16,8 +32,11 @@ class SentryLogging {
         this.filterEvent(event);
 
         if (this.comfyDesktopApp?.comfySettings.get('Comfy-Desktop.SendStatistics')) {
+          queueMixPanelEvents(event);
           return event;
         }
+
+        getTelemetry().clearSentryQueue();
 
         const errorMessage = event.exception?.values?.[0]?.value || 'Unknown error';
         const errorType = event.exception?.values?.[0]?.type || 'Error';

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -5,8 +5,7 @@ import { SENTRY_URL_ENDPOINT } from '../constants';
 import { ComfyDesktopApp } from '../main-process/comfyDesktopApp';
 import { getTelemetry } from './telemetry';
 
-const createSentryUrl = (eventId: string) =>
-  `https://comfy-org.sentry.io/issues/6245490990/events/${eventId}/?project=4508007940685824`;
+const createSentryUrl = (eventId: string) => `https://comfy-org.sentry.io/projects/4508007940685824/events/${eventId}/`;
 
 const queueMixPanelEvents = (event: Sentry.Event) => {
   const mixpanel = getTelemetry();

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/electron/main';
 import { app, ipcMain } from 'electron';
 import log from 'electron-log/main';
 import mixpanel, { PropertyDict } from 'mixpanel';
@@ -21,6 +20,10 @@ export interface ITelemetry {
   track(eventName: string, properties?: PropertyDict): void;
   flush(): void;
   registerHandlers(): void;
+  queueSentryEvent(props: MixPanelEvent): void;
+  popSentryEvent(): MixPanelEvent | undefined;
+  hasPendingSentryEvents(): boolean;
+  clearSentryQueue(): void;
 }
 
 interface GpuInfo {
@@ -29,14 +32,20 @@ interface GpuInfo {
   vram: number | null;
 }
 
+interface MixPanelEvent {
+  eventName: string;
+  properties: Record<string, unknown>;
+}
+
 const MIXPANEL_TOKEN = '6a7f9f6ae2084b4e7ff7ced98a6b5988';
 export class MixpanelTelemetry implements ITelemetry {
   public hasConsent: boolean = false;
   private readonly distinctId: string;
   private readonly storageFile: string;
-  private readonly queue: { eventName: string; properties: PropertyDict }[] = [];
+  private readonly queue: MixPanelEvent[] = [];
   private readonly mixpanelClient: mixpanel.Mixpanel;
   private cachedGpuInfo: GpuInfo[] | null = null;
+  private sentryQueue: MixPanelEvent[] = [];
   constructor(mixpanelClass: mixpanel.Mixpanel) {
     this.mixpanelClient = mixpanelClass.init(MIXPANEL_TOKEN, {
       geolocate: true,
@@ -129,6 +138,22 @@ export class MixpanelTelemetry implements ITelemetry {
     });
   }
 
+  hasPendingSentryEvents() {
+    return this.sentryQueue.length > 0;
+  }
+
+  queueSentryEvent(props: MixPanelEvent) {
+    this.sentryQueue.push(props);
+  }
+
+  popSentryEvent() {
+    return this.sentryQueue.shift();
+  }
+
+  clearSentryQueue() {
+    this.sentryQueue = [];
+  }
+
   /**
    * Fetch GPU information and cache it.
    */
@@ -178,35 +203,6 @@ export interface HasTelemetry {
   telemetry: ITelemetry;
 }
 
-function formatLogLine(line: string): string {
-  try {
-    // Match the timestamp and log level pattern
-    const logPattern = /\[\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}]\s\[(debug|info|error|warn)]\s+/;
-
-    // Remove timestamp and level prefix, trim whitespace
-    return line.replace(logPattern, '').trim();
-  } catch {
-    return line.trim();
-  }
-}
-
-function getLastLogLines(numberOfLines: number = 10): string {
-  try {
-    const logFile = log.transports.file.getFile();
-    const content = fs.readFileSync(logFile.path, 'utf8');
-
-    const lines = content
-      .split('\n')
-      .filter((line) => line.trim() !== '')
-      .slice(-numberOfLines);
-
-    return lines.map((line) => formatLogLine(line)).join(String.raw`\n`);
-  } catch (error) {
-    log.error('Failed to read log file:', error);
-    return '';
-  }
-}
-
 /**
  * Decorator to track the start, error, and end of a function.
  * @param eventName
@@ -231,17 +227,14 @@ export function trackEvent(eventName: string) {
           .then(() => {
             this.telemetry.track(`${eventName}_end`);
           })
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-          .catch((error: any) => {
-            const eventId = Sentry.captureException(error);
-            this.telemetry.track(`${eventName}_error`, {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-              error_message: error.message,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-              error_name: error.name,
-              sentry_event_id: eventId,
-              sentry_url: `https://comfy-org.sentry.io/issues/6245490990/events/${eventId}/?project=4508007940685824`,
-              log_tail: getLastLogLines(32),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          .catch((error: Error) => {
+            this.telemetry.queueSentryEvent({
+              eventName: `${eventName}_error`,
+              properties: {
+                error_message: error.message,
+                error_name: error.name,
+              },
             });
             throw error;
           })


### PR DESCRIPTION
All reports are opt-in by the user and done only with consent.

On Mixpanel error events, add event to `sentryQueue` then throw. When Sentry captures the thrown error, it generates the sentry event ID and adds the associated URL to all events in queue (multiple when there is a nested mixpanel scope). Sentry class then flushes the enriched events back to Mixpanel's `queue` for normal processing.

![Selection_818](https://github.com/user-attachments/assets/a9501505-10cd-4adc-9d6d-4502d81a7711)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-739-Add-Sentry-URL-to-mixpanel-error-events-1866d73d3650813f9c80f5e74c920a04) by [Unito](https://www.unito.io)
