### PR TITLE
[Cleanup] Remove unused API endpoint isFirstTimeSetup

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,6 @@ export const IPC_CHANNELS = {
   TERMINAL_RESIZE: 'resize-terminal',
   TERMINAL_RESTORE: 'restore-terminal',
   TERMINAL_ON_OUTPUT: 'terminal-output',
-  IS_FIRST_TIME_SETUP: 'is-first-time-setup',
   GET_SYSTEM_PATHS: 'get-system-paths',
   VALIDATE_INSTALL_PATH: 'validate-install-path',
   VALIDATE_COMFYUI_SOURCE: 'validate-comfyui-source',

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -5,7 +5,6 @@ import log from 'electron-log/main';
 import path from 'node:path';
 import { graphics } from 'systeminformation';
 
-import { ComfyServerConfig } from '../config/comfyServerConfig';
 import { IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { InstallationManager } from '../install/installationManager';
 import { DownloadManager } from '../models/DownloadManager';
@@ -117,9 +116,6 @@ export class ComfyDesktopApp implements HasTelemetry {
         }
       }
     );
-    ipcMain.handle(IPC_CHANNELS.IS_FIRST_TIME_SETUP, () => {
-      return !ComfyServerConfig.exists();
-    });
 
     // Replace the reinstall IPC handler.
     ipcMain.removeHandler(IPC_CHANNELS.REINSTALL);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -249,12 +249,6 @@ const electronAPI = {
     },
   },
   /**
-   * Check if the user has completed the first time setup wizard.
-   */
-  isFirstTimeSetup: (): Promise<boolean> => {
-    return ipcRenderer.invoke(IPC_CHANNELS.IS_FIRST_TIME_SETUP);
-  },
-  /**
    * Get the system paths for the application.
    */
   getSystemPaths: (): Promise<SystemPaths> => {


### PR DESCRIPTION
The check `!ComfyServerConfig.exists()` is now invalid after the install process changes. Removing this api endpoint now as it is unused in the frontend.