### PR TITLE
Support using custom torch pip mirror

### DIFF
--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy.Server.LaunchArgs': {},
   'Comfy-Desktop.PythonInstallMirror': '',
   'Comfy-Desktop.PypiInstallMirror': '',
+  'Comfy-Desktop.TorchInstallMirror': '',
 } as const;
 
 export interface ComfySettingsData {
@@ -20,6 +21,7 @@ export interface ComfySettingsData {
   'Comfy.Server.LaunchArgs': Record<string, string>;
   'Comfy-Desktop.PythonInstallMirror': string;
   'Comfy-Desktop.PypiInstallMirror': string;
+  'Comfy-Desktop.TorchInstallMirror': string;
   [key: string]: unknown;
 }
 

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -66,6 +66,7 @@ export class InstallWizard implements HasTelemetry {
       'Comfy-Desktop.SendStatistics': this.installOptions.allowMetrics,
       'Comfy-Desktop.PythonInstallMirror': this.installOptions.pythonMirror,
       'Comfy-Desktop.PypiInstallMirror': this.installOptions.pypiMirror,
+      'Comfy-Desktop.TorchInstallMirror': this.installOptions.torchMirror,
     };
 
     if (this.installOptions.device === 'cpu') {

--- a/src/main-process/comfyInstallation.ts
+++ b/src/main-process/comfyInstallation.ts
@@ -71,6 +71,7 @@ export class ComfyInstallation {
       selectedDevice: this.device,
       pythonMirror: this.comfySettings.get('Comfy-Desktop.PythonInstallMirror'),
       pypiMirror: this.comfySettings.get('Comfy-Desktop.PypiInstallMirror'),
+      torchMirror: this.comfySettings.get('Comfy-Desktop.TorchInstallMirror'),
     });
   }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -26,9 +26,11 @@ export interface InstallOptions {
   migrationItemIds?: string[];
   /** Torch compute device */
   device: TorchDeviceType;
-  /** UV python mirrors */
+  /** UV python mirror */
   pythonMirror?: string; // UV_PYTHON_INSTALL_MIRROR
-  pypiMirror?: string; // UV_PYPI_INSTALL_MIRROR
+  /** pip mirrors */
+  pypiMirror?: string; // Common pip install mirror
+  torchMirror?: string; // Torch install mirror
 }
 
 export interface SystemPaths {

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -100,6 +100,7 @@ export class VirtualEnvironment implements HasTelemetry {
   readonly telemetry: ITelemetry;
   readonly pythonMirror?: string;
   readonly pypiMirror?: string;
+  readonly torchMirror?: string;
   uvPty: pty.IPty | undefined;
 
   /** @todo Refactor to `using` */
@@ -138,12 +139,14 @@ export class VirtualEnvironment implements HasTelemetry {
       pythonVersion,
       pythonMirror,
       pypiMirror,
+      torchMirror,
     }: {
       telemetry: ITelemetry;
       selectedDevice?: TorchDeviceType;
       pythonVersion?: string;
       pythonMirror?: string;
       pypiMirror?: string;
+      torchMirror?: string;
     }
   ) {
     this.venvRootPath = venvPath;
@@ -152,6 +155,7 @@ export class VirtualEnvironment implements HasTelemetry {
     this.selectedDevice = selectedDevice ?? 'cpu';
     this.pythonMirror = pythonMirror;
     this.pypiMirror = pypiMirror;
+    this.torchMirror = torchMirror;
 
     // uv defaults to .venv
     this.venvPath = path.join(venvPath, '.venv');
@@ -453,6 +457,9 @@ export class VirtualEnvironment implements HasTelemetry {
 
   async installPytorch(callbacks?: ProcessCallbacks): Promise<void> {
     const config = getPyTorchConfig(this.selectedDevice, process.platform);
+    if (this.torchMirror) {
+      config.indexUrl = this.torchMirror;
+    }
     const installArgs = getPyTorchInstallArgs(config);
 
     log.info(`Installing PyTorch with config: ${JSON.stringify(config)}`);

--- a/tests/unit/comfySettings.test.ts
+++ b/tests/unit/comfySettings.test.ts
@@ -85,6 +85,7 @@ describe('ComfySettings', () => {
         'Comfy.Server.LaunchArgs': { test: 'value' },
         'Comfy-Desktop.PythonInstallMirror': '',
         'Comfy-Desktop.PypiInstallMirror': '',
+        'Comfy-Desktop.TorchInstallMirror': '',
       };
 
       vi.mocked(fs.access).mockResolvedValue();


### PR DESCRIPTION
This PR allows frontend specify a torch mirror url for torch installation.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-743-Support-using-custom-torch-pip-mirror-1876d73d36508195b1bbf3e388764bb1) by [Unito](https://www.unito.io)
