### PR TITLE
[Test] Fix installationManager test on Windows

### DIFF
--- a/tests/unit/install/installationManager.test.ts
+++ b/tests/unit/install/installationManager.test.ts
@@ -28,7 +28,8 @@ vi.mock('@/utils', async () => {
   return {
     ...actual,
     pathAccessible: vi.fn().mockImplementation((path: string) => {
-      return Promise.resolve(path.startsWith('valid/'));
+      const isValid = path.startsWith('valid/') || path.endsWith(`\\System32\\vcruntime140.dll`);
+      return Promise.resolve(isValid);
     }),
     canExecute: vi.fn().mockResolvedValue(true),
     canExecuteShellCommand: vi.fn().mockResolvedValue(true),


### PR DESCRIPTION
Automatically bypasses the VC++ redist test in Windows unit tests.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-749-Test-Fix-installationManager-test-on-Windows-1896d73d365081149887ca691b6f4849) by [Unito](https://www.unito.io)
