### PR TITLE
Extract hardcoded torch install URL to global constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,3 +124,6 @@ export enum DownloadStatus {
   ERROR = 'error',
   CANCELLED = 'cancelled',
 }
+
+export const CUDA_TORCH_URL = 'https://download.pytorch.org/whl/cu124';
+export const NIGHTLY_CPU_TORCH_URL = 'https://download.pytorch.org/whl/nightly/cpu';

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -6,6 +6,7 @@ import { rm } from 'node:fs/promises';
 import os, { EOL } from 'node:os';
 import path from 'node:path';
 
+import { CUDA_TORCH_URL, NIGHTLY_CPU_TORCH_URL } from './constants';
 import type { TorchDeviceType } from './preload';
 import { HasTelemetry, ITelemetry, trackEvent } from './services/telemetry';
 import { getDefaultShell } from './shell/util';
@@ -40,7 +41,7 @@ export function getPyTorchConfig(selectedDevice: TorchDeviceType, platform: stri
   if (selectedDevice === 'nvidia' || platform === 'win32') {
     return {
       packages: basePackages,
-      indexUrl: 'https://download.pytorch.org/whl/cu124',
+      indexUrl: CUDA_TORCH_URL,
     };
   }
 
@@ -48,7 +49,7 @@ export function getPyTorchConfig(selectedDevice: TorchDeviceType, platform: stri
   if (selectedDevice === 'mps' || platform === 'darwin') {
     return {
       packages: basePackages,
-      extraIndexUrl: 'https://download.pytorch.org/whl/nightly/cpu',
+      extraIndexUrl: NIGHTLY_CPU_TORCH_URL,
       prerelease: true,
       upgradePackages: true,
     };


### PR DESCRIPTION
For frontend display purpose.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-752-Extract-hardcoded-torch-install-URL-to-global-constants-1896d73d365081a3b054e2126688c052) by [Unito](https://www.unito.io)
