### PR TITLE
Fix install packages loop

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -530,7 +530,7 @@ export class VirtualEnvironment implements HasTelemetry {
       onStdout: (data) => (output += data.toString()),
       onStderr: (data) => (output += data.toString()),
     };
-    const result = await this.runCommandAsync(this.uvPath, args, { PYTHONIOENCODING: 'utf8' }, callbacks);
+    const result = await this.runCommandAsync(this.uvPath, args, { VIRTUAL_ENV: this.venvPath }, callbacks);
 
     if (result.exitCode !== 0)
       throw new Error(`Failed to get packages: Exit code ${result.exitCode}, signal ${result.signal}`);


### PR DESCRIPTION
#### Current

If user runs the app with the VIRTUAL_ENV var set, the maintenance task to check installed python packages will use that venv.

#### Proposed

Use explicit env var to override user env vars.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-755-Fix-install-packages-loop-1896d73d365081669092fa9e826d499c) by [Unito](https://www.unito.io)
