### PR TITLE
Use draft instead of publish for release builds

### DIFF
--- a/.github/workflows/publish_all.yml
+++ b/.github/workflows/publish_all.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   build-todesktop:


### PR DESCRIPTION
Sets the workflow to use draft instead of publish for release builds. Allows the build to be tested before being made public.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-758-Use-draft-instead-of-publish-for-release-builds-18a6d73d365081148b96daff27d938ec) by [Unito](https://www.unito.io)
