### PR TITLE
[Cleanup] Installation manager refactor / clean up

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -181,6 +181,12 @@ export class InstallationManager {
     useDesktopConfig().set('versionConsentedMetrics', __COMFYUI_DESKTOP_VERSION__);
     useDesktopConfig().set('selectedDevice', device);
 
+    // Load the next page
+    const page = device === 'unsupported' ? 'not-supported' : 'server-start';
+    if (!this.appWindow.isOnPage(page)) {
+      await this.appWindow.loadPage(page);
+    }
+
     // Creates folders and initializes ComfyUI settings
     const installWizard = new InstallWizard(installOptions, this.telemetry);
     await installWizard.install();
@@ -190,12 +196,6 @@ export class InstallationManager {
       !!installWizard.migrationSource && installWizard.migrationItemIds.has('custom_nodes');
     if (shouldMigrateCustomNodes) {
       useDesktopConfig().set('migrateCustomNodesFrom', installWizard.migrationSource);
-    }
-
-    // Load the next page
-    const page = device === 'unsupported' ? 'not-supported' : 'server-start';
-    if (!this.appWindow.isOnPage(page)) {
-      await this.appWindow.loadPage(page);
     }
 
     const installation = new ComfyInstallation('installed', installWizard.basePath, this.telemetry, device);


### PR DESCRIPTION
- Moves page load earlier
- Saves settings to config.json earlier
- nits

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-762-Cleanup-Installation-manager-refactor-clean-up-18a6d73d365081a5af56ef272f1c7284) by [Unito](https://www.unito.io)
