### PR TITLE
Fix cannot install - unable to run uv commands

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -125,7 +125,7 @@ export class VirtualEnvironment implements HasTelemetry {
       VIRTUAL_ENV: this.venvPath,
       // Empty strings are not valid values for these env vars,
       // dropping them here to avoid passing them to uv.
-      UV_PYTHON_INSTALL_MIRROR: this.pythonMirror || undefined,
+      ...(this.pythonMirror ? { UV_PYTHON_INSTALL_MIRROR: this.pythonMirror } : {}),
     };
 
     if (!this.uvPty) {


### PR DESCRIPTION
Setting uv mirror to undefined causes it to set the environment var as an empty string.  All uv commands fail in prod tests.

Spread empty object instead.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-763-Fix-uv-blocks-install-and-maintenance-tasks-18a6d73d365081bb9979f15d80cb7ebd) by [Unito](https://www.unito.io)
