### PR TITLE
Use 'started' installation state when installing

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -198,10 +198,8 @@ export class InstallationManager {
       useDesktopConfig().set('migrateCustomNodesFrom', installWizard.migrationSource);
     }
 
-    const installation = new ComfyInstallation('installed', installWizard.basePath, this.telemetry, device);
+    const installation = new ComfyInstallation('started', installWizard.basePath, this.telemetry, device);
     const { virtualEnvironment } = installation;
-
-    installation.setState('installed');
 
     // Virtual terminal output callbacks
     const processCallbacks: ProcessCallbacks = {
@@ -229,6 +227,7 @@ export class InstallationManager {
       }).show();
     }
 
+    installation.setState('installed');
     return installation;
   }
 


### PR DESCRIPTION
Correctly sets 'started' installation state in `ComfyInstallation` prior to installing the virtual environment.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-764-Use-started-installation-state-when-installing-18a6d73d36508164b632e954861fb2f6) by [Unito](https://www.unito.io)
