### PR TITLE
Add maintenance task logging

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -96,7 +96,10 @@ export class InstallationManager {
         });
       }
     };
-    const sendLogIpc = (data: string) => this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
+    const sendLogIpc = (data: string) => {
+      log.info(data);
+      this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);
+    };
 
     ipcMain.handle(IPC_CHANNELS.GET_VALIDATION_STATE, () => {
       installation.onUpdate?.(installation.validation);

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -596,7 +596,8 @@ export class VirtualEnvironment implements HasTelemetry {
     try {
       await this.#using(() => this.ensurePip(callbacks));
       return true;
-    } catch {
+    } catch (error) {
+      log.error('Failed to upgrade pip:', error);
       return false;
     }
   }
@@ -610,7 +611,8 @@ export class VirtualEnvironment implements HasTelemetry {
       const callbacks: ProcessCallbacks = { onStdout: onData };
       await this.#using(() => this.createVenvWithPython(callbacks));
       return true;
-    } catch {
+    } catch (error) {
+      log.error('Failed to create virtual environment:', error);
       return false;
     }
   }


### PR DESCRIPTION
Adds logging to maintenance task wrappers.

N.B. These duplicate methods will be removed when #765 is resolved.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-766-Add-maintenance-task-logging-18a6d73d36508196bd96c956f49c4e6f) by [Unito](https://www.unito.io)
