### PR TITLE
Fix pip prerelease install

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -67,7 +67,7 @@ function getPipInstallArgs(config: PipInstallConfig): string[] {
   }
 
   if (config.prerelease) {
-    installArgs.push('--prerelease', 'allow');
+    installArgs.push('--pre');
   }
 
   if (config.requirementsFile) {


### PR DESCRIPTION
`--prerelease` is not a valid pip argument.

Ref:
- https://stackoverflow.com/questions/35131861/what-does-the-pre-option-in-pip-signify
- ![Screenshot 2025-01-29 at 10 34 43 AM](https://github.com/user-attachments/assets/a29475f3-a7a0-4d79-bd35-27d2c3f22e2a)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-767-Fix-pip-prerelease-install-18a6d73d3650814b8e61fb179a08514c) by [Unito](https://www.unito.io)
