### PR TITLE
Fix maintenance page refresh broken

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -215,6 +215,9 @@ export class AppWindow {
       if (process.env.DEV_TOOLS_AUTO === 'true') this.window.webContents.openDevTools();
       await this.window.loadURL(url);
     } else {
+      // TODO: Remove this temporary workaround when RENDERER_READY is reworked.
+      if (page === 'maintenance') this.rendererReady = true;
+
       const appResourcesPath = getAppResourcesPath();
       const frontendPath = path.join(appResourcesPath, 'ComfyUI', 'web_custom_versions', 'desktop_app');
       try {


### PR DESCRIPTION
Forces the message queue to empty when loading the maintenance page, as it handles this itself.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-780-Fix-maintenance-page-refresh-broken-18a6d73d365081fe9bc5c7e6ba0b1e9c) by [Unito](https://www.unito.io)
