### PR TITLE
Use --base-directory in ComfyUI to resolve model import issues.

### DIFF
--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -254,8 +254,10 @@ export class ComfyServerConfig {
     }
 
     if (!parsedConfig.desktop_patch) {
+      const customNodesPath = path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes');
+      log.info(`Adding custom node extra_path to config ${customNodesPath}`);
       parsedConfig.desktop_patch = {};
-      parsedConfig.desktop_patch.custom_nodes = path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes');
+      parsedConfig.desktop_patch.custom_nodes = customNodesPath;
       const stringified = ComfyServerConfig.generateConfigFileContent(parsedConfig);
       await ComfyServerConfig.writeConfigFile(ComfyServerConfig.configPath, stringified);
     }

--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -252,10 +252,10 @@ export class ComfyServerConfig {
       return;
     }
 
-    if (!parsedConfig.desktop_patch) {
+    if (!parsedConfig.desktop_extensions) {
       const customNodesPath = path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes');
       log.info(`Adding custom node extra_path to config ${customNodesPath}`);
-      parsedConfig.desktop_patch = { custom_nodes: customNodesPath };
+      parsedConfig.desktop_extensions = { custom_nodes: customNodesPath };
       const stringified = ComfyServerConfig.generateConfigFileContent(parsedConfig);
       await ComfyServerConfig.writeConfigFile(ComfyServerConfig.configPath, stringified);
     }

--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -78,7 +78,6 @@ export class ComfyServerConfig {
   static readonly EXTRA_MODEL_CONFIG_PATH = 'extra_models_config.yaml';
 
   private static readonly commonPaths = {
-    ...this.getBaseModelPathsFromRepoPath(''),
     custom_nodes: path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes'),
     download_model_base: 'models',
   };

--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -5,6 +5,8 @@ import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import yaml, { type YAMLParseError } from 'yaml';
 
+import { getAppResourcesPath } from '@/install/resourcePaths';
+
 const knownModelKeys = [
   'checkpoints',
   'classifiers',
@@ -77,7 +79,7 @@ export class ComfyServerConfig {
 
   private static readonly commonPaths = {
     ...this.getBaseModelPathsFromRepoPath(''),
-    custom_nodes: 'custom_nodes/',
+    custom_nodes: path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes'),
     download_model_base: 'models',
   };
   private static readonly configTemplates: Record<string, ModelPaths> = {
@@ -238,5 +240,24 @@ export class ComfyServerConfig {
     const stringified = ComfyServerConfig.generateConfigFileContent(parsedConfig);
 
     return await ComfyServerConfig.writeConfigFile(ComfyServerConfig.configPath, stringified);
+  }
+
+  /**
+   * Patches extra_model_config.yaml to include the custom nodes bundled with the app (eg. ComfyUI-Manager).
+   * @returns
+   */
+  public static async addAppBundledCustomNodesToConfig(): Promise<void> {
+    const parsedConfig = await ComfyServerConfig.readConfigFile(ComfyServerConfig.configPath);
+    if (parsedConfig === null) {
+      log.error('Failed to read config file');
+      return;
+    }
+
+    if (!parsedConfig.desktop_patch) {
+      parsedConfig.desktop_patch = {};
+      parsedConfig.desktop_patch.custom_nodes = path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes');
+      const stringified = ComfyServerConfig.generateConfigFileContent(parsedConfig);
+      await ComfyServerConfig.writeConfigFile(ComfyServerConfig.configPath, stringified);
+    }
   }
 }

--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -255,8 +255,7 @@ export class ComfyServerConfig {
     if (!parsedConfig.desktop_patch) {
       const customNodesPath = path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes');
       log.info(`Adding custom node extra_path to config ${customNodesPath}`);
-      parsedConfig.desktop_patch = {};
-      parsedConfig.desktop_patch.custom_nodes = customNodesPath;
+      parsedConfig.desktop_patch = { custom_nodes: customNodesPath };
       const stringified = ComfyServerConfig.generateConfigFileContent(parsedConfig);
       await ComfyServerConfig.writeConfigFile(ComfyServerConfig.configPath, stringified);
     }

--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -77,6 +77,7 @@ export class ComfyServer implements HasTelemetry {
       'input-directory': this.inputDirectoryPath,
       'output-directory': this.outputDirectoryPath,
       'front-end-root': this.webRootPath,
+      'base-directory': this.basePath,
       'extra-model-paths-config': ComfyServerConfig.configPath,
       port: this.serverArgs.port.toString(),
       listen: this.serverArgs.host,
@@ -103,6 +104,7 @@ export class ComfyServer implements HasTelemetry {
   @trackEvent('comfyui:server_start')
   async start() {
     ComfySettings.lockWrites();
+    await ComfyServerConfig.addAppBundledCustomNodesToConfig();
     await rotateLogFiles(app.getPath('logs'), 'comfyui', 50);
     return new Promise<void>((resolve, reject) => {
       const comfyUILog = log.create({ logId: 'comfyui' });

--- a/tests/unit/comfyServer.test.ts
+++ b/tests/unit/comfyServer.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { ComfyServer } from '@/main-process/comfyServer';
+
+vi.mock('@/install/resourcePaths', () => ({
+  getAppResourcesPath: vi.fn().mockReturnValue('/mocked/app_resources'),
+}));
 
 describe('ComfyServer', () => {
   describe('buildLaunchArgs', () => {

--- a/tests/unit/comfyServerConfig.test.ts
+++ b/tests/unit/comfyServerConfig.test.ts
@@ -22,6 +22,10 @@ vi.mock('electron-log/main', () => ({
   },
 }));
 
+vi.mock('@/install/resourcePaths', () => ({
+  getAppResourcesPath: vi.fn().mockReturnValue('/mocked/app_resources'),
+}));
+
 async function createTmpDir() {
   const prefix = path.join(tmpdir(), 'vitest-');
   return mkdtemp(prefix);
@@ -207,7 +211,7 @@ describe('ComfyServerConfig', () => {
 
       expect(platformConfig.checkpoints).toContain(path.join('models', 'checkpoints'));
       expect(platformConfig.loras).toContain(path.join('models', 'loras'));
-      expect(platformConfig.custom_nodes).toBe('custom_nodes/');
+      expect(platformConfig.custom_nodes).toBe('/mocked/app_resources/ComfyUI/custom_nodes');
       expect(platformConfig.is_default).toBe('true');
     });
 

--- a/tests/unit/comfyServerConfig.test.ts
+++ b/tests/unit/comfyServerConfig.test.ts
@@ -209,8 +209,6 @@ describe('ComfyServerConfig', () => {
       Object.defineProperty(process, 'platform', { value: platform });
       const platformConfig = ComfyServerConfig.getBaseConfig();
 
-      expect(platformConfig.checkpoints).toContain(path.join('models', 'checkpoints'));
-      expect(platformConfig.loras).toContain(path.join('models', 'loras'));
       expect(platformConfig.custom_nodes).toBe('/mocked/app_resources/ComfyUI/custom_nodes');
       expect(platformConfig.is_default).toBe('true');
     });


### PR DESCRIPTION
Since `--base-directory` was added to core, we can utilize that to avoid adding so many paths in `extra_model_config.yaml`. Most custom nodes utilize the `model_dir` in folder paths to add their own model directories. 

This PR changes:
- Add base_directory argument when starting ComfyUI to the base_path of the desktop application
- Remove model extra paths from the default newly created extra_model_config.yaml
- Add additional custom_nodes mapping so Manager will be added from the app resource folder, which is bundled with the application

```
desktop_patch:
    custom_nodes: /...app resources folder
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-782-Use-base-directory-in-ComfyUI-to-resolve-model-import-issues-18b6d73d365081119102c71e8c4675fe) by [Unito](https://www.unito.io)
