### PR TITLE
Disable unicorn optimisation rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,7 @@ export default tseslint.config(
       'unicorn/prevent-abbreviations': 'off',
       'unicorn/switch-case-braces': 'off',
       'unicorn/explicit-length-check': 'off',
+      'unicorn/consistent-function-scoping': 'off',
     },
   },
 


### PR DESCRIPTION
This rule is currently counterproductive for this repo.  It provides no detectable performance gain, but requires distancing even minute functions from the calling code.

Prefer maintainability in this instance.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-783-Disable-unicorn-optimisation-rule-18b6d73d36508124b255fd0efcae5332) by [Unito](https://www.unito.io)
