### PR TITLE
Revert explicit null return - prefer language defaults

### DIFF
--- a/src/main-process/comfyInstallation.ts
+++ b/src/main-process/comfyInstallation.ts
@@ -74,7 +74,7 @@ export class ComfyInstallation {
    * @returns A ComfyInstallation (not validated) object if config is saved, otherwise `undefined`.
    * @throws If YAML config is unreadable due to access restrictions
    */
-  static async fromConfig(): Promise<ComfyInstallation | null> {
+  static async fromConfig(): Promise<ComfyInstallation | undefined> {
     const config = useDesktopConfig();
     const state = config.get('installState');
     const basePath = config.get('basePath');
@@ -82,8 +82,6 @@ export class ComfyInstallation {
       const comfySettings = new ComfySettings(basePath);
       await comfySettings.loadSettings();
       return new ComfyInstallation(state, basePath, getTelemetry(), comfySettings);
-    } else {
-      return null;
     }
   }
 


### PR DESCRIPTION
#770 changes undefined type to null.  This change reverts to language standard return pattern of undefined when a match is not found.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-787-Revert-explicit-null-return-prefer-language-defaults-18b6d73d36508180b9fdca40d4277796) by [Unito](https://www.unito.io)
