### PR TITLE
[chore] Update frontend to 1.8.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.8.11",
+    "frontendVersion": "1.8.12",
     "comfyVersion": "0.3.13",
     "managerCommit": "b4e52e65ec87978fc6294e82d55e1b91c5b02d55",
     "uvVersion": "0.5.11"

--- a/scripts/updateFrontend.js
+++ b/scripts/updateFrontend.js
@@ -30,8 +30,9 @@ async function main() {
 
     // Create the PR
     console.log('Creating PR...');
+    const prBody = `Automated frontend update to ${version}: https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v${version}`;
     execSync(
-      `gh pr create --title "[chore] Update frontend to ${version}" --label "dependencies" --body "Automated frontend update to ${version}"`,
+      `gh pr create --title "[chore] Update frontend to ${version}" --label "dependencies" --body "${prBody}"`,
       { stdio: 'inherit' }
     );
 


### PR DESCRIPTION
Automated frontend update to 1.8.12: https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.8.12

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-790-chore-Update-frontend-to-1-8-12-18c6d73d36508127928df4e289b99e88) by [Unito](https://www.unito.io)
