### PR TITLE
Fix API TS return type

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -415,7 +415,7 @@ const electronAPI = {
      * Install the requirements for the ComfyUI server.
      * @returns A promise that resolves when the uv command is complete.
      */
-    installRequirements: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.UV_INSTALL_REQUIREMENTS),
+    installRequirements: (): Promise<boolean> => ipcRenderer.invoke(IPC_CHANNELS.UV_INSTALL_REQUIREMENTS),
 
     /**
      * Clears the uv cache of all downloaded packages.


### PR DESCRIPTION
Fixes TS type in API - currently void, should be boolean.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-792-Fix-API-TS-return-type-18c6d73d3650817a8311cc777166e566) by [Unito](https://www.unito.io)
