### PR TITLE
Increase normalize depth limit in Sentry options

### DIFF
--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -27,6 +27,7 @@ class SentryLogging {
       dsn: SENTRY_URL_ENDPOINT,
       autoSessionTracking: false,
       enabled: process.env.SENTRY_ENABLED === 'true' || app.isPackaged,
+      normalizeDepth: 3,
       beforeSend: async (event) => {
         this.filterEvent(event);
 


### PR DESCRIPTION
Increases the normalize depth limit in Sentry options. The default depth limit results in the `gpu` field being normalized:

![Screenshot 2025-01-31 201512](https://github.com/user-attachments/assets/50805ed7-22b1-4491-8339-d13151d5316d)
