### PR TITLE
[Refactor] Shared app state object & declarative abstraction

### DIFF
--- a/src/main-process/appState.ts
+++ b/src/main-process/appState.ts
@@ -1,0 +1,25 @@
+import { app } from 'electron';
+
+/**
+ * Stores global state for the app.
+ *
+ * @see {@link AppState}
+ */
+export interface IAppState {
+  /** Whether the app is already quitting. */
+  readonly isQuitting: boolean;
+}
+
+/**
+ * Concrete implementation of {@link IAppState}.
+ */
+export class AppState implements IAppState {
+  isQuitting = false;
+
+  constructor() {
+    // Store quitting state - suppresses errors when already quitting
+    app.once('before-quit', () => {
+      this.isQuitting = true;
+    });
+  }
+}


### PR DESCRIPTION
- Adds AppState object to house shared app state
- Initial impl. only handles the isQuitting value
- Minor refactor to more declarative code

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-796-Refactor-Shared-app-state-object-declarative-abstraction-18d6d73d3650819cb10ddbd520e5fcd6) by [Unito](https://www.unito.io)
