### PR TITLE
Fixed: missing mock for unit test on MacOS.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.yarn/releases/*    binary
 /.yarn/plugins/**/*  binary
 /.pnp.*              binary linguist-generated
+* text=auto eol=lf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   lint-and-format:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/unit/main-process/appWindow.test.ts
+++ b/tests/unit/main-process/appWindow.test.ts
@@ -23,6 +23,7 @@ vi.mock('electron', () => ({
   },
   Tray: vi.fn(() => ({
     setContextMenu: vi.fn(),
+    setPressedImage: vi.fn(),
     setToolTip: vi.fn(),
     on: vi.fn(),
   })),


### PR DESCRIPTION
Was missing a mock for a function that was only hit on macos.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-804-Fixed-missing-mock-for-unit-test-on-MacOS-18f6d73d365081cfb28ae13774c2c82a) by [Unito](https://www.unito.io)
