### PR TITLE
Remove unused API code

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,6 @@ export const IPC_CHANNELS = {
   REINSTALL: 'reinstall',
   QUIT: 'quit',
   LOG_MESSAGE: 'log-message',
-  OPEN_DIALOG: 'open-dialog',
   DOWNLOAD_PROGRESS: 'download-progress',
   START_DOWNLOAD: 'start-download',
   PAUSE_DOWNLOAD: 'pause-download',

--- a/src/desktopApp.ts
+++ b/src/desktopApp.ts
@@ -1,4 +1,4 @@
-import { app, dialog, ipcMain } from 'electron';
+import { app, dialog } from 'electron';
 import log from 'electron-log/main';
 
 import { DEFAULT_SERVER_ARGS, ProgressStatus } from './constants';
@@ -59,12 +59,6 @@ export class DesktopApp implements HasTelemetry {
       registerNetworkHandlers();
       registerAppInfoHandlers(appWindow);
       registerAppHandlers();
-      ipcMain.handle(IPC_CHANNELS.OPEN_DIALOG, (event, options: Electron.OpenDialogOptions) => {
-        log.debug('Open dialog');
-        return dialog.showOpenDialogSync({
-          ...options,
-        });
-      });
     } catch (error) {
       log.error('Fatal error occurred during app pre-startup.', error);
       app.exit(2024);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -139,9 +139,6 @@ const electronAPI = {
   reinstall: (): Promise<void> => {
     return ipcRenderer.invoke(IPC_CHANNELS.REINSTALL);
   },
-  openDialog: (options: Electron.OpenDialogOptions) => {
-    return ipcRenderer.invoke(IPC_CHANNELS.OPEN_DIALOG, options);
-  },
   /**
    * Various paths that are useful to the renderer.
    * - Base path: The base path of the application.


### PR DESCRIPTION
- Removes `openDialog` API method - unused

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-805-Remove-unused-API-code-1906d73d36508121bbd6f731f2fd9b8e) by [Unito](https://www.unito.io)
