### PR TITLE
Fix restart core API

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -328,7 +328,7 @@ const electronAPI = {
   /** Restart the python server without restarting desktop. */
   restartCore: async (): Promise<void> => {
     console.log('Restarting core process');
-    await ipcRenderer.invoke(IPC_CHANNELS.RESTART_APP);
+    await ipcRenderer.invoke(IPC_CHANNELS.RESTART_CORE);
   },
   /** Gets the platform reported by node.js */
   getPlatform: () => process.platform,


### PR DESCRIPTION
Fixes typo in restart core API that caused the desktop app to restart instead.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-809-Fix-restart-core-API-1906d73d36508102815bf6141d2f167c) by [Unito](https://www.unito.io)
