### PR TITLE
[Test] Fix cross-platform config test fail

### DIFF
--- a/tests/unit/comfyServerConfig.test.ts
+++ b/tests/unit/comfyServerConfig.test.ts
@@ -209,7 +209,9 @@ describe('ComfyServerConfig', () => {
       Object.defineProperty(process, 'platform', { value: platform });
       const platformConfig = ComfyServerConfig.getBaseConfig();
 
-      expect(platformConfig.custom_nodes).toBe('/mocked/app_resources/ComfyUI/custom_nodes');
+      expect(platformConfig.custom_nodes).toBe(
+        path.join(path.sep, 'mocked', 'app_resources', 'ComfyUI', 'custom_nodes')
+      );
       expect(platformConfig.is_default).toBe('true');
     });
 


### PR DESCRIPTION
Makes cross-platform test cross-platform.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-810-Test-Fix-cross-platform-config-test-fail-1906d73d36508183b6e1d285d49d10a8) by [Unito](https://www.unito.io)
