### PR TITLE
[Refactor] Remove server argument workarounds

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -104,16 +104,18 @@ export const MigrationItems: MigrationItem[] = [
   },
 ] as const;
 
-export const DEFAULT_SERVER_ARGS = {
+export interface ServerArgs {
   /** The host to use for the ComfyUI server. */
-  host: '127.0.0.1',
+  listen: string;
   /** The port to use for the ComfyUI server. */
-  port: 8000,
-  // Extra arguments to pass to the ComfyUI server.
-  extraServerArgs: {} as Record<string, string>,
+  port: string;
+  /** Extra arguments to pass to the ComfyUI server. */
+  [key: string]: string | number;
+}
+export const DEFAULT_SERVER_ARGS: ServerArgs = {
+  listen: '127.0.0.1',
+  port: '8000',
 };
-
-export type ServerArgs = typeof DEFAULT_SERVER_ARGS;
 
 export enum DownloadStatus {
   PENDING = 'pending',

--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -139,7 +139,7 @@ export class AppWindow {
   }
 
   public async loadComfyUI(serverArgs: ServerArgs) {
-    const host = serverArgs.host === '0.0.0.0' ? 'localhost' : serverArgs.host;
+    const host = serverArgs.listen === '0.0.0.0' ? 'localhost' : serverArgs.listen;
     const url = this.devUrlOverride ?? `http://${host}:${serverArgs.port}`;
     await this.window.loadURL(url);
   }

--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -37,7 +37,7 @@ export class ComfyServer implements HasTelemetry {
   ) {}
 
   get baseUrl() {
-    return `http://${this.serverArgs.host}:${this.serverArgs.port}`;
+    return `http://${this.serverArgs.listen}:${this.serverArgs.port}`;
   }
 
   /**
@@ -79,8 +79,6 @@ export class ComfyServer implements HasTelemetry {
       'front-end-root': this.webRootPath,
       'base-directory': this.basePath,
       'extra-model-paths-config': ComfyServerConfig.configPath,
-      port: this.serverArgs.port.toString(),
-      listen: this.serverArgs.host,
     };
   }
 
@@ -97,7 +95,7 @@ export class ComfyServer implements HasTelemetry {
   get launchArgs() {
     return ComfyServer.buildLaunchArgs(this.mainScriptPath, {
       ...this.coreLaunchArgs,
-      ...this.serverArgs.extraServerArgs,
+      ...this.serverArgs,
     });
   }
 


### PR DESCRIPTION
- Removes workarounds that were layered on top of each other (no longer relevant or required).
- Args are now a single POJO.
- Renames `host` to `listen`; this is the name of the ComfyUI server argument.  Can be changed to host again and a simple translation function implemented at the server start, if required.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-823-Refactor-Remove-server-argument-workarounds-1906d73d36508155927cdd917f3c21a5) by [Unito](https://www.unito.io)
