### PR TITLE
Use global uv cache.

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -102,10 +102,6 @@ export class VirtualEnvironment implements HasTelemetry {
   get uvPtyInstance() {
     const env = {
       ...(process.env as Record<string, string>),
-      UV_CACHE_DIR: this.cacheDir,
-      UV_TOOL_DIR: this.cacheDir,
-      UV_TOOL_BIN_DIR: this.cacheDir,
-      UV_PYTHON_INSTALL_DIR: this.cacheDir,
       VIRTUAL_ENV: this.venvPath,
       // Empty strings are not valid values for these env vars,
       // dropping them here to avoid passing them to uv.


### PR DESCRIPTION
Remove the local cache. 
- Benefit from the global uv cache for all users of uv (eg. torch doesn't need to be downloaded again)
- Avoid issues where cache is not compatible on an external hard drive (eg. drives with exFat formatting)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-828-Use-global-uv-cache-1916d73d365081648813edd818f8951a) by [Unito](https://www.unito.io)
