### PR TITLE
Add tracking for python mirror urls.

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -178,6 +178,10 @@ export class InstallationManager {
       autoUpdate: installOptions.autoUpdate,
       allowMetrics: installOptions.allowMetrics,
       migrationItemIds: installOptions.migrationItemIds,
+      pythonMirror: installOptions.pythonMirror,
+      pypiMirror: installOptions.pypiMirror,
+      torchMirror: installOptions.torchMirror,
+      device: installOptions.device,
     });
 
     // Save desktop config

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -55,7 +55,7 @@ export class MixpanelTelemetry implements ITelemetry {
     this.storageFile = path.join(app.getPath('userData'), 'telemetry.txt');
     this.distinctId = this.getOrCreateDistinctId(this.storageFile);
     this.queue = [];
-    ipcMain.once(IPC_CHANNELS.INSTALL_COMFYUI, (_event, installOptions: InstallOptions) => {
+    ipcMain.on(IPC_CHANNELS.INSTALL_COMFYUI, (_event, installOptions: InstallOptions) => {
       if (installOptions.allowMetrics) {
         this.hasConsent = true;
       }


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-829-Add-tracking-for-python-mirror-urls-1916d73d36508132b40fc9e62b1adb5e) by [Unito](https://www.unito.io)
