### PR TITLE
Empty telemetry from front of the queue.

### DIFF
--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -124,7 +124,7 @@ export class MixpanelTelemetry implements ITelemetry {
    */
   flush(): void {
     while (this.queue.length > 0) {
-      const { eventName, properties } = this.queue.pop()!;
+      const { eventName, properties } = this.queue.shift()!;
       this.mixpanelTrack(eventName, properties);
     }
   }

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -88,7 +88,7 @@ export class MixpanelTelemetry implements ITelemetry {
   track(eventName: string, properties?: PropertyDict): void {
     const defaultProperties = {
       distinct_id: this.distinctId,
-      time: new Date(),
+      time: Date.now(),
       $os: os.platform(),
     };
 

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -83,7 +83,7 @@ describe('MixpanelTelemetry', () => {
       expect(telemetry['queue'][0].properties).toMatchObject({
         ...properties,
         distinct_id: expect.any(String),
-        time: expect.any(Date),
+        time: expect.any(Number),
       });
     });
 
@@ -142,7 +142,7 @@ describe('MixpanelTelemetry', () => {
         properties: expect.objectContaining({
           foo: 'bar',
           distinct_id: expect.any(String),
-          time: expect.any(Date),
+          time: expect.any(Number),
         }),
       });
     });


### PR DESCRIPTION
Previously was FIFO and that was a bug...

 - Fix sending correct timestamp.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-838-Empty-telemetry-from-front-of-the-queue-1926d73d3650810ea658d17452fb87ea) by [Unito](https://www.unito.io)
