### PR TITLE
Revert ComfyUI-Manager version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "config": {
     "frontendVersion": "1.8.12",
     "comfyVersion": "0.3.13",
-    "managerCommit": "b2094f773a6b04dbfa29604787b4f6b7f9ff8b81",
+    "managerCommit": "1434b12c343b58a401f1c9f913965ceb0cfd089e",
     "uvVersion": "0.5.26"
   },
   "scripts": {


### PR DESCRIPTION
Could not revert previous PR for some reason on Github.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-842-Revert-ComfyUI-Manager-version-1926d73d36508137b60cc5b2b368aaa0) by [Unito](https://www.unito.io)
