### PR TITLE
Add telemetry for installation events (from validation page).

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -111,12 +111,20 @@ export class InstallationManager {
       installation.onUpdate?.(installation.validation);
       return installation.validation;
     });
-    ipcMain.handle(IPC_CHANNELS.VALIDATE_INSTALLATION, async () => await installation.validate());
-    ipcMain.handle(IPC_CHANNELS.UV_INSTALL_REQUIREMENTS, () =>
-      installation.virtualEnvironment.reinstallRequirements(sendLogIpc)
-    );
-    ipcMain.handle(IPC_CHANNELS.UV_CLEAR_CACHE, async () => await installation.virtualEnvironment.clearUvCache());
+    ipcMain.handle(IPC_CHANNELS.VALIDATE_INSTALLATION, async () => {
+      this.telemetry.track('installation_manager:installation_validate');
+      return await installation.validate();
+    });
+    ipcMain.handle(IPC_CHANNELS.UV_INSTALL_REQUIREMENTS, () => {
+      this.telemetry.track('installation_manager:uv_requirements_install');
+      return installation.virtualEnvironment.reinstallRequirements(sendLogIpc);
+    });
+    ipcMain.handle(IPC_CHANNELS.UV_CLEAR_CACHE, async () => {
+      this.telemetry.track('installation_manager:uv_cache_clear');
+      return await installation.virtualEnvironment.clearUvCache();
+    });
     ipcMain.handle(IPC_CHANNELS.UV_RESET_VENV, async (): Promise<boolean> => {
+      this.telemetry.track('installation_manager:uv_venv_reset');
       const venv = installation.virtualEnvironment;
       const deleted = await venv.removeVenvDirectory();
       if (!deleted) return false;


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-846-Add-telemetry-for-installation-events-from-validation-page-1926d73d3650819493ded69032c5c23c) by [Unito](https://www.unito.io)
