### PR TITLE
Fix virtual env won't load - bypass zsh profile

### DIFF
--- a/src/shell/util.ts
+++ b/src/shell/util.ts
@@ -11,3 +11,7 @@ export function getDefaultShell(): string {
       return 'bash';
   }
 }
+
+export function getDefaultShellArgs(): string[] {
+  return os.platform() === 'darwin' ? ['-df'] : [];
+}

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 import { CUDA_TORCH_URL, NIGHTLY_CPU_TORCH_URL } from './constants';
 import type { TorchDeviceType } from './preload';
 import { HasTelemetry, ITelemetry, trackEvent } from './services/telemetry';
-import { getDefaultShell } from './shell/util';
+import { getDefaultShell, getDefaultShellArgs } from './shell/util';
 import { pathAccessible } from './utils';
 
 export type ProcessCallbacks = {
@@ -110,7 +110,7 @@ export class VirtualEnvironment implements HasTelemetry {
 
     if (!this.uvPty) {
       const shell = getDefaultShell();
-      this.uvPty = pty.spawn(shell, [], {
+      this.uvPty = pty.spawn(shell, getDefaultShellArgs(), {
         handleFlowControl: false,
         conptyInheritCursor: false,
         name: 'xterm',


### PR DESCRIPTION
Adds `-df` flags when using vritual environment shell, to bypass profile loading and customisation on macOS.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-851-Fix-virtual-env-won-t-load-bypass-zsh-profile-1936d73d3650810ab20cd367419c2118) by [Unito](https://www.unito.io)
