### PR TITLE
[Test] Add cursor rules for vitest test generation

### DIFF
--- a/.cursor/rules/vitest.mdc
+++ b/.cursor/rules/vitest.mdc
@@ -1,0 +1,19 @@
+---
+description: Creating unit tests
+globs: 
+---
+
+# Creating unit tests
+
+- This project uses `vitest` for unit testing
+- Tests are stored in the `tests/unit/` directory
+  - Directory structure of `tests/unit/` should match that of the tested file in `src/`
+- Tests should be cross-platform compatible; able to run on Windows, macOS, and linux
+  - e.g. the use of `path.join` and `path.sep` to ensure tests work the same on all platforms
+- Tests should be mocked properly
+  - Mocks should be cleanly written and easy to understand
+  - Mocks should be re-usable where possible
+  - Class mocks should be stored in a separate file and imported for use
+- Read at least five existing unit tests to determine testing patterns
+  - appWindow.test.ts is a good example
+  - desktopApp.test.ts is a good example


### PR DESCRIPTION
#### Current

Cursor composer "Add tests for this class" results in one / many of:

- Attempts to run `npm -i jest`
- Generates jest test files
- Create basic test structures with "create unit tests for this file"

#### Proposed

Adds basic cursor rules for unit test generation.

Successfully generated two full test sets with only basic prompting: "Add tests for this class" or "create tests for this file"

- Copy and paste any errors "I received an error: <PASTE> referencing file <PASTE>"
- Some minor corrections were performed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-852-Test-Add-cursor-rules-for-vitest-test-generation-1936d73d3650815bbdb3c9104a21ab66) by [Unito](https://www.unito.io)
