### PR TITLE
Make comfy settings a singleton

### DIFF
--- a/src/desktopApp.ts
+++ b/src/desktopApp.ts
@@ -44,13 +44,10 @@ export class DesktopApp implements HasTelemetry {
   }
 
   private async initializeTelemetry(installation: ComfyInstallation): Promise<void> {
-    const { comfySettings } = installation;
-
     await SentryLogging.setSentryGpuContext();
-    SentryLogging.shouldSendStatistics = () => comfySettings.get('Comfy-Desktop.SendStatistics');
     SentryLogging.getBasePath = () => installation.basePath;
 
-    const allowMetrics = await promptMetricsConsent(this.config, this.appWindow, comfySettings);
+    const allowMetrics = await promptMetricsConsent(this.config, this.appWindow);
     this.telemetry.hasConsent = allowMetrics;
     if (allowMetrics) this.telemetry.flush();
   }

--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { ComfyConfigManager } from '../config/comfyConfigManager';
 import { ComfyServerConfig, ModelPaths } from '../config/comfyServerConfig';
-import { type ComfySettingsData, DEFAULT_SETTINGS } from '../config/comfySettings';
+import { type ComfySettingsData, comfySettings } from '../config/comfySettings';
 import { InstallOptions } from '../preload';
 import { HasTelemetry, ITelemetry, trackEvent } from '../services/telemetry';
 
@@ -31,7 +31,7 @@ export class InstallWizard implements HasTelemetry {
     // Setup the ComfyUI folder structure.
     ComfyConfigManager.createComfyDirectories(this.basePath);
     this.initializeUserFiles();
-    this.initializeSettings();
+    await this.initializeSettings();
     await this.initializeModelPaths();
   }
 
@@ -52,16 +52,12 @@ export class InstallWizard implements HasTelemetry {
   /**
    * Setup comfy.settings.json file
    */
-  public initializeSettings() {
-    const settingsPath = path.join(this.basePath, 'user', 'default', 'comfy.settings.json');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const existingSettings: ComfySettingsData = fs.existsSync(settingsPath)
-      ? JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
-      : {};
+  public async initializeSettings() {
+    // Load any existing settings if they exist
+    await comfySettings.loadSettings();
 
-    const settings = {
-      ...DEFAULT_SETTINGS,
-      ...existingSettings,
+    // Add install options to settings
+    const settings: Partial<ComfySettingsData> = {
       'Comfy-Desktop.AutoUpdate': this.installOptions.autoUpdate,
       'Comfy-Desktop.SendStatistics': this.installOptions.allowMetrics,
       'Comfy-Desktop.UV.PythonInstallMirror': this.installOptions.pythonMirror,
@@ -74,9 +70,12 @@ export class InstallWizard implements HasTelemetry {
       settings['Comfy.Server.LaunchArgs']['cpu'] = '';
     }
 
-    const settingsJson = JSON.stringify(settings, null, 2);
-    fs.writeFileSync(settingsPath, settingsJson);
-    log.info(`Wrote settings to ${settingsPath}: ${settingsJson}`);
+    for (const [key, value] of Object.entries(settings)) {
+      comfySettings.set(key, value);
+    }
+
+    await comfySettings.saveSettings();
+    log.info(`Wrote install options to comfy settings file.`);
   }
 
   /**

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -1,8 +1,6 @@
 import { Notification, app, dialog, ipcMain } from 'electron';
 import log from 'electron-log/main';
 
-import { ComfySettings } from '@/config/comfySettings';
-
 import { IPC_CHANNELS, ProgressStatus } from '../constants';
 import type { AppWindow } from '../main-process/appWindow';
 import { ComfyInstallation } from '../main-process/comfyInstallation';
@@ -29,7 +27,7 @@ export class InstallationManager implements HasTelemetry {
    * @returns A valid {@link ComfyInstallation} object.
    */
   async ensureInstalled(): Promise<ComfyInstallation> {
-    const installation = await ComfyInstallation.fromConfig();
+    const installation = ComfyInstallation.fromConfig();
     log.info(`Install state: ${installation?.state ?? 'not installed'}`);
 
     // Fresh install
@@ -218,9 +216,7 @@ export class InstallationManager implements HasTelemetry {
       useDesktopConfig().set('migrateCustomNodesFrom', installWizard.migrationSource);
     }
 
-    const comfySettings = new ComfySettings(installWizard.basePath);
-    await comfySettings.loadSettings();
-    const installation = new ComfyInstallation('started', installWizard.basePath, this.telemetry, comfySettings);
+    const installation = new ComfyInstallation('started', installWizard.basePath, this.telemetry);
     InstallationManager.setReinstallHandler(installation);
     const { virtualEnvironment } = installation;
 

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -2,6 +2,8 @@ import todesktop from '@todesktop/runtime';
 import { app, ipcMain } from 'electron';
 import log from 'electron-log/main';
 
+import { comfySettings } from '@/config/comfySettings';
+
 import { DEFAULT_SERVER_ARGS, IPC_CHANNELS, ProgressStatus, ServerArgs } from '../constants';
 import { DownloadManager } from '../models/DownloadManager';
 import { HasTelemetry, ITelemetry } from '../services/telemetry';
@@ -21,10 +23,6 @@ export class ComfyDesktopApp implements HasTelemetry {
     readonly appWindow: AppWindow,
     readonly telemetry: ITelemetry
   ) {}
-
-  get comfySettings() {
-    return this.installation.comfySettings;
-  }
 
   get basePath() {
     return this.installation.basePath;
@@ -47,7 +45,7 @@ export class ComfyDesktopApp implements HasTelemetry {
     const serverArgs: ServerArgs = {
       listen: DEFAULT_SERVER_ARGS.listen,
       port: DEFAULT_SERVER_ARGS.port,
-      ...this.comfySettings.get('Comfy.Server.LaunchArgs'),
+      ...comfySettings.get('Comfy.Server.LaunchArgs'),
     };
 
     if (COMFY_HOST) serverArgs.listen = COMFY_HOST;
@@ -69,7 +67,7 @@ export class ComfyDesktopApp implements HasTelemetry {
       autoCheckInterval: 60 * 60 * 1000, // every hour
       customLogger: log,
       updateReadyAction: { showInstallAndRestartPrompt: 'always', showNotification: 'always' },
-      autoUpdater: this.comfySettings.get('Comfy-Desktop.AutoUpdate'),
+      autoUpdater: comfySettings.get('Comfy-Desktop.AutoUpdate'),
     });
     todesktop.autoUpdater?.setFeedURL('https://updater.comfy.org');
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { app, shell } from 'electron';
 import { LevelOption } from 'electron-log';
 import log from 'electron-log/main';
 
+import { comfySettings } from './config/comfySettings';
 import { DesktopApp } from './desktopApp';
 import { AppState } from './main-process/appState';
 import { DevOverrides } from './main-process/devOverrides';
@@ -54,6 +55,9 @@ async function startApp() {
       exitCode: 20,
     });
   }
+
+  const isNewUser = config.get('basePath') === undefined;
+  if (!isNewUser) await comfySettings.loadSettings();
 
   const desktopApp = new DesktopApp(appState, overrides, config);
   await desktopApp.showLoadingPage();

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -7,7 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import si from 'systeminformation';
 
-import type { IComfySettings } from '@/config/comfySettings';
+import { comfySettings } from '@/config/comfySettings';
 
 import { IPC_CHANNELS } from '../constants';
 import { AppWindow } from '../main-process/appWindow';
@@ -241,11 +241,7 @@ export function trackEvent<T extends HasTelemetry>(eventName: string) {
 }
 
 /** @returns Whether the user has consented to sending metrics. */
-export async function promptMetricsConsent(
-  store: DesktopConfig,
-  appWindow: AppWindow,
-  comfySettings: IComfySettings
-): Promise<boolean> {
+export async function promptMetricsConsent(store: DesktopConfig, appWindow: AppWindow): Promise<boolean> {
   const consent = comfySettings.get('Comfy-Desktop.SendStatistics') ?? false;
   const consentedOn = store.get('versionConsentedMetrics');
   const isOutdated = !consentedOn || compareVersions(consentedOn, '0.4.12') < 0;

--- a/tests/unit/desktopApp.test.ts
+++ b/tests/unit/desktopApp.test.ts
@@ -57,16 +57,36 @@ vi.mock('@/main-process/appWindow', () => ({
   AppWindow: vi.fn().mockImplementation(() => mockAppWindow),
 }));
 
-const mockComfySettings = new ComfySettings('/mock/path');
-mockComfySettings.get = vi.fn().mockReturnValue('true');
-mockComfySettings.set = vi.fn();
-mockComfySettings.saveSettings = vi.fn();
+vi.mock('@/config/comfySettings', () => ({
+  ComfySettings: {
+    getInstance: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue('true'),
+      set: vi.fn(),
+      saveSettings: vi.fn(),
+      loadSettings: vi.fn(),
+    }),
+  },
+  comfySettings: {
+    get: vi.fn().mockReturnValue('true'),
+    set: vi.fn(),
+    saveSettings: vi.fn(),
+    loadSettings: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/desktopConfig', () => ({
+  useDesktopConfig: vi.fn().mockReturnValue({
+    get: vi.fn().mockReturnValue('/mock/path'),
+    set: vi.fn(),
+  }),
+}));
+
+const mockComfySettings = ComfySettings.getInstance();
 
 const mockInstallation: Partial<ComfyInstallation> = {
   basePath: '/mock/path',
   virtualEnvironment: {} as any,
   validation: {} as any,
-  comfySettings: mockComfySettings,
   hasIssues: false,
   isValid: true,
   state: 'installed',
@@ -226,7 +246,7 @@ describe('DesktopApp', () => {
 
       await desktopApp['initializeTelemetry'](testInstallation);
 
-      expect(promptMetricsConsent).toHaveBeenCalledWith(mockConfig, mockAppWindow, testInstallation.comfySettings);
+      expect(promptMetricsConsent).toHaveBeenCalledWith(mockConfig, mockAppWindow);
       expect(SentryLogging.setSentryGpuContext).toHaveBeenCalled();
       expect(desktopApp.telemetry.hasConsent).toBe(true);
       expect(desktopApp.telemetry.flush).toHaveBeenCalled();
@@ -235,11 +255,12 @@ describe('DesktopApp', () => {
     it('should respect user rejection of telemetry', async () => {
       vi.mocked(promptMetricsConsent).mockResolvedValueOnce(false);
       vi.mocked(mockConfig.get).mockReturnValue('false');
-      vi.mocked(testInstallation.comfySettings.get).mockReturnValue('false');
+      vi.mocked(mockComfySettings.get).mockReturnValue('false');
 
       await desktopApp['initializeTelemetry'](testInstallation);
 
-      expect(promptMetricsConsent).toHaveBeenCalledWith(mockConfig, mockAppWindow, testInstallation.comfySettings);
+      expect(promptMetricsConsent).toHaveBeenCalledWith(mockConfig, mockAppWindow);
+      expect(SentryLogging.setSentryGpuContext).toHaveBeenCalled();
       expect(desktopApp.telemetry.hasConsent).toBe(false);
       expect(desktopApp.telemetry.flush).not.toHaveBeenCalled();
     });

--- a/tests/unit/desktopApp.test.ts
+++ b/tests/unit/desktopApp.test.ts
@@ -66,12 +66,6 @@ vi.mock('@/config/comfySettings', () => ({
       loadSettings: vi.fn(),
     }),
   },
-  comfySettings: {
-    get: vi.fn().mockReturnValue('true'),
-    set: vi.fn(),
-    saveSettings: vi.fn(),
-    loadSettings: vi.fn(),
-  },
 }));
 
 vi.mock('@/store/desktopConfig', () => ({


### PR DESCRIPTION
Makes `ComfySettings` a singleton. Initially, the default settings are loaded. For returning users, their settings file is read and merged into the defaults on startup. For installing users, install options are merged into defaults in the same process as before.

This PR enables the Sentry class to check whether the user consents to metrics during the installation process, so that installation errors can be manually captured and sent to Sentry.