### PR TITLE
Fix custom nodes installed to wrong location

### DIFF
--- a/src/config/comfyServerConfig.ts
+++ b/src/config/comfyServerConfig.ts
@@ -78,7 +78,7 @@ export class ComfyServerConfig {
   static readonly EXTRA_MODEL_CONFIG_PATH = 'extra_models_config.yaml';
 
   private static readonly commonPaths = {
-    custom_nodes: path.join(getAppResourcesPath(), 'ComfyUI', 'custom_nodes'),
+    custom_nodes: 'custom_nodes/',
     download_model_base: 'models',
   };
   private static readonly configTemplates: Record<string, ModelPaths> = {

--- a/tests/unit/config/comfyServerConfig.test.ts
+++ b/tests/unit/config/comfyServerConfig.test.ts
@@ -209,9 +209,7 @@ describe('ComfyServerConfig', () => {
       Object.defineProperty(process, 'platform', { value: platform });
       const platformConfig = ComfyServerConfig.getBaseConfig();
 
-      expect(platformConfig.custom_nodes).toBe(
-        path.join(path.sep, 'mocked', 'app_resources', 'ComfyUI', 'custom_nodes')
-      );
+      expect(platformConfig.custom_nodes).toBe('custom_nodes/');
       expect(platformConfig.is_default).toBe('true');
     });
 


### PR DESCRIPTION
Reverts change to custom nodes path in default extra_model_paths.yaml

Original commit ID: 1fe0ee6e6d1fb6f35481cc63c2910aff6c522b2e

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-865-Fix-custom-nodes-installed-to-wrong-location-1946d73d365081628e7ed2a05ddb71a6) by [Unito](https://www.unito.io)
