### PR TITLE
Fix virtual env won't load on linux

### DIFF
--- a/src/shell/util.ts
+++ b/src/shell/util.ts
@@ -13,5 +13,13 @@ export function getDefaultShell(): string {
 }
 
 export function getDefaultShellArgs(): string[] {
-  return os.platform() === 'darwin' ? ['-df'] : [];
+  switch (os.platform()) {
+    case 'darwin':
+      return ['-df']; // Prevent loading initialization files for zsh
+    case 'win32':
+      return [];
+    default: // Linux and others
+      // Start with completely clean env
+      return ['-c', 'env -i bash --noprofile --norc'];
+  }
 }


### PR DESCRIPTION
Various environment variables can interfere with the install process, including modifications to PATH made by python version managers (inserting shims). Bypassing shell profiles alone is not enough because environment variables will already be set in the parent process and inherited.

A more consistent fix is to start with a clean enviornment. I don't think it's necessary to preserve any user environment variables and the ones set in `spawn` call will still be inserted.


https://github.com/user-attachments/assets/ec810a1f-05f8-49d1-bd83-1f7433df4af4

