### PR TITLE
Always log events locally (debug)

### DIFF
--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -92,7 +92,7 @@ export class MixpanelTelemetry implements ITelemetry {
       $os: os.platform(),
     };
 
-    log.debug(`Event:[${eventName}] ${JSON.stringify(properties)}`);
+    log.debug(`Event:[${eventName}]`, properties);
     if (!this.hasConsent) {
       log.debug('Queueing previous event');
       this.queue.push({


### PR DESCRIPTION
- Ensures events are logged locally for when debugging logs are enabled
- Removes manual stringification in favour of structured logging

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-869-Always-log-events-locally-debug-1946d73d36508118b3fad854f6c5d858) by [Unito](https://www.unito.io)
