### PR TITLE
Ensure users do not use the CPU mirror for non-CPU installs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -128,4 +128,4 @@ export enum DownloadStatus {
 
 export const CUDA_TORCH_URL = 'https://download.pytorch.org/whl/cu124';
 export const NIGHTLY_CPU_TORCH_URL = 'https://download.pytorch.org/whl/nightly/cpu';
-export const DEFAULT_PYTHON_URL = 'https://pypi.org/simple/';
+export const DEFAULT_PYPI_INDEX_URL = 'https://pypi.org/simple/';

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -6,7 +6,7 @@ import { rm } from 'node:fs/promises';
 import os, { EOL } from 'node:os';
 import path from 'node:path';
 
-import { CUDA_TORCH_URL, DEFAULT_PYTHON_URL, NIGHTLY_CPU_TORCH_URL } from './constants';
+import { CUDA_TORCH_URL, DEFAULT_PYPI_INDEX_URL, NIGHTLY_CPU_TORCH_URL } from './constants';
 import type { TorchDeviceType } from './preload';
 import { HasTelemetry, ITelemetry, trackEvent } from './services/telemetry';
 import { getDefaultShell, getDefaultShellArgs } from './shell/util';
@@ -72,13 +72,13 @@ function getDefaultTorchMirror(device: TorchDeviceType): string {
     case 'nvidia':
       return CUDA_TORCH_URL;
     default:
-      return DEFAULT_PYTHON_URL;
+      return DEFAULT_PYPI_INDEX_URL;
   }
 }
 
 /** Disallows using the default mirror (CPU torch) when the selected device is not CPU. */
 function fixDeviceMirrorMismatch(device: TorchDeviceType, mirror: string | undefined) {
-  if (mirror === DEFAULT_PYTHON_URL) {
+  if (mirror === DEFAULT_PYPI_INDEX_URL) {
     if (device === 'nvidia') return CUDA_TORCH_URL;
     else if (device === 'mps') return NIGHTLY_CPU_TORCH_URL;
   }


### PR DESCRIPTION
- Resolves cannot start app after uv command fails - empty index URL
- Silently corrects use of default python mirror to default mirror for selected device
- Resolves issue where user is unable to start the app due to an invalid mirror configuration

The mirror correction is a workaround that should be expanded into a proper feature, or removed.

- #870

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-871-Ensure-users-do-not-use-the-CPU-mirror-for-non-CPU-installs-1946d73d365081679cc8c18fdc242080) by [Unito](https://www.unito.io)
