### PR TITLE
Update maintenance URL to cu126 from cu124

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -126,6 +126,6 @@ export enum DownloadStatus {
   CANCELLED = 'cancelled',
 }
 
-export const CUDA_TORCH_URL = 'https://download.pytorch.org/whl/cu124';
+export const CUDA_TORCH_URL = 'https://download.pytorch.org/whl/cu126';
 export const NIGHTLY_CPU_TORCH_URL = 'https://download.pytorch.org/whl/nightly/cpu';
 export const DEFAULT_PYPI_INDEX_URL = 'https://pypi.org/simple/';


### PR DESCRIPTION
Maintenance URL now matches compiled requirements.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-876-Update-maintenance-URL-to-cu126-from-cu124-1956d73d36508163ae34c2baf8f9829d) by [Unito](https://www.unito.io)
