### PR TITLE
Capture and report caught exceptions

### DIFF
--- a/tests/unit/desktopApp.test.ts
+++ b/tests/unit/desktopApp.test.ts
@@ -108,7 +108,6 @@ vi.mock('@/main-process/comfyDesktopApp', () => ({
 vi.mock('@/services/sentry', () => ({
   default: {
     setSentryGpuContext: vi.fn().mockResolvedValue(undefined),
-    shouldSendStatistics: vi.fn(),
     getBasePath: vi.fn(),
   },
 }));

--- a/tests/unit/install/installWizard.test.ts
+++ b/tests/unit/install/installWizard.test.ts
@@ -62,6 +62,12 @@ vi.mock('../../../src/install/resourcePaths', () => ({
   getAppResourcesPath: () => '/test/resources',
 }));
 
+vi.mock('@sentry/electron/main', () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  setContext: vi.fn(),
+}));
+
 describe('InstallWizard', () => {
   let installWizard: InstallWizard;
   const mockTelemetry: ITelemetry = {
@@ -69,10 +75,6 @@ describe('InstallWizard', () => {
     hasConsent: true,
     flush: vi.fn(),
     registerHandlers: vi.fn(),
-    queueSentryEvent: vi.fn(),
-    popSentryEvent: vi.fn(),
-    hasPendingSentryEvents: vi.fn(),
-    clearSentryQueue: vi.fn(),
   };
 
   const defaultInstallOptions: InstallOptions = {

--- a/tests/unit/install/installationManager.test.ts
+++ b/tests/unit/install/installationManager.test.ts
@@ -110,10 +110,6 @@ const createMockTelemetry = (): ITelemetry => ({
   hasConsent: true,
   flush: vi.fn(),
   registerHandlers: vi.fn(),
-  queueSentryEvent: vi.fn(),
-  popSentryEvent: vi.fn(),
-  hasPendingSentryEvents: vi.fn().mockReturnValue(false),
-  clearSentryQueue: vi.fn(),
 });
 
 describe('InstallationManager', () => {

--- a/tests/unit/main-process/comfyServer.test.ts
+++ b/tests/unit/main-process/comfyServer.test.ts
@@ -6,6 +6,12 @@ vi.mock('@/install/resourcePaths', () => ({
   getAppResourcesPath: vi.fn().mockReturnValue('/mocked/app_resources'),
 }));
 
+vi.mock('@sentry/electron/main', () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  setContext: vi.fn(),
+}));
+
 describe('ComfyServer', () => {
   describe('buildLaunchArgs', () => {
     it('should convert basic arguments correctly', () => {

--- a/tests/unit/services/telemetry.test.ts
+++ b/tests/unit/services/telemetry.test.ts
@@ -9,6 +9,12 @@ import type { AppWindow } from '@/main-process/appWindow';
 import { MixpanelTelemetry, promptMetricsConsent } from '@/services/telemetry';
 import type { DesktopConfig } from '@/store/desktopConfig';
 
+vi.mock('@sentry/electron/main', () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  setContext: vi.fn(),
+}));
+
 vi.mock('electron', () => ({
   app: {
     getPath: vi.fn().mockReturnValue('/mock/user/data'),


### PR DESCRIPTION
Reverts https://github.com/Comfy-Org/desktop/pull/739 in favor of manually capturing exceptions in `track` and `trackEvent`, which is preferable because it doesn't require exceptions to go uncaught/unresolved to be logged. Additionally, adds fields for last 64 lines of log file  mirror settings.

Example events: [Sentry](https://comfy-org.sentry.io/issues/6283123346/events/3065c15d414c4176acf548f3afba96c6/?project=4508007940685824) | [Mixpanel](https://mixpanel.com/project/3484456/view/3986560/app/profile#distinct_id=f1f2c45a-1f07-4edb-9583-c2a9b070521e)