### PR TITLE
Fix prettier plugin breaks when using "using"

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -16,7 +16,7 @@
       "files": "*.{js,cjs,mjs,ts,cts,mts}",
       "options": {
         "plugins": ["@trivago/prettier-plugin-sort-imports"],
-        "importOrderParserPlugins": ["typescript", "decorators"],
+        "importOrderParserPlugins": ["typescript", "decorators", "explicitResourceManagement"],
         "importOrder": ["^@core/(.*)$", "<THIRD_PARTY_MODULES>", "^@/(.*)$", "^[./]"],
         "importOrderSeparation": true,
         "importOrderSortSpecifiers": true


### PR DESCRIPTION
`@trivago/prettier-plugin-sort-imports` crashes when using `using` keyword.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-881-Fix-prettier-plugin-breaks-when-using-using-1956d73d365081699d41f3f4cab635f3) by [Unito](https://www.unito.io)
