### PR TITLE
Only use managed python for uv.

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -277,7 +277,7 @@ export class VirtualEnvironment implements HasTelemetry {
   @trackEvent('install_flow:virtual_environment_create_python')
   public async createVenvWithPython(callbacks?: ProcessCallbacks): Promise<void> {
     log.info(`Creating virtual environment at ${this.venvPath} with python ${this.pythonVersion}`);
-    const args = ['venv', '--python', this.pythonVersion];
+    const args = ['venv', '--python', this.pythonVersion, '--python-preference', 'only-managed'];
     const { exitCode } = await this.runUvCommandAsync(args, callbacks);
 
     if (exitCode !== 0) {


### PR DESCRIPTION
Only use the uv managed python-standalone. Not system Python, which can be unpredictable or corrupt.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-889-Only-use-managed-python-for-uv-1986d73d365081708cdbc521d3305ce3) by [Unito](https://www.unito.io)
