### PR TITLE
[CI] Remove duplicate build CI task

### DIFF
--- a/.github/workflows/debug_all.yml
+++ b/.github/workflows/debug_all.yml
@@ -1,23 +1,6 @@
 name: Build - All Platforms
 
 on:
-  pull_request:
-    branches:
-      - 'main'
-    paths-ignore:
-      - '.prettierrc'
-      - '.eslintrc.json'
-      - '.prettierignore'
-      - 'README.md'
-      - '.husky/**'
-      - '.vscode/**'
-      - 'scripts/**'
-      - '.gitignore'
-      - 'todesktop.json'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.cursor/**'
-      - '*_example'
-      - 'tests/**'
   push:
     branches:
       - 'main'


### PR DESCRIPTION
- Windows build is also performed in the "integration" test workflow
- Adds PR/push triggers to Mac build workflow
- Fixes husky path ignore missing leading full stop

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-892-CI-Remove-duplicate-build-CI-task-1986d73d3650811c94d7d89d62005f06) by [Unito](https://www.unito.io)
