### PR TITLE
[chore] Update frontend to 1.9.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.9.6",
+    "frontendVersion": "1.9.15",
     "comfyVersion": "0.3.14",
     "managerCommit": "1434b12c343b58a401f1c9f913965ceb0cfd089e",
     "uvVersion": "0.5.26"


### PR DESCRIPTION
Automated frontend update to 1.9.15: https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.9.15

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-893-chore-Update-frontend-to-1-9-15-1996d73d3650817fb9f0ee771ce924ff) by [Unito](https://www.unito.io)
