### PR TITLE
Add electron-rebuild to windows build action

### DIFF
--- a/.github/actions/build/windows/app/action.yml
+++ b/.github/actions/build/windows/app/action.yml
@@ -27,6 +27,7 @@ runs:
     - run: yarn install --immutable
       shell: cmd
     - name: Rebuild node-pty
+      shell: cmd
       run: npx electron-rebuild
     - name: Mod
       shell: powershell


### PR DESCRIPTION
Fixes error when starting CI-built Windows app:

`The module '/electron/node_modules/node-pty/build/Release/pty.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 115. This version of Node.js requires NODE_MODULE_VERSION 125.`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-898-Add-electron-rebuild-to-windows-build-action-19a6d73d36508172929ac04c1a3346cc) by [Unito](https://www.unito.io)
