### PR TITLE
Split playwright tests into install and post-install projects

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,11 +29,11 @@ export default defineConfig({
   projects: [
     {
       name: 'install',
-      testMatch: ['tests/integration/tests/install/**/*.spec.ts', 'tests/integration/tests/shared/**/*.spec.ts'],
+      testMatch: ['tests/install/**/*.spec.ts', 'tests/shared/**/*.spec.ts'],
     },
     {
       name: 'post-install',
-      testMatch: ['tests/integration/tests/post-install/**/*.spec.ts', 'tests/integration/tests/shared/**/*.spec.ts'],
+      testMatch: ['tests/post-install/**/*.spec.ts', 'tests/shared/**/*.spec.ts'],
       dependencies: ['install'],
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,4 +26,15 @@ export default defineConfig({
     trace: 'on-first-retry',
     video: 'on-first-retry',
   },
+  projects: [
+    {
+      name: 'install',
+      testMatch: ['tests/integration/tests/install/**/*.spec.ts', 'tests/integration/tests/shared/**/*.spec.ts'],
+    },
+    {
+      name: 'post-install',
+      testMatch: ['tests/integration/tests/post-install/**/*.spec.ts', 'tests/integration/tests/shared/**/*.spec.ts'],
+      dependencies: ['install'],
+    },
+  ],
 });

--- a/tests/integration/tests/install/installApp.spec.ts
+++ b/tests/integration/tests/install/installApp.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { test } from './testExtensions';
+import { test } from '../../testExtensions';
 
 test.use({ disposeTestEnvironment: true });
 

--- a/tests/integration/tests/install/installWizard.spec.ts
+++ b/tests/integration/tests/install/installWizard.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { test } from './testExtensions';
+import { test } from '../../testExtensions';
 
 test.describe('Install Wizard', () => {
   test('can click through first time installer', async ({ installWizard, window, attachScreenshot }) => {

--- a/tests/integration/tests/shared/appWindow.spec.ts
+++ b/tests/integration/tests/shared/appWindow.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { test } from './testExtensions';
+import { test } from '../../testExtensions';
 
 test('App window has title', async ({ app }) => {
   const window = await app.firstWindow();


### PR DESCRIPTION
Split playwright tests into install project and post-install project. Set install project as dependency of post-install project, so that it runs first. Create `shared` folder for test files that should be run against both pre-install and post-install state. Resolves #900. 

[Playwright project dependencies docs](https://playwright.dev/docs/test-projects#dependencies)