### PR TITLE
Remove unnecessary nullcheck

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -159,7 +159,7 @@ export class InstallationManager implements HasTelemetry {
 
     // Check available GPU
     const hardware = await validateHardware();
-    if (typeof hardware?.gpu === 'string') config.set('detectedGpu', hardware.gpu);
+    if (typeof hardware.gpu === 'string') config.set('detectedGpu', hardware.gpu);
 
     /** Resovles when the user has confirmed all install options */
     const optionsPromise = new Promise<InstallOptions>((resolve) => {


### PR DESCRIPTION
Removes unnecessary/misleading check -- not possible for `validateHardware` to return falsy value and `hardware` is used without nullcheck in proceeding lines.

https://github.com/Comfy-Org/desktop/blob/9bf7785fe493e4e4c6e33b0475814428929d6b89/src/utils.ts#L140
