### PR TITLE
[e2e] Fix regression in per-test timeout (60sec)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,14 +30,10 @@ export default defineConfig({
     {
       name: 'install',
       testMatch: ['install/**/*.spec.ts', 'shared/**/*.spec.ts'],
-      // Per-test timeout - 60 sec
-      timeout: 60_000,
     },
     {
       name: 'post-install',
       testMatch: ['post-install/**/*.spec.ts', 'shared/**/*.spec.ts'],
-      // Per-test timeout - 60 sec
-      timeout: 60_000,
       dependencies: ['install'],
     },
   ],


### PR DESCRIPTION
Resolves test fail due to timeout.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-903-e2e-Fix-regression-in-per-test-timeout-60sec-19b6d73d3650812b8076f55fce1cdc7c) by [Unito](https://www.unito.io)
