### PR TITLE
Add support for bundling cherry-picked branches in Build Process

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "frontendVersion": "1.9.15",
     "comfyVersion": "0.3.14",
     "managerCommit": "1434b12c343b58a401f1c9f913965ceb0cfd089e",
+    "managerCherryPicks": [],
+    "comfyCherryPicks": ["042a905c3791e466327764b79748cf26738a4c26"],
     "uvVersion": "0.5.26"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,8 @@
   "type": "module",
   "config": {
     "frontendVersion": "1.9.15",
-    "comfyVersion": "0.3.14",
+    "comfyBranch": "v0.3.14",
     "managerCommit": "1434b12c343b58a401f1c9f913965ceb0cfd089e",
-    "managerCherryPicks": [],
-    "comfyCherryPicks": ["042a905c3791e466327764b79748cf26738a4c26"],
     "uvVersion": "0.5.26"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "type": "module",
   "config": {
     "frontendVersion": "1.9.15",
-    "comfyBranch": "v0.3.14",
+    "comfyUI": {
+      "version": "0.3.14",
+      "optionalBranch": "desktop-release-feb172025"
+    },
     "managerCommit": "1434b12c343b58a401f1c9f913965ceb0cfd089e",
     "uvVersion": "0.5.26"
   },

--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -5,6 +5,10 @@ import pkg from './getPackage.js';
 const comfyRepo = 'https://github.com/comfyanonymous/ComfyUI';
 const managerRepo = 'https://github.com/Comfy-Org/ComfyUI-Manager';
 
+// Needed to do cherry-picks
+execSync('git config --global user.email "build-bot@example.com"');
+execSync('git config --global user.name "Build Bot"');
+
 // Clone and checkout base versions
 execSync(`git clone ${comfyRepo} --depth 1 --branch v${pkg.config.comfyVersion} assets/ComfyUI`);
 execSync(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);

--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -5,7 +5,13 @@ import pkg from './getPackage.js';
 const comfyRepo = 'https://github.com/comfyanonymous/ComfyUI';
 const managerRepo = 'https://github.com/Comfy-Org/ComfyUI-Manager';
 
-execSync(`git clone ${comfyRepo} --depth 1 --branch ${pkg.config.comfyBranch} assets/ComfyUI`);
+if (pkg.config.comfyUI.optionalBranch) {
+  // Checkout branch.
+  execSync(`git clone ${comfyRepo} --depth 1 --branch ${pkg.config.comfyUI.optionalBranch} assets/ComfyUI`);
+} else {
+  // Checkout tag as branch.
+  execSync(`git clone ${comfyRepo} --depth 1 --branch v${pkg.config.comfyUI.version} assets/ComfyUI`);
+}
 execSync(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);
 execSync(`cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git checkout ${pkg.config.managerCommit} && cd ../../..`);
 execSync(`yarn run make:frontend`);

--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -5,14 +5,9 @@ import pkg from './getPackage.js';
 const comfyRepo = 'https://github.com/comfyanonymous/ComfyUI';
 const managerRepo = 'https://github.com/Comfy-Org/ComfyUI-Manager';
 
-// Needed to do cherry-picks
-execSync('git config --global user.email "build-bot@example.com"');
-execSync('git config --global user.name "Build Bot"');
-
 // Clone and checkout base versions
 execSync(`git clone ${comfyRepo} --depth 1 --branch ${pkg.config.comfyBranch} assets/ComfyUI`);
 execSync(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);
 execSync(`cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git checkout ${pkg.config.managerCommit} && cd ../../..`);
-
 execSync(`yarn run make:frontend`);
 execSync(`yarn run download:uv all`);

--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -10,35 +10,9 @@ execSync('git config --global user.email "build-bot@example.com"');
 execSync('git config --global user.name "Build Bot"');
 
 // Clone and checkout base versions
-execSync(`git clone ${comfyRepo} --depth 1 --branch v${pkg.config.comfyVersion} assets/ComfyUI`);
+execSync(`git clone ${comfyRepo} --depth 1 --branch ${pkg.config.comfyBranch} assets/ComfyUI`);
 execSync(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);
 execSync(`cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git checkout ${pkg.config.managerCommit} && cd ../../..`);
-
-// Cherry-pick commits for ComfyUI if specified
-if (pkg.config.comfyCherryPicks?.length > 0) {
-  for (const commit of pkg.config.comfyCherryPicks) {
-    try {
-      execSync(`cd assets/ComfyUI && git fetch origin ${commit} && git cherry-pick ${commit} && cd ../..`);
-    } catch (error) {
-      console.error(`Failed to cherry-pick commit ${commit} for ComfyUI:`, error.message);
-      throw error;
-    }
-  }
-}
-
-// Cherry-pick commits for Manager if specified
-if (pkg.config.managerCherryPicks?.length > 0) {
-  for (const commit of pkg.config.managerCherryPicks) {
-    try {
-      execSync(
-        `cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git fetch origin ${commit} && git cherry-pick ${commit} && cd ../../../..`
-      );
-    } catch (error) {
-      console.error(`Failed to cherry-pick commit ${commit} for Manager:`, error.message);
-      throw error;
-    }
-  }
-}
 
 execSync(`yarn run make:frontend`);
 execSync(`yarn run download:uv all`);

--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -5,8 +5,36 @@ import pkg from './getPackage.js';
 const comfyRepo = 'https://github.com/comfyanonymous/ComfyUI';
 const managerRepo = 'https://github.com/Comfy-Org/ComfyUI-Manager';
 
+// Clone and checkout base versions
 execSync(`git clone ${comfyRepo} --depth 1 --branch v${pkg.config.comfyVersion} assets/ComfyUI`);
 execSync(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);
 execSync(`cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git checkout ${pkg.config.managerCommit} && cd ../../..`);
+
+// Cherry-pick commits for ComfyUI if specified
+if (pkg.config.comfyCherryPicks?.length > 0) {
+  for (const commit of pkg.config.comfyCherryPicks) {
+    try {
+      execSync(`cd assets/ComfyUI && git fetch origin ${commit} && git cherry-pick ${commit} && cd ../..`);
+    } catch (error) {
+      console.error(`Failed to cherry-pick commit ${commit} for ComfyUI:`, error.message);
+      throw error;
+    }
+  }
+}
+
+// Cherry-pick commits for Manager if specified
+if (pkg.config.managerCherryPicks?.length > 0) {
+  for (const commit of pkg.config.managerCherryPicks) {
+    try {
+      execSync(
+        `cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git fetch origin ${commit} && git cherry-pick ${commit} && cd ../../../..`
+      );
+    } catch (error) {
+      console.error(`Failed to cherry-pick commit ${commit} for Manager:`, error.message);
+      throw error;
+    }
+  }
+}
+
 execSync(`yarn run make:frontend`);
 execSync(`yarn run download:uv all`);

--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -5,7 +5,6 @@ import pkg from './getPackage.js';
 const comfyRepo = 'https://github.com/comfyanonymous/ComfyUI';
 const managerRepo = 'https://github.com/Comfy-Org/ComfyUI-Manager';
 
-// Clone and checkout base versions
 execSync(`git clone ${comfyRepo} --depth 1 --branch ${pkg.config.comfyBranch} assets/ComfyUI`);
 execSync(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);
 execSync(`cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git checkout ${pkg.config.managerCommit} && cd ../../..`);

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -26,7 +26,7 @@ export function getBuildConfig(env: ConfigEnv): UserConfig {
     clearScreen: false,
 
     define: {
-      __COMFYUI_VERSION__: JSON.stringify(pkg.config.comfyVersion),
+      __COMFYUI_VERSION__: JSON.stringify(pkg.config.comfyUI.version),
       __COMFYUI_DESKTOP_VERSION__: JSON.stringify(process.env.npm_package_version),
     },
 


### PR DESCRIPTION
Sometimes we need to release a commit that has not made it to a ComfyUI stable release yet.

In this PR we are adding the ComfyUI branch [desktop-release-feb172025](https://github.com/comfyanonymous/ComfyUI/tree/refs/heads/desktop-release-feb172025), which includes the commit for https://github.com/comfyanonymous/ComfyUI/pull/6807 to fix installing in locations with special characters on Windows.

Full CI Run Complete
https://github.com/comfyanonymous/ComfyUI/actions/runs/13378074466

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-911-Add-support-for-bundling-cherry-picked-branches-in-Build-Process-19c6d73d3650810aa9e4f47dda8bd9c3) by [Unito](https://www.unito.io)
