### PR TITLE
Use upstream Manager.

### DIFF
--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -26,6 +26,9 @@ cffi==1.17.1
     #   pynacl
     #   soundfile
     # from https://pypi.org/simple
+chardet==5.2.0
+    # via -r assets/ComfyUI/custom_nodes/ComfyUI-Manager/requirements.txt
+    # from https://pypi.org/simple
 charset-normalizer==3.4.1
     # via requests
     # from https://pypi.org/simple

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -27,6 +27,9 @@ cffi==1.17.1
     #   pynacl
     #   soundfile
     # from https://pypi.org/simple
+chardet==5.2.0
+    # via -r assets/ComfyUI/custom_nodes/ComfyUI-Manager/requirements.txt
+    # from https://pypi.org/simple
 charset-normalizer==3.4.1
     # via requests
     # from https://pypi.org/simple

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "version": "0.3.18",
       "optionalBranch": ""
     },
-    "managerCommit": "661586d3b64759bc695417b6ded0128985d1e0ef",
+    "managerCommit": "b0035ff4a7fcbe9a766f28a455c7d43dc3b93e12",
     "uvVersion": "0.5.31"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "version": "0.3.18",
       "optionalBranch": ""
     },
-    "managerCommit": "1434b12c343b58a401f1c9f913965ceb0cfd089e",
+    "managerCommit": "661586d3b64759bc695417b6ded0128985d1e0ef",
     "uvVersion": "0.5.31"
   },
   "scripts": {

--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -3,7 +3,7 @@ import { execSync } from 'node:child_process';
 import pkg from './getPackage.js';
 
 const comfyRepo = 'https://github.com/comfyanonymous/ComfyUI';
-const managerRepo = 'https://github.com/Comfy-Org/ComfyUI-Manager';
+const managerRepo = 'https://github.com/ltdrdata/ComfyUI-Manager';
 
 if (pkg.config.comfyUI.optionalBranch) {
   // Checkout branch.

--- a/src/services/cmCli.ts
+++ b/src/services/cmCli.ts
@@ -1,4 +1,3 @@
-import { app } from 'electron';
 import log from 'electron-log/main';
 import path from 'node:path';
 import { fileSync } from 'tmp';
@@ -59,7 +58,7 @@ export class CmCli implements HasTelemetry {
     try {
       log.debug('Using temp file:', tmpFile.name);
       await this.saveSnapshot(fromComfyDir, tmpFile.name, callbacks);
-      await this.restoreSnapshot(tmpFile.name, fromComfyDir, callbacks);
+      await this.restoreSnapshot(tmpFile.name, this.virtualEnvironment.basePath, callbacks);
     } finally {
       tmpFile?.removeCallback();
     }
@@ -79,14 +78,11 @@ export class CmCli implements HasTelemetry {
     log.info(output);
   }
 
-  public async restoreSnapshot(snapshotFile: string, fromComfyDir: string, callbacks: ProcessCallbacks) {
+  public async restoreSnapshot(snapshotFile: string, toComfyDir: string, callbacks: ProcessCallbacks) {
     log.info('Restoring snapshot', snapshotFile);
     const output = await this.runCommandAsync(
-      ['restore-snapshot', snapshotFile, '--user-directory', app.getPath('userData')],
-      callbacks,
-      {
-        COMFYUI_PATH: fromComfyDir,
-      }
+      ['restore-snapshot', snapshotFile, '--restore-to', toComfyDir],
+      callbacks
     );
     log.info(output);
   }

--- a/src/services/cmCli.ts
+++ b/src/services/cmCli.ts
@@ -58,7 +58,7 @@ export class CmCli implements HasTelemetry {
     try {
       log.debug('Using temp file:', tmpFile.name);
       await this.saveSnapshot(fromComfyDir, tmpFile.name, callbacks);
-      await this.restoreSnapshot(tmpFile.name, this.virtualEnvironment.basePath, callbacks);
+      await this.restoreSnapshot(tmpFile.name, path.join(this.virtualEnvironment.basePath, 'custom_nodes'), callbacks);
     } finally {
       tmpFile?.removeCallback();
     }
@@ -82,7 +82,10 @@ export class CmCli implements HasTelemetry {
     log.info('Restoring snapshot', snapshotFile);
     const output = await this.runCommandAsync(
       ['restore-snapshot', snapshotFile, '--restore-to', toComfyDir],
-      callbacks
+      callbacks,
+      {
+        COMFYUI_PATH: path.join(getAppResourcesPath(), 'ComfyUI'),
+      }
     );
     log.info(output);
   }

--- a/src/services/cmCli.ts
+++ b/src/services/cmCli.ts
@@ -58,7 +58,7 @@ export class CmCli implements HasTelemetry {
     try {
       log.debug('Using temp file:', tmpFile.name);
       await this.saveSnapshot(fromComfyDir, tmpFile.name, callbacks);
-      await this.restoreSnapshot(tmpFile.name, callbacks);
+      await this.restoreSnapshot(tmpFile.name, fromComfyDir, callbacks);
     } finally {
       tmpFile?.removeCallback();
     }
@@ -78,9 +78,11 @@ export class CmCli implements HasTelemetry {
     log.info(output);
   }
 
-  public async restoreSnapshot(snapshotFile: string, callbacks: ProcessCallbacks) {
+  public async restoreSnapshot(snapshotFile: string, fromComfyDir: string, callbacks: ProcessCallbacks) {
     log.info('Restoring snapshot', snapshotFile);
-    const output = await this.runCommandAsync(['restore-snapshot', snapshotFile], callbacks);
+    const output = await this.runCommandAsync(['restore-snapshot', snapshotFile], callbacks, {
+      COMFYUI_PATH: fromComfyDir,
+    });
     log.info(output);
   }
 }

--- a/src/services/cmCli.ts
+++ b/src/services/cmCli.ts
@@ -1,4 +1,5 @@
 import log from 'electron-log/main';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileSync } from 'tmp';
 
@@ -59,6 +60,13 @@ export class CmCli implements HasTelemetry {
       log.debug('Using temp file:', tmpFile.name);
       await this.saveSnapshot(fromComfyDir, tmpFile.name, callbacks);
       await this.restoreSnapshot(tmpFile.name, path.join(this.virtualEnvironment.basePath, 'custom_nodes'), callbacks);
+
+      // Remove extra ComfyUI-Manager directory that was created by the migration.
+      const managerPath = path.join(this.virtualEnvironment.basePath, 'custom_nodes', 'ComfyUI-Manager');
+      if (fs.existsSync(managerPath)) {
+        await fs.promises.rm(managerPath, { recursive: true, force: true });
+        log.info('Removed extra ComfyUI-Manager directory:', managerPath);
+      }
     } finally {
       tmpFile?.removeCallback();
     }

--- a/src/services/cmCli.ts
+++ b/src/services/cmCli.ts
@@ -1,7 +1,9 @@
 import log from 'electron-log/main';
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileSync } from 'tmp';
+
+import { pathAccessible } from '@/utils';
 
 import { getAppResourcesPath } from '../install/resourcePaths';
 import { ProcessCallbacks, VirtualEnvironment } from '../virtualEnvironment';
@@ -63,8 +65,8 @@ export class CmCli implements HasTelemetry {
 
       // Remove extra ComfyUI-Manager directory that was created by the migration.
       const managerPath = path.join(this.virtualEnvironment.basePath, 'custom_nodes', 'ComfyUI-Manager');
-      if (fs.existsSync(managerPath)) {
-        await fs.promises.rm(managerPath, { recursive: true, force: true });
+      if (await pathAccessible(managerPath)) {
+        await fs.rm(managerPath, { recursive: true, force: true });
         log.info('Removed extra ComfyUI-Manager directory:', managerPath);
       }
     } finally {

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -559,12 +559,10 @@ export class VirtualEnvironment implements HasTelemetry {
 
     // Manager upgrade in 0.4.18 - uv, toml (exactly)
     const isManagerUpgrade = (output: string) => {
+      // Match the original case: 2 packages (uv + toml) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/816a53a7b1a057af373c458ebf80aaae565b996b
       // Match the new case: 1 package (chardet) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/60a5e4f2614c688b41a1ebaf0694953eb26db38a
-      const latest = /\bWould install 1 package\s+\+ chardet==[\d.]+\s*$/;
-      // Match upgrade from <0.4.18: 2 additional packages (uv + toml) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/816a53a7b1a057af373c458ebf80aaae565b996b
-      const allPackages = /\bWould install 3 packages(\s+\+ (toml|uv|chardet)==[\d.]+){2}\s*$/;
-
-      return latest.test(output) || allPackages.test(output);
+      const anyCombination = /\bWould install [1-3] packages(\s+\+ (toml|uv|chardet)==[\d.]+){1,3}\s*$/;
+      return anyCombination.test(output);
     };
 
     // Package upgrade in 0.4.21 - aiohttp, av, yarl

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -559,12 +559,12 @@ export class VirtualEnvironment implements HasTelemetry {
 
     // Manager upgrade in 0.4.18 - uv, toml (exactly)
     const isManagerUpgrade = (output: string) => {
-      // Match the original case: 2 packages (uv + toml) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/816a53a7b1a057af373c458ebf80aaae565b996b
-      const twoPackages = /\bWould install 2 packages(\s+\+ (toml|uv)==[\d.]+){2}\s*$/;
       // Match the new case: 1 package (chardet) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/60a5e4f2614c688b41a1ebaf0694953eb26db38a
-      const onePackage = /\bWould install 1 package\s+\+ chardet==[\d.]+\s*$/;
+      const latest = /\bWould install 1 package\s+\+ chardet==[\d.]+\s*$/;
+      // Match upgrade from <0.4.18: 2 additional packages (uv + toml) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/816a53a7b1a057af373c458ebf80aaae565b996b
+      const allPackages = /\bWould install 3 packages(\s+\+ (toml|uv|chardet)==[\d.]+){2}\s*$/;
 
-      return twoPackages.test(output) || onePackage.test(output);
+      return latest.test(output) || allPackages.test(output);
     };
 
     // Package upgrade in 0.4.21 - aiohttp, av, yarl

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -559,7 +559,7 @@ export class VirtualEnvironment implements HasTelemetry {
 
     // Manager upgrade in 0.4.18 - uv, toml (exactly)
     const isManagerUpgrade = (output: string) => {
-      return output.search(/\bWould install 2 packages(\s+\+ (toml|uv)==[\d.]+){2}\s*$/) !== -1;
+      return output.search(/\bWould install 1 package\s+\+ chardet==[\d.]+\s*$/) !== -1;
     };
 
     // Package upgrade in 0.4.21 - aiohttp, av, yarl

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -425,7 +425,7 @@ export class VirtualEnvironment implements HasTelemetry {
     callbacks?: ProcessCallbacks,
     cwd: string = this.basePath
   ): ChildProcess {
-    log.info(`Running command: ${command} ${args.join(' ')} in ${cwd} with env ${JSON.stringify(env)}`);
+    log.info(`Running command: ${command} ${args.join(' ')} in ${cwd}`);
     const childProcess = spawn(command, args, {
       cwd,
       env: {
@@ -559,7 +559,7 @@ export class VirtualEnvironment implements HasTelemetry {
 
     // Manager upgrade in 0.4.18 - uv, toml (exactly)
     const isManagerUpgrade = (output: string) => {
-      return output.search(/\bWould install 1 package\s+\+ chardet==[\d.]+\s*$/) !== -1;
+      return output.search(/\bWould install 2 packages(\s+\+ (toml|uv)==[\d.]+){2}\s*$/) !== -1;
     };
 
     // Package upgrade in 0.4.21 - aiohttp, av, yarl

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -425,7 +425,7 @@ export class VirtualEnvironment implements HasTelemetry {
     callbacks?: ProcessCallbacks,
     cwd: string = this.basePath
   ): ChildProcess {
-    log.info(`Running command: ${command} ${args.join(' ')} in ${cwd}`);
+    log.info(`Running command: ${command} ${args.join(' ')} in ${cwd} with env ${JSON.stringify(env)}`);
     const childProcess = spawn(command, args, {
       cwd,
       env: {

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -559,7 +559,12 @@ export class VirtualEnvironment implements HasTelemetry {
 
     // Manager upgrade in 0.4.18 - uv, toml (exactly)
     const isManagerUpgrade = (output: string) => {
-      return output.search(/\bWould install 2 packages(\s+\+ (toml|uv)==[\d.]+){2}\s*$/) !== -1;
+      // Match the original case: 2 packages (uv + toml) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/816a53a7b1a057af373c458ebf80aaae565b996b
+      const twoPackages = /\bWould install 2 packages(\s+\+ (toml|uv)==[\d.]+){2}\s*$/;
+      // Match the new case: 1 package (chardet) | Added in https://github.com/ltdrdata/ComfyUI-Manager/commit/60a5e4f2614c688b41a1ebaf0694953eb26db38a
+      const onePackage = /\bWould install 1 package\s+\+ chardet==[\d.]+\s*$/;
+
+      return twoPackages.test(output) || onePackage.test(output);
     };
 
     // Package upgrade in 0.4.21 - aiohttp, av, yarl


### PR DESCRIPTION
- Includes bug fixes from manager:
https://github.com/ltdrdata/ComfyUI-Manager/commit/488f023bdf49d6b85a00e230501eb009f5ffdbd9
- Fixed: migrating custom nodes: uses `restore-to` to fix importing custom nodes.
- Remove extra ComfyUI-Manager when migrating/importing from another ComfyUI install
- Updated requirements.compiled

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-912-Use-upstream-Manager-19c6d73d365081fe9711f9baf8bb81b6) by [Unito](https://www.unito.io)
