### PR TITLE
[GitHub] Fix expander not showing in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -11,7 +11,7 @@ body:
         - **1:** You have looked at the existing bug reports and made sure this isn't already reported.
         - **2:** You confirmed that the bug is not caused by a custom node.
 
-        <detail>
+        <details>
 
         <summary>How to disable custom nodes</summary>
 
@@ -23,7 +23,7 @@ body:
 
         ![Disable custom nodes](https://github.com/user-attachments/assets/2dea6011-1baf-44b8-9115-ddfd485e239f)
 
-        </detail>
+        </details>
   - type: textarea
     attributes:
       label: App Version


### PR DESCRIPTION
Fixes bug report template issue introduced in (steps are not behind expander, indent broken):

- #916

![image](https://github.com/user-attachments/assets/e3c37c5f-a89a-43a9-b006-8ee778c7a6e7)