### PR TITLE
[GitHub] Improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -6,14 +6,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before submitting a **Bug Report**, please ensure the following:
+        ### Before submitting a **Bug Report**, please ensure the following:
 
         - **1:** You have looked at the existing bug reports and made sure this isn't already reported.
         - **2:** You confirmed that the bug is not caused by a custom node.
 
         <details>
 
-        <summary>How to disable custom nodes</summary>
+        <summary>**How to disable custom nodes**</summary>
 
         Open the setting by clicking the cog icon in the bottom-left of the screen.
 
@@ -28,8 +28,16 @@ body:
     attributes:
       label: App Version
       description: |
-        What is the version you are using? You can check this in the settings dialog
+        What is the version you are using? You can check this in the settings dialog.
+        <details>
+
+        <summary>**Where to find desktop version**</summary>
+
+        Open the setting by clicking the cog icon in the bottom-left of the screen, then click `About`.
+
         ![Desktop version](https://github.com/user-attachments/assets/eb741720-00c1-4d45-b0a2-341a45d089c5)
+
+        </details>
     validations:
       required: true
   - type: textarea
@@ -54,12 +62,25 @@ body:
     attributes:
       label: Debug Logs
       description: |
-        Please copy the output from your terminal logs here.  If the issue is related to app startup, please include `main.log` and `comfyui.log`, located in the ComfyUI log directory:
+        Please copy your logs here.  If the issue is related to starting the app, please include both `main.log` and `comfyui.log`.
+        <details>
 
-        on macOS: `~/Library/Logs/ComfyUI`
-        on Windows: `%AppData%\ComfyUI\logs`
+        <summary>**Where to find log files**</summary>
+
+        Log file locations:
+
+        - **Windows**: `%APPDATA%\ComfyUI\logs`
+        - **macOS**: `~/Library/Logs/ComfyUI`
+
+        </details>
+
+        <details>
+
+        <summary>Copy terminal logs from inside the app</summary>
 
         ![DebugLogs](https://github.com/user-attachments/assets/168b6ea3-ab93-445b-9cd2-670bd9c098a7)
+
+        </details>
       render: powershell
     validations:
       required: true
@@ -67,17 +88,32 @@ body:
     attributes:
       label: Browser Logs
       description: |
-        Please copy the output from your browser logs here.
+        Browser logs are found in the DevTools console.  Please copy the entire output here.
+
+        <details>
+
+        <summary>**How to open the console**</summary>
+
         ![OpenDevTools](https://github.com/user-attachments/assets/4505621e-34f0-4b66-b9d0-2e1a9133a635)
+
         ![ConsoleTab](https://github.com/user-attachments/assets/cc96c0db-2880-40bb-93a2-c035360c41b2)
+
+        </details>
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Setting JSON
+      label: Settings JSON
       description: |
-        Please upload the setting file here. Follow following screenshot to open model directory. The setting file is located at `../user/default/comfy.settings.json`
+        Please upload the settings file here. The settings file is located at `../user/default/comfy.settings.json`
+
+        <details>
+
+        <summary>**How to open model directory**</summary>
+
         ![OpenFolder](https://github.com/user-attachments/assets/254e41c7-6335-4d6a-a7dd-c93ab74a9d5e)
+
+        </details>
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
- Puts all images behind expanders
- Adds formatting

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-922-GitHub-Improve-bug-report-template-19d6d73d36508194809fd0d827fb6885) by [Unito](https://www.unito.io)
