### PR TITLE
[GitHub] Improve in bug report template - expanding tips

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -11,41 +11,36 @@ body:
         - **1:** You have looked at the existing bug reports and made sure this isn't already reported.
         - **2:** You confirmed that the bug is not caused by a custom node.
 
-        <details>
-
-        <summary>
-        
-        **How to disable custom nodes**
-        
-        </summary>
-
-        Open the setting by clicking the cog icon in the bottom-left of the screen.
-
-        1. Click `Server-Config`
-        1. Scroll down if necessary, then click `Disable all custom nodes`
-        1. A notification will appear; click `Restart`
-
-        ![Disable custom nodes](https://github.com/user-attachments/assets/2dea6011-1baf-44b8-9115-ddfd485e239f)
-
-        </details>
+        > [!TIP]
+        > <details>
+        > 
+        > <summary>Click to see how to disable custom nodes</summary>
+        > 
+        > Open the setting by clicking the cog icon in the bottom-left of the screen.
+        > 
+        > 1. Click `Server-Config`
+        > 1. Scroll down if necessary, then click `Disable all custom nodes`
+        > 1. A notification will appear; click `Restart`
+        > 
+        > ![Disable custom nodes](https://github.com/user-attachments/assets/2dea6011-1baf-44b8-9115-ddfd485e239f)
+        > 
+        > </details>
   - type: textarea
     attributes:
       label: App Version
       description: |
         What is the version you are using? You can check this in the settings dialog.
-        <details>
 
-        <summary>
-        
-        **Where to find desktop version**
-        
-        </summary>
-
-        Open the setting by clicking the cog icon in the bottom-left of the screen, then click `About`.
-
-        ![Desktop version](https://github.com/user-attachments/assets/eb741720-00c1-4d45-b0a2-341a45d089c5)
-
-        </details>
+        > [!TIP]
+        > <details>
+        > 
+        > <summary>Click to show where to find the version</summary>
+        > 
+        > Open the setting by clicking the cog icon in the bottom-left of the screen, then click `About`.
+        > 
+        > ![Desktop version](https://github.com/user-attachments/assets/eb741720-00c1-4d45-b0a2-341a45d089c5)
+        > 
+        > </details>
     validations:
       required: true
   - type: textarea
@@ -71,28 +66,21 @@ body:
       label: Debug Logs
       description: |
         Please copy your logs here.  If the issue is related to starting the app, please include both `main.log` and `comfyui.log`.
-        <details>
 
-        <summary>
-        
-        **Where to find log files**
-        
-        </summary>
+        > [!TIP]
+        > Log file locations:
+        > 
+        > - **Windows: `%APPDATA%\ComfyUI\logs`**
+        > - **macOS**: `~/Library/Logs/ComfyUI`
 
-        Log file locations:
-
-        - **Windows**: `%APPDATA%\ComfyUI\logs`
-        - **macOS**: `~/Library/Logs/ComfyUI`
-
-        </details>
-
-        <details>
-
-        <summary>Copy terminal logs from inside the app</summary>
-
-        ![DebugLogs](https://github.com/user-attachments/assets/168b6ea3-ab93-445b-9cd2-670bd9c098a7)
-
-        </details>
+        > [!TIP]
+        > <details>
+        > 
+        > <summary>Copy terminal logs from inside the app</summary>
+        > 
+        > ![DebugLogs](https://github.com/user-attachments/assets/168b6ea3-ab93-445b-9cd2-670bd9c098a7)
+        > 
+        > </details>
       render: powershell
     validations:
       required: true
@@ -102,19 +90,16 @@ body:
       description: |
         Browser logs are found in the DevTools console.  Please copy the entire output here.
 
-        <details>
-
-        <summary>
-        
-        **How to open the console**
-        
-        </summary>
-
-        ![OpenDevTools](https://github.com/user-attachments/assets/4505621e-34f0-4b66-b9d0-2e1a9133a635)
-
-        ![ConsoleTab](https://github.com/user-attachments/assets/cc96c0db-2880-40bb-93a2-c035360c41b2)
-
-        </details>
+        > [!TIP]
+        > <details>
+        > 
+        > <summary>Click to show how to open the browser console</summary>
+        > 
+        > ![OpenDevTools](https://github.com/user-attachments/assets/4505621e-34f0-4b66-b9d0-2e1a9133a635)
+        > 
+        > ![ConsoleTab](https://github.com/user-attachments/assets/cc96c0db-2880-40bb-93a2-c035360c41b2)
+        > 
+        > </details>
     validations:
       required: true
   - type: textarea
@@ -123,17 +108,14 @@ body:
       description: |
         Please upload the settings file here. The settings file is located at `../user/default/comfy.settings.json`
 
-        <details>
-
-        <summary>
-        
-        **How to open model directory**
-        
-        </summary>
-
-        ![OpenFolder](https://github.com/user-attachments/assets/254e41c7-6335-4d6a-a7dd-c93ab74a9d5e)
-
-        </details>
+        > [!TIP]
+        > <details>
+        > 
+        > <summary>Click to show how to open the models directory</summary>
+        > 
+        > ![OpenFolder](https://github.com/user-attachments/assets/254e41c7-6335-4d6a-a7dd-c93ab74a9d5e)
+        > 
+        > </details>
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Use expanders nested in `Tip` callouts to hide images and steps by default.