### PR TITLE
[e2e] Fix flaky test - mark fix venv as slow

### DIFF
--- a/tests/integration/post-install/troubleshootingVenv.spec.ts
+++ b/tests/integration/post-install/troubleshootingVenv.spec.ts
@@ -12,6 +12,8 @@ test.describe('Troubleshooting - broken venv', () => {
   });
 
   test('Can fix venv', async ({ troubleshooting, serverStart, installedApp }) => {
+    test.slow();
+
     await troubleshooting.expectReady();
     const { resetVenvCard, installPythonPackagesCard } = troubleshooting;
     await expect(resetVenvCard.rootEl).toBeVisible();


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-927-e2e-Fix-flaky-test-mark-fix-venv-as-slow-19d6d73d365081149cffd2b78a55ea18) by [Unito](https://www.unito.io)
