### PR TITLE
Fix manager package update metric always runs

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -52,7 +52,7 @@ export class InstallationManager implements HasTelemetry {
       if (state === 'upgraded') installation.upgradeConfig();
 
       // Install updated manager requirements
-      await this.updateManagerPackages(installation);
+      if (installation.needsManagerPackageUpdate) await this.updateManagerPackages(installation);
 
       // Resolve issues and re-run validation
       if (installation.hasIssues) {
@@ -317,8 +317,6 @@ export class InstallationManager implements HasTelemetry {
 
   @trackEvent('installation_manager:manager_packages_update')
   private async updateManagerPackages(installation: ComfyInstallation) {
-    if (installation.validation.managerPythonPackages !== 'warning') return;
-
     const sendLogIpc = (data: string) => {
       log.info(data);
       this.appWindow.send(IPC_CHANNELS.LOG_MESSAGE, data);

--- a/src/main-process/comfyInstallation.ts
+++ b/src/main-process/comfyInstallation.ts
@@ -40,6 +40,11 @@ export class ComfyInstallation {
     return this.state === 'installed' && !this.hasIssues;
   }
 
+  /** `true` if Manager needs toml and uv to be installed, otherwise `false`. */
+  get needsManagerPackageUpdate() {
+    return this.validation.managerPythonPackages === 'warning';
+  }
+
   /**
    * Called during/after each step of validation
    * @param data The data to send to the renderer


### PR DESCRIPTION
Ensures the event to record manager package update is skipped along with the update itself.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-931-Fix-manager-package-update-metric-always-runs-19d6d73d36508118b38ae71fe62e11d9) by [Unito](https://www.unito.io)
