### PR TITLE
Fix reinstall in help menu only works after fresh install

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -37,6 +37,9 @@ export class InstallationManager implements HasTelemetry {
     // Resume installation
     if (installation.state === 'started') return await this.resumeInstallation();
 
+    // Replace the reinstall IPC handler.
+    InstallationManager.setReinstallHandler(installation);
+
     // Validate the installation
     return await this.validateInstallation(installation);
   }


### PR DESCRIPTION
Fixes regression in help -> reinstall behaviour - now works on any app open.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-937-Fix-reinstall-in-help-menu-only-works-after-fresh-install-19e6d73d365081b4bfcdcd69958e6e4e) by [Unito](https://www.unito.io)
