### PR TITLE
Prevent unexpected error message on window close

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -132,17 +132,20 @@ export class AppWindow {
       this.messageQueue.push({ channel, data });
       return;
     }
+    const { webContents } = this.window;
 
     // Send queued messages first
     while (this.messageQueue.length > 0) {
       const message = this.messageQueue.shift();
-      if (message && this.window) {
-        this.window.webContents.send(message.channel, message.data);
+      if (message && !webContents.isDestroyed()) {
+        webContents.send(message.channel, message.data);
       }
     }
 
     // Send current message
-    this.window.webContents.send(channel, data);
+    if (!webContents.isDestroyed()) {
+      webContents.send(channel, data);
+    }
   }
 
   /**


### PR DESCRIPTION
Guards against unhandled exception error dialog when closing the app during app start, by closing the window.

Requires losing a tight async race; this should not have been experienced by many users.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-939-Prevent-unexpected-error-message-on-window-close-19e6d73d3650814fb5f1d8db7e7d0665) by [Unito](https://www.unito.io)
