### PR TITLE
Prevent white flashes when browsing pages

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -97,6 +97,7 @@ export class AppWindow {
       minHeight: 640,
       x,
       y,
+      backgroundColor: '#171717',
       webPreferences: {
         // eslint-disable-next-line unicorn/prefer-module
         preload: path.join(__dirname, '../build/preload.cjs'),


### PR DESCRIPTION
### Electron-accepted solution to brief flash of white

Long-standing, well-known Chromium issue - flash of white on renderer start.  Electron restarts renderer each navigation.

- Hard-codes the background colour to #171717
  - Can be altered if we move from default-dark-mode, and a brief flash of really-dark-grey is visually disruptive
- https://www.electronjs.org/docs/latest/api/browser-window#setting-the-backgroundcolor-property

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-940-Prevent-white-flashes-when-browsing-pages-19e6d73d365081a28dadd78ef29fa3cf) by [Unito](https://www.unito.io)
