### PR TITLE
[CI] Ignore unit test updates in E2E workflow

### DIFF
--- a/.github/workflows/integration_test_windows.yml
+++ b/.github/workflows/integration_test_windows.yml
@@ -16,6 +16,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.cursor/**'
       - '*_example'
+      - 'tests/unit/**'
   push:
     branches: [main]
     paths-ignore:
@@ -31,6 +32,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.cursor/**'
       - '*_example'
+      - 'tests/unit/**'
 
 jobs:
   integration-windows-test:


### PR DESCRIPTION
Changes to unit tests have no impact on end-to-end tests.  E2E workflow will not be triggered.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-942-CI-Ignore-unit-test-updates-in-E2E-workflow-19e6d73d3650814eae5fe4d30d9b7264) by [Unito](https://www.unito.io)
