### PR TITLE
[API] Publish types for version 0.4.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
- Automated minor version bump to: 0.4.20
- Triggers npm publish workflow of API types

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-948-0-4-20-types-19f6d73d3650818e848cccc901bce3c3) by [Unito](https://www.unito.io)
