### PR TITLE
[chore] Update frontend to 1.9.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.9.15",
+    "frontendVersion": "1.9.18",
     "comfyUI": {
       "version": "0.3.14",
       "optionalBranch": "desktop-release-feb172025"


### PR DESCRIPTION
- Update frontend to 1.9.18: https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.9.18
- Resolves #951

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-952-chore-Update-frontend-to-1-9-18-19f6d73d365081c0ad1bca3a7bc865c5) by [Unito](https://www.unito.io)
