### PR TITLE
[API] Remove unused internal types

### DIFF
--- a/src/main_types.ts
+++ b/src/main_types.ts
@@ -1,5 +1,5 @@
 export * from './constants';
-export type { DownloadManager, Download, DownloadState } from './models/DownloadManager';
+export type { DownloadState } from './models/DownloadManager';
 export type {
   ElectronAPI,
   ElectronContextMenuOptions,


### PR DESCRIPTION
- Reduces API size
- Removes types which are not actually accessible via API

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-955-API-Remove-unused-internal-types-19f6d73d365081ebaa3ddbfe25d69799) by [Unito](https://www.unito.io)
