### PR TITLE
[CI] Do not build when updating tests

### DIFF
--- a/.github/workflows/debug_all.yml
+++ b/.github/workflows/debug_all.yml
@@ -17,6 +17,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.cursor/**'
       - '*_example'
+      - 'tests/**'
   push:
     branches:
       - 'main'
@@ -33,6 +34,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.cursor/**'
       - '*_example'
+      - 'tests/**'
 
 jobs:
   build-windows-debug-all:


### PR DESCRIPTION
Changing tests does alter build artifacts.  Build CI will be skipped.