### PR TITLE
[chore] Update frontend to 1.10.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.9.18",
+    "frontendVersion": "1.10.7",
     "comfyUI": {
       "version": "0.3.14",
       "optionalBranch": "desktop-release-feb172025"


### PR DESCRIPTION
Automated frontend update to 1.10.7: https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.10.7

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-961-chore-Update-frontend-to-1-10-7-1a06d73d365081ae9ee3ed8bb7a9934c) by [Unito](https://www.unito.io)
