### PR TITLE
[API] Add disableCustomNodes endpoint

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,7 @@ export const IPC_CHANNELS = {
   UV_RESET_VENV: 'uv-delete-venv',
   CAN_ACCESS_URL: 'can-access-url',
   START_TROUBLESHOOTING: 'start-troubleshooting',
+  DISABLE_CUSTOM_NODES: 'disable-custom-nodes',
 } as const;
 
 export enum ProgressStatus {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -413,6 +413,11 @@ const electronAPI = {
     await ipcRenderer.invoke(IPC_CHANNELS.START_TROUBLESHOOTING);
   },
 
+  /** Disables custom nodes by setting the `Comfy.Server.LaunchArgs` to an empty array. */
+  disableCustomNodes: async () => {
+    await ipcRenderer.invoke(IPC_CHANNELS.DISABLE_CUSTOM_NODES);
+  },
+
   uv: {
     /**
      * Install the requirements for the ComfyUI server.


### PR DESCRIPTION
- Adds IPC channel and frontend endpoint
- Not implemented
- PR is ahead of impl. to ensure it is included in the API type package

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-966-API-Add-disableCustomNodes-endpoint-1a06d73d36508187b752c6a1e05afa5a) by [Unito](https://www.unito.io)
