### PR TITLE
[Test] Globally mock sentry and telemetry

### DIFF
--- a/tests/unit/services/telemetry.test.ts
+++ b/tests/unit/services/telemetry.test.ts
@@ -9,6 +9,9 @@ import type { AppWindow } from '@/main-process/appWindow';
 import { MixpanelTelemetry, promptMetricsConsent } from '@/services/telemetry';
 import type { DesktopConfig } from '@/store/desktopConfig';
 
+vi.unmock('@sentry/electron/main');
+vi.unmock('@/services/telemetry');
+
 vi.mock('@sentry/electron/main', () => ({
   init: vi.fn(),
   captureException: vi.fn(),

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,5 +1,7 @@
 import { vi } from 'vitest';
 
+import type { ITelemetry } from '@/services/telemetry';
+
 vi.mock('electron-log/main');
 
 vi.mock('@/main-process/appState', () => ({
@@ -14,3 +16,22 @@ vi.mock('@/main-process/appState', () => ({
     emitLoaded: vi.fn(),
   }),
 }));
+
+const mockTelemetry: ITelemetry = {
+  track: vi.fn(),
+  hasConsent: true,
+  flush: vi.fn(),
+  registerHandlers: vi.fn(),
+};
+
+vi.mock('@/services/sentry');
+
+vi.mock('@/services/telemetry', async () => {
+  const actual = await vi.importActual<typeof import('@/services/telemetry')>('@/services/telemetry');
+
+  return {
+    ...actual,
+    getTelemetry: vi.fn().mockReturnValue(mockTelemetry),
+    promptMetricsConsent: vi.fn().mockResolvedValue(true),
+  };
+});


### PR DESCRIPTION
- Makes tests less brittle by mocking global singletons once during setup.
- Unmocked at start of relevant test files

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-972-Test-Globally-mock-sentry-and-telemetry-1a16d73d365081ada2cbfb8acc5be309) by [Unito](https://www.unito.io)
