### PR TITLE
Launch server with stdout logging option by default

### DIFF
--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -88,6 +88,7 @@ export class ComfyServer implements HasTelemetry {
       'front-end-root': this.webRootPath,
       'base-directory': this.basePath,
       'extra-model-paths-config': ComfyServerConfig.configPath,
+      'log-stdout': '',
     };
   }
 


### PR DESCRIPTION
### comfyui.log

Default logging change:

- ComfyUI server now logs to stdout for all log levels below warning
- `comfyui.log` entries are prefixed with `[info]` instead of `[error]`
- Warning & error level server logging remains unchanged

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-975-Launch-server-with-stdout-logging-option-by-default-1a16d73d365081fcbf11ddc21320ccca) by [Unito](https://www.unito.io)
