### PR TITLE
Fix error attempting to migrate with same source and destination

### DIFF
--- a/src/install/installWizard.ts
+++ b/src/install/installWizard.ts
@@ -46,7 +46,11 @@ export class InstallWizard implements HasTelemetry {
     // Copy user files from migration source to the new ComfyUI folder.
     const srcUserFilesDir = path.join(this.migrationSource, 'user');
     const destUserFilesDir = path.join(this.basePath, 'user');
-    fs.cpSync(srcUserFilesDir, destUserFilesDir, { recursive: true });
+    if (path.resolve(srcUserFilesDir) !== path.resolve(destUserFilesDir)) {
+      fs.cpSync(srcUserFilesDir, destUserFilesDir, { recursive: true });
+    } else {
+      log.warn(`Skipping user files migration: source and destination are the same (${srcUserFilesDir})`);
+    }
   }
 
   /**

--- a/tests/unit/install/installWizard.test.ts
+++ b/tests/unit/install/installWizard.test.ts
@@ -107,6 +107,24 @@ describe('InstallWizard', () => {
       expect(getTelemetry().track).not.toHaveBeenCalled();
     });
 
+    it('should not copy files when source and destination are the same', () => {
+      const wizardWithSamePaths = new InstallWizard(
+        {
+          ...defaultInstallOptions,
+          installPath: '/test/path',
+          migrationSourcePath: '/test/path',
+          migrationItemIds: ['user_files'],
+        },
+        getTelemetry()
+      );
+
+      wizardWithSamePaths.initializeUserFiles();
+
+      expect(fs.cpSync).not.toHaveBeenCalled();
+      // Should still track that we attempted migration
+      expect(getTelemetry().track).toHaveBeenCalledWith('migrate_flow:migrate_user_files');
+    });
+
     it('should copy user files when migration source is set and user_files is in migrationItemIds', () => {
       const wizardWithMigration = new InstallWizard(
         {


### PR DESCRIPTION
Guards against issue during migration in which the source and destination folder are the same, which seems to happen after restarting an aborted installation that proceeded past migration initially.

There are 124 instances of this error in past 3 days (2.7%): [error report](https://comfy-org.sentry.io/issues/6312995827/events/d72da9eaa3504ddd8a9bdc9b729ee995/events/?cursor=0%3A0%3A1&project=4508007940685824)