### PR TITLE
[Test] Fix state leakage between unit tests

### DIFF
--- a/tests/unit/config/comfyServerConfig.test.ts
+++ b/tests/unit/config/comfyServerConfig.test.ts
@@ -5,7 +5,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import fsPromises from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ComfyServerConfig } from '@/config/comfyServerConfig';
 
@@ -16,7 +16,7 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('@/install/resourcePaths', () => ({
-  getAppResourcesPath: vi.fn().mockReturnValue('/mocked/app_resources'),
+  getAppResourcesPath: vi.fn(() => '/mocked/app_resources'),
 }));
 
 async function createTmpDir() {
@@ -30,13 +30,17 @@ async function copyFixture(fixturePath: string, targetPath: string) {
 }
 
 describe('ComfyServerConfig', () => {
+  const mockUserDataPath = '/fake/user/data';
   let tempDir = '';
 
   beforeAll(async () => {
     tempDir = await createTmpDir();
-    vi.mocked(app.getPath).mockImplementation((name: string) => {
-      if (name === 'userData') return '/fake/user/data';
-      throw new Error(`Unexpected getPath key: ${name}`);
+  });
+
+  beforeEach(() => {
+    vi.mocked(app.getPath).mockImplementation((key: string) => {
+      if (key === 'userData') return '/fake/user/data';
+      throw new Error(`Unexpected getPath key: ${key}`);
     });
   });
 
@@ -46,17 +50,13 @@ describe('ComfyServerConfig', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    vi.unstubAllGlobals();
   });
 
   describe('configPath', () => {
     it('should return the correct path', () => {
-      const mockUserDataPath = '/fake/user/data';
       const { getPath } = app;
       vi.mocked(getPath).mockImplementation((key: string) => {
-        if (key === 'userData') {
-          return mockUserDataPath;
-        }
+        if (key === 'userData') return mockUserDataPath;
         throw new Error(`Unexpected getPath key: ${key}`);
       });
 

--- a/tests/unit/desktopApp.test.ts
+++ b/tests/unit/desktopApp.test.ts
@@ -25,8 +25,8 @@ vi.mock('electron', () => ({
     exit: vi.fn(() => {
       throw new Error('Test exited via app.exit()');
     }),
-    getPath: vi.fn().mockReturnValue('/mock/app/path'),
-    getAppPath: vi.fn().mockReturnValue('/mock/app/path'),
+    getPath: vi.fn(() => '/mock/app/path'),
+    getAppPath: vi.fn(() => '/mock/app/path'),
   },
   dialog: {
     showErrorBox: vi.fn(),
@@ -41,14 +41,14 @@ vi.mock('electron', () => ({
 }));
 
 const mockAppWindow = {
-  loadPage: vi.fn().mockResolvedValue(undefined),
+  loadPage: vi.fn(),
   send: vi.fn(),
   sendServerStartProgress: vi.fn(),
-  loadComfyUI: vi.fn().mockResolvedValue(undefined),
+  loadComfyUI: vi.fn(),
 };
 
 vi.mock('@/main-process/appWindow', () => ({
-  AppWindow: vi.fn().mockImplementation(() => mockAppWindow),
+  AppWindow: vi.fn(() => mockAppWindow),
 }));
 
 vi.mock('@/config/comfySettings', () => ({
@@ -59,18 +59,18 @@ vi.mock('@/config/comfySettings', () => ({
       saveSettings: vi.fn(),
     }),
   },
-  useComfySettings: vi.fn().mockReturnValue({
-    get: vi.fn().mockReturnValue('true'),
+  useComfySettings: vi.fn(() => ({
+    get: vi.fn(),
     set: vi.fn(),
     saveSettings: vi.fn(),
-  }),
+  })),
 }));
 
 vi.mock('@/store/desktopConfig', () => ({
-  useDesktopConfig: vi.fn().mockReturnValue({
-    get: vi.fn().mockReturnValue('/mock/path'),
+  useDesktopConfig: vi.fn(() => ({
+    get: vi.fn(() => '/mock/path'),
     set: vi.fn(),
-  }),
+  })),
 }));
 
 const mockInstallation: Partial<ComfyInstallation> = {
@@ -84,7 +84,7 @@ const mockInstallation: Partial<ComfyInstallation> = {
 };
 
 const mockInstallationManager = {
-  ensureInstalled: vi.fn().mockResolvedValue(mockInstallation),
+  ensureInstalled: vi.fn(() => Promise.resolve(mockInstallation)),
 };
 vi.mock('@/install/installationManager', () => ({
   InstallationManager: Object.assign(
@@ -94,27 +94,18 @@ vi.mock('@/install/installationManager', () => ({
 }));
 
 const mockComfyDesktopApp = {
-  buildServerArgs: vi.fn().mockResolvedValue({ port: '8188' }),
-  startComfyServer: vi.fn().mockResolvedValue(undefined),
+  buildServerArgs: vi.fn(),
+  startComfyServer: vi.fn(),
 };
 vi.mock('@/main-process/comfyDesktopApp', () => ({
-  ComfyDesktopApp: vi.fn().mockImplementation(() => mockComfyDesktopApp),
+  ComfyDesktopApp: vi.fn(() => mockComfyDesktopApp),
 }));
 
 vi.mock('@/services/sentry', () => ({
   default: {
-    setSentryGpuContext: vi.fn().mockResolvedValue(undefined),
+    setSentryGpuContext: vi.fn(),
     getBasePath: vi.fn(),
   },
-}));
-
-vi.mock('@/services/telemetry', () => ({
-  getTelemetry: vi.fn().mockReturnValue({
-    hasConsent: false,
-    track: vi.fn(),
-    flush: vi.fn(),
-  }),
-  promptMetricsConsent: vi.fn().mockResolvedValue(true),
 }));
 
 describe('DesktopApp', () => {

--- a/tests/unit/handlers/appinfoHandlers.test.ts
+++ b/tests/unit/handlers/appinfoHandlers.test.ts
@@ -12,7 +12,7 @@ vi.mock('electron', () => ({
   app: {
     isPackaged: false,
     getPath: vi.fn(),
-    getVersion: vi.fn().mockReturnValue('1.0.0'),
+    getVersion: vi.fn(() => '1.0.0'),
   },
   ipcMain: {
     on: vi.fn(),
@@ -21,17 +21,17 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('@/store/desktopConfig', () => ({
-  useDesktopConfig: vi.fn().mockReturnValue({
-    get: vi.fn().mockImplementation((key) => {
+  useDesktopConfig: vi.fn(() => ({
+    get: vi.fn((key: string) => {
       if (key === 'basePath') return MOCK_BASE_PATH;
     }),
-    set: vi.fn().mockReturnValue(true),
-    getAsync: vi.fn().mockImplementation((key) => {
+    set: vi.fn(),
+    getAsync: vi.fn((key: string) => {
       if (key === 'windowStyle') return Promise.resolve(MOCK_WINDOW_STYLE);
       if (key === 'detectedGpu') return Promise.resolve(MOCK_GPU_NAME);
     }),
-    setAsync: vi.fn().mockReturnValue(Promise.resolve(true)),
-  }),
+    setAsync: vi.fn(),
+  })),
 }));
 
 vi.mock('@/config/comfyServerConfig', () => ({

--- a/tests/unit/main-process/appWindow.test.ts
+++ b/tests/unit/main-process/appWindow.test.ts
@@ -35,19 +35,19 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('electron-store', () => ({
-  default: vi.fn().mockImplementation(() => ({
+  default: vi.fn(() => ({
     get: vi.fn(),
     set: vi.fn(),
   })),
 }));
 
 vi.mock('@/store/desktopConfig', () => ({
-  useDesktopConfig: vi.fn().mockReturnValue({
-    get: vi.fn().mockImplementation((key) => {
+  useDesktopConfig: vi.fn(() => ({
+    get: vi.fn((key: string) => {
       if (key === 'installState') return 'installed';
     }),
-    set: vi.fn().mockReturnValue(true),
-  }),
+    set: vi.fn(),
+  })),
 }));
 
 describe('AppWindow.isOnPage', () => {

--- a/tests/unit/main-process/comfyDesktopApp.test.ts
+++ b/tests/unit/main-process/comfyDesktopApp.test.ts
@@ -15,15 +15,15 @@ import { findAvailablePort, getModelsDirectory } from '@/utils';
 // Mock dependencies
 vi.mock('@/config/comfySettings', () => {
   const mockSettings = {
-    get: vi.fn().mockReturnValue(true),
+    get: vi.fn(() => true),
     set: vi.fn(),
     saveSettings: vi.fn(),
   };
   return {
     ComfySettings: {
-      load: vi.fn().mockResolvedValue(mockSettings),
+      load: vi.fn(() => Promise.resolve(mockSettings)),
     },
-    useComfySettings: vi.fn().mockReturnValue(mockSettings),
+    useComfySettings: vi.fn(() => mockSettings),
   };
 });
 
@@ -63,7 +63,7 @@ const mockTerminal = {
   restore: vi.fn(),
 };
 vi.mock('@/shell/terminal', () => ({
-  Terminal: vi.fn().mockImplementation(() => mockTerminal),
+  Terminal: vi.fn(() => mockTerminal),
 }));
 
 vi.mock('@/main-process/comfyServer', () => ({

--- a/tests/unit/services/telemetry.test.ts
+++ b/tests/unit/services/telemetry.test.ts
@@ -20,9 +20,9 @@ vi.mock('@sentry/electron/main', () => ({
 
 vi.mock('electron', () => ({
   app: {
-    getPath: vi.fn().mockReturnValue('/mock/user/data'),
+    getPath: vi.fn(() => '/mock/user/data'),
     isPackaged: true,
-    getVersion: vi.fn().mockReturnValue('1.0.0'),
+    getVersion: vi.fn(() => '1.0.0'),
   },
   ipcMain: {
     on: vi.fn(),
@@ -60,7 +60,7 @@ vi.mock('@/config/comfySettings', () => {
     ComfySettings: {
       load: vi.fn().mockResolvedValue(mockSettings),
     },
-    useComfySettings: vi.fn().mockReturnValue(mockSettings),
+    useComfySettings: vi.fn(() => mockSettings),
   };
 });
 
@@ -74,12 +74,14 @@ vi.mock('mixpanel', () => ({
   },
 }));
 
-vi.mock('@/store/desktopConfig', () => ({
-  useDesktopConfig: vi.fn().mockReturnValue({
-    get: vi.fn().mockReturnValue('/mock/path'),
-    set: vi.fn(),
-  }),
-}));
+const config = {
+  get: vi.fn(() => '/mock/path'),
+  set: vi.fn(),
+};
+const configModule = {
+  useDesktopConfig: vi.fn(() => config),
+};
+vi.mock('@/store/desktopConfig', () => configModule);
 
 describe('MixpanelTelemetry', () => {
   let telemetry: MixpanelTelemetry;
@@ -91,7 +93,7 @@ describe('MixpanelTelemetry', () => {
     },
   };
   const mockMixpanelClient = {
-    init: vi.fn().mockReturnValue(mockInitializedMixpanelClient),
+    init: vi.fn(() => mockInitializedMixpanelClient),
   };
 
   beforeEach(async () => {

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -4,17 +4,18 @@ import type { ITelemetry } from '@/services/telemetry';
 
 vi.mock('electron-log/main');
 
+const appState = {
+  initialize: vi.fn(),
+  isQuitting: false,
+  ipcRegistered: false,
+  loaded: false,
+  currentPage: undefined,
+  emitIpcRegistered: vi.fn(),
+  emitLoaded: vi.fn(),
+};
 vi.mock('@/main-process/appState', () => ({
   initializeAppState: vi.fn(),
-  useAppState: vi.fn().mockReturnValue({
-    initialize: vi.fn(),
-    isQuitting: false,
-    ipcRegistered: false,
-    loaded: false,
-    currentPage: undefined,
-    emitIpcRegistered: vi.fn(),
-    emitLoaded: vi.fn(),
-  }),
+  useAppState: vi.fn(() => appState),
 }));
 
 const mockTelemetry: ITelemetry = {
@@ -31,7 +32,7 @@ vi.mock('@/services/telemetry', async () => {
 
   return {
     ...actual,
-    getTelemetry: vi.fn().mockReturnValue(mockTelemetry),
+    getTelemetry: vi.fn(() => mockTelemetry),
     promptMetricsConsent: vi.fn().mockResolvedValue(true),
   };
 });

--- a/tests/unit/store/desktopConfig.test.ts
+++ b/tests/unit/store/desktopConfig.test.ts
@@ -9,7 +9,7 @@ import { DesktopConfig, useDesktopConfig } from '@/store/desktopConfig';
 
 vi.mock('electron', () => ({
   app: {
-    getPath: vi.fn().mockReturnValue('/mock/user/data'),
+    getPath: vi.fn(() => '/mock/user/data'),
     quit: vi.fn(),
   },
   dialog: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,8 @@ export default defineConfig((env) => {
       name: 'main',
       include: ['tests/unit/**/*.test.ts'],
       setupFiles: ['./tests/unit/setup.ts'],
+      restoreMocks: true,
+      unstubGlobals: true,
     },
   };
 


### PR DESCRIPTION
- Unit tests are now isolated by performing a full reset of all mocks.
- Default mocks are now added using the proper default mock syntax, rather than adding a resettable mock at the start of a file.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-978-Test-Fix-state-leakage-between-unit-tests-1a26d73d36508143809dfb07d80bae63) by [Unito](https://www.unito.io)
