### PR TITLE
Add event name to error report

### DIFF
--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -39,9 +39,10 @@ const getLogTail = (numLines: number, logFilename: string): string => {
 /**
  * Capture a Sentry exception and return the Sentry URL for the captured event.
  * @param error The error to capture
+ * @param eventName The name to tag the captured Sentry event with
  * @returns The Sentry URL for the captured event
  */
-export function captureSentryException(error: unknown) {
+export function captureSentryException(error: unknown, eventName: string) {
   const settings = useComfySettings();
   const eventId = Sentry.captureException(error, {
     tags: {
@@ -50,6 +51,7 @@ export function captureSentryException(error: unknown) {
       pythonMirror: settings.get('Comfy-Desktop.UV.PythonInstallMirror'),
       pypiMirror: settings.get('Comfy-Desktop.UV.PypiInstallMirror'),
       torchMirror: settings.get('Comfy-Desktop.UV.TorchInstallMirror'),
+      eventName,
     },
     extra: {
       logs: getLogTail(NUM_LOG_LINES_CAPTURED, MAIN_LOG_FILENAME),

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -203,8 +203,9 @@ export function trackEvent<T extends HasTelemetry>(eventName: string) {
         await originalMethod!.apply(this, args);
         this.telemetry.track(`${eventName}_end`);
       } catch (error) {
-        const sentryUrl = captureSentryException(error);
-        this.telemetry.track(`${eventName}_error`, {
+        const errorEventName = `${eventName}_error`;
+        const sentryUrl = captureSentryException(error, errorEventName);
+        this.telemetry.track(errorEventName, {
           error_message: (error as Error)?.message,
           error_name: (error as Error)?.name,
           sentry_url: sentryUrl,

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -264,8 +264,12 @@ export class VirtualEnvironment implements HasTelemetry {
       });
       log.info('Successfully created virtual environment at', this.venvPath);
     } catch (error) {
-      const sentryUrl = captureSentryException(error instanceof Error ? error : new Error(String(error)));
-      this.telemetry.track('install_flow:virtual_environment_create_error', {
+      const errorEventName = 'install_flow:virtual_environment_create_error';
+      const sentryUrl = captureSentryException(
+        error instanceof Error ? error : new Error(String(error)),
+        errorEventName
+      );
+      this.telemetry.track(errorEventName, {
         error_name: error instanceof Error ? error.name : 'UnknownError',
         error_type: error instanceof Error ? error.constructor.name : typeof error,
         error_message: error instanceof Error ? error.message : 'Unknown error occurred',


### PR DESCRIPTION
Adds Mixpanel event name to Sentry tags.

Currently, you can browse by event on Mixpanel and follow links to full Sentry reports. However, you should also be able to construct queries on Sentry and filter by Mixpanel event in the case that Sentry has additional info not available in Mixpanel query params.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-980-Add-event-name-to-error-report-1a26d73d36508135998bdc116fc88ac1) by [Unito](https://www.unito.io)
