### PR TITLE
[e2e] Always attach and remove logs after every test

### DIFF
--- a/tests/integration/testEnvironment.ts
+++ b/tests/integration/testEnvironment.ts
@@ -121,6 +121,12 @@ export class TestEnvironment implements AsyncDisposable {
     await rm(this.defaultInstallLocation, { recursive: true, force: true });
   }
 
+  async deleteLogsIfPresent() {
+    assertPlaywrightEnabled();
+    await rm(this.mainLogPath, { force: true });
+    await rm(this.comfyuiLogPath, { force: true });
+  }
+
   async [Symbol.asyncDispose]() {
     await this.restoreInstallPath();
     await this.restoreVenv();

--- a/tests/integration/testExtensions.ts
+++ b/tests/integration/testExtensions.ts
@@ -59,11 +59,13 @@ export const test = baseTest.extend<DesktopTestOptions & DesktopTestFixtures>({
     app.shouldDisposeTestEnvironment = disposeTestEnvironment;
     await use(app);
 
-    if (!disposeTestEnvironment) return;
-
     // Attach logs after test
-    await attachIfExists(testInfo, app.testEnvironment.mainLogPath);
-    await attachIfExists(testInfo, app.testEnvironment.comfyuiLogPath);
+    const testEnv = app.testEnvironment;
+    await attachIfExists(testInfo, testEnv.mainLogPath);
+    await attachIfExists(testInfo, testEnv.comfyuiLogPath);
+
+    // Delete logs if present
+    await testEnv.deleteLogsIfPresent();
   },
   window: async ({ app }, use, testInfo) => {
     const window = await app.firstWindow();


### PR DESCRIPTION
Original design was to handle test interaction.  This is no longer a priority, and logs may simply be concatenated by timestamp.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-994-e2e-Always-attach-and-remove-logs-after-every-test-1a56d73d365081e8bd0dd4776dfa9eeb) by [Unito](https://www.unito.io)
