### PR TITLE
Reinstall dependencies when detected by troubleshooting page

### DIFF
--- a/src/infrastructure/interfaces.ts
+++ b/src/infrastructure/interfaces.ts
@@ -31,5 +31,4 @@ export type Page =
   | 'metrics-consent'
   | 'server-start'
   | ''
-  | 'maintenance'
-  | 'desktop-update';
+  | 'maintenance';

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -57,6 +57,13 @@ export class InstallationManager implements HasTelemetry {
     // Convert from old format
     if (state === 'upgraded') installation.upgradeConfig();
 
+    // Install missing requirements
+    if (installation.validation.pythonPackages === 'error') {
+      log.error('Detected missing requirements. Trying to install missing requirements.');
+      await installation.virtualEnvironment.installComfyUIRequirements();
+      await installation.virtualEnvironment.installComfyUIManagerRequirements();
+      await installation.validate();
+    }
     // Resolve issues and re-run validation
     if (installation.hasIssues) {
       while (!(await this.resolveIssues(installation, troubleshooting))) {

--- a/src/main-process/comfyInstallation.ts
+++ b/src/main-process/comfyInstallation.ts
@@ -40,11 +40,6 @@ export class ComfyInstallation {
     return this.state === 'installed' && !this.hasIssues;
   }
 
-  /** `true` if Manager needs toml and uv to be installed, otherwise `false`. */
-  get needsManagerPackageUpdate() {
-    return this.validation.managerPythonPackages === 'warning';
-  }
-
   /**
    * Called during/after each step of validation
    * @param data The data to send to the renderer
@@ -135,14 +130,8 @@ export class ComfyInstallation {
 
           // Python packages
           try {
-            const result = await venv.hasRequirements();
-            if (result === 'manager-upgrade') {
-              validation.pythonPackages = 'OK';
-              validation.managerPythonPackages = 'warning';
-            } else {
-              validation.pythonPackages = result;
-              if (result !== 'OK') log.error('Virtual environment is incomplete.');
-            }
+            validation.pythonPackages = (await venv.hasRequirements()) ? 'OK' : 'error';
+            if (validation.pythonPackages !== 'OK') log.error('Virtual environment is incomplete.');
           } catch (error) {
             log.error('Failed to read venv packages.', error);
             validation.pythonPackages = 'error';

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -100,7 +100,6 @@ export interface InstallValidation {
   uv?: ValidationIssueState;
   git?: ValidationIssueState;
   vcRedist?: ValidationIssueState;
-  managerPythonPackages?: ValidationIssueState;
 }
 
 const electronAPI = {

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -493,7 +493,7 @@ export class VirtualEnvironment implements HasTelemetry {
     }
   }
 
-  private async installComfyUIRequirements(callbacks?: ProcessCallbacks): Promise<void> {
+  async installComfyUIRequirements(callbacks?: ProcessCallbacks): Promise<void> {
     log.info(`Installing ComfyUI requirements from ${this.comfyUIRequirementsPath}`);
     const installCmd = getPipInstallArgs({
       requirementsFile: this.comfyUIRequirementsPath,
@@ -506,7 +506,7 @@ export class VirtualEnvironment implements HasTelemetry {
     }
   }
 
-  private async installComfyUIManagerRequirements(callbacks?: ProcessCallbacks): Promise<void> {
+  async installComfyUIManagerRequirements(callbacks?: ProcessCallbacks): Promise<void> {
     log.info(`Installing ComfyUIManager requirements from ${this.comfyUIManagerRequirementsPath}`);
     const installCmd = getPipInstallArgs({
       requirementsFile: this.comfyUIManagerRequirementsPath,


### PR DESCRIPTION
- Reverted previous PR https://github.com/Comfy-Org/desktop/pull/841/files
- When installation validation detects missing `pythonPackages`, try reinstalling once.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-995-Reinstall-dependencies-when-detected-by-troubleshooting-page-1a66d73d365081e1a88acd72041436ca) by [Unito](https://www.unito.io)
