### PR TITLE
Update manager: Fix restore snapshot.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "version": "0.3.18",
       "optionalBranch": ""
     },
-    "managerCommit": "b0035ff4a7fcbe9a766f28a455c7d43dc3b93e12",
+    "managerCommit": "0bd1bf260555b7101a8c5df6071dbf332cfa833d",
     "uvVersion": "0.5.31"
   },
   "scripts": {


### PR DESCRIPTION
Previously, restore-snapshot crashed because the COMFYUI_PATH passed to it did not have a .git directory.
https://github.com/ltdrdata/ComfyUI-Manager/commit/0bd1bf260555b7101a8c5df6071dbf332cfa833d