### PR TITLE
[CI] Fix regression - all command output discarded

### DIFF
--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -5,15 +5,29 @@ import pkg from './getPackage.js';
 const comfyRepo = 'https://github.com/comfyanonymous/ComfyUI';
 const managerRepo = 'https://github.com/ltdrdata/ComfyUI-Manager';
 
+/** Suppress warning about detached head */
+const noWarning = '-c advice.detachedHead=false';
+
 if (pkg.config.comfyUI.optionalBranch) {
   // Checkout branch.
-  execSync(`git clone ${comfyRepo} --depth 1 --branch ${pkg.config.comfyUI.optionalBranch} assets/ComfyUI`);
+  execAndLog(`git clone ${comfyRepo} --depth 1 --branch ${pkg.config.comfyUI.optionalBranch} assets/ComfyUI`);
 } else {
   // Checkout tag as branch.
-  execSync(`git clone ${comfyRepo} --depth 1 --branch v${pkg.config.comfyUI.version} assets/ComfyUI`);
+  execAndLog(`git ${noWarning} clone ${comfyRepo} --depth 1 --branch v${pkg.config.comfyUI.version} assets/ComfyUI`);
 }
-execSync(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);
-execSync(`cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git checkout ${pkg.config.managerCommit} && cd ../../..`);
-execSync(`yarn run make:frontend`);
-execSync(`yarn run download:uv all`);
-execSync(`yarn run patch:core:frontend`);
+execAndLog(`git clone ${managerRepo} assets/ComfyUI/custom_nodes/ComfyUI-Manager`);
+execAndLog(
+  `cd assets/ComfyUI/custom_nodes/ComfyUI-Manager && git ${noWarning} checkout ${pkg.config.managerCommit} && cd ../../..`
+);
+execAndLog(`yarn run make:frontend`);
+execAndLog(`yarn run download:uv all`);
+execAndLog(`yarn run patch:core:frontend`);
+
+/**
+ * Run a command and log the output.
+ * @param {string} command The command to run.
+ */
+function execAndLog(command) {
+  const output = execSync(command, { encoding: 'utf8' });
+  console.log(output);
+}


### PR DESCRIPTION
- Either at or before #623
- Output is now logged via console.log

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1043-CI-Fix-regression-all-command-output-discarded-1b26d73d365081458586dc14d0ef9085) by [Unito](https://www.unito.io)
