### PR TITLE
Remove patch step since make:assets already runs it.

### DIFF
--- a/.github/actions/build/todesktop/action.yml
+++ b/.github/actions/build/todesktop/action.yml
@@ -44,7 +44,6 @@ runs:
         set -x
         yarn make:assets
         yarn clean:assets:git
-        yarn patch:core:frontend
 
     - name: Make app
       shell: bash


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1051-Remove-patch-step-since-make-assets-already-runs-it-1b46d73d365081529d3af3bbb6c95a35) by [Unito](https://www.unito.io)
