### PR TITLE
Fixed: User gets stuck in Desktop Updating page when error occurs

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -285,9 +285,14 @@ export class InstallationManager implements HasTelemetry {
       onStdout: sendLogIpc,
       onStderr: sendLogIpc,
     };
-    await installation.virtualEnvironment.installComfyUIRequirements(callbacks);
-    await installation.virtualEnvironment.installComfyUIManagerRequirements(callbacks);
-    await installation.validate();
+    try {
+      await installation.virtualEnvironment.installComfyUIRequirements(callbacks);
+      await installation.virtualEnvironment.installComfyUIManagerRequirements(callbacks);
+      await installation.validate();
+    } catch (error) {
+      log.error('Error auto-updating packages:', error);
+      this.appWindow.sendServerStartProgress(ProgressStatus.ERROR);
+    }
   }
 
   static setReinstallHandler(installation: ComfyInstallation) {

--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -291,7 +291,7 @@ export class InstallationManager implements HasTelemetry {
       await installation.validate();
     } catch (error) {
       log.error('Error auto-updating packages:', error);
-      this.appWindow.sendServerStartProgress(ProgressStatus.ERROR);
+      await this.appWindow.loadPage('server-start');
     }
   }
 


### PR DESCRIPTION
When installation of requirements error out (it did on Windows with access denied error when installing new dependencies), don't have the user get stuck in the `desktop-update` page. 

Currently user will wait in the Desktop update spinner forever.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1055-Draft-Show-maintenance-page-when-1b46d73d365081d6a088c96f741fd026) by [Unito](https://www.unito.io)
