### PR TITLE
Rotate main.log file to make it easier to debug user sessions.

### DIFF
--- a/src/main-process/appWindow.ts
+++ b/src/main-process/appWindow.ts
@@ -357,7 +357,11 @@ export class AppWindow {
         const message = this.messageQueue.shift();
         if (message) {
           log.info('Sending queued message', message);
-          this.window.webContents.send(message.channel, message.data);
+          if (this.window.webContents.isDestroyed()) {
+            log.warn('Window is destroyed, cannot send message', message);
+          } else {
+            this.window.webContents.send(message.channel, message.data);
+          }
         }
       }
     });

--- a/src/main-process/comfyServer.ts
+++ b/src/main-process/comfyServer.ts
@@ -122,7 +122,7 @@ export class ComfyServer implements HasTelemetry {
 
     ComfySettings.lockWrites();
     await ComfyServerConfig.addAppBundledCustomNodesToConfig();
-    await rotateLogFiles(app.getPath('logs'), 'comfyui', 50);
+    await rotateLogFiles(app.getPath('logs'), LogFile.ComfyUI, 50);
     return new Promise<void>((resolve, reject) => {
       const comfyUILog = log.create({ logId: 'comfyui' });
       comfyUILog.transports.file.fileName = LogFile.ComfyUI;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { app, shell } from 'electron';
 import { LevelOption } from 'electron-log';
 import log from 'electron-log/main';
 
+import { LogFile } from './constants';
 import { DesktopApp } from './desktopApp';
 import { removeAnsiCodesTransform, replaceFileLoggingTransform } from './infrastructure/structuredLogging';
 import { initializeAppState } from './main-process/appState';
@@ -11,6 +12,7 @@ import { DevOverrides } from './main-process/devOverrides';
 import SentryLogging from './services/sentry';
 import { getTelemetry } from './services/telemetry';
 import { DesktopConfig } from './store/desktopConfig';
+import { rotateLogFiles } from './utils';
 
 // Synchronous pre-start configuration
 dotenv.config();
@@ -41,8 +43,8 @@ if (!gotTheLock) {
 async function startApp() {
   // Wait for electron app ready event
   await new Promise<void>((resolve) => app.once('ready', () => resolve()));
+  await rotateLogFiles(app.getPath('logs'), LogFile.Main, 50);
   log.debug('App ready');
-
   telemetry.registerHandlers();
   telemetry.track('desktop:app_ready');
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,13 +93,13 @@ export function findAvailablePort(host: string, startPort: number, endPort: numb
  * @param maxFiles The maximum number of log files to keep. When 0, no files are removed. Default: 50
  */
 export async function rotateLogFiles(logDir: string, baseName: string, maxFiles = 50) {
-  const currentLogPath = path.join(logDir, `${baseName}.log`);
+  const currentLogPath = path.join(logDir, `${baseName}`);
 
   try {
     await fsPromises.access(logDir, fs.constants.R_OK | fs.constants.W_OK);
     await fsPromises.access(currentLogPath);
   } catch {
-    log.error('Log rotation: cannot access log dir.');
+    log.error('Log rotation: cannot access log dir', currentLogPath);
     // TODO: Report to user
     return;
   }


### PR DESCRIPTION
Also fixed a bug where if the browser webContent is destroyed already, we should not send the event.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1056-Rotate-main-log-file-to-make-it-easier-to-debug-user-sessions-1b56d73d36508126b17cc2f217b1e806) by [Unito](https://www.unito.io)
