### PR TITLE
Install Path Validation Improvements

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -29,10 +29,17 @@ export function registerPathHandlers() {
   });
 
   ipcMain.handle(IPC_CHANNELS.GET_SYSTEM_PATHS, (): SystemPaths => {
+    let documentsPath = app.getPath('documents');
+
+    // Remove OneDrive from documents path if present
+    if (process.platform === 'win32') {
+      documentsPath = documentsPath.replace(/OneDrive\\/, '');
+    }
+
     return {
       appData: app.getPath('appData'),
       appPath: app.getAppPath(),
-      defaultInstallPath: path.join(app.getPath('documents'), 'ComfyUI'),
+      defaultInstallPath: path.join(documentsPath, 'ComfyUI'),
     };
   });
 

--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -129,8 +129,7 @@ export function registerPathHandlers() {
         result.parentMissing ||
         result.freeSpace < requiredSpace ||
         result.error ||
-        result.isOneDrive ||
-        result.isNonDefaultDrive
+        result.isOneDrive
           ? false
           : true;
       return result;

--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -38,7 +38,7 @@ export function registerPathHandlers() {
       return {
         appData: app.getPath('appData'),
         appPath: app.getAppPath(),
-        defaultInstallPath: path.win32.join(documentsPath, 'ComfyUI'),
+        defaultInstallPath: path.join(documentsPath, 'ComfyUI'),
       };
     }
 
@@ -74,9 +74,13 @@ export function registerPathHandlers() {
         if (process.platform === 'win32') {
           // Check if path is in OneDrive
           const { oneDrive } = process.env;
-          const normalizedPath = path.resolve(inputPath);
-          if (oneDrive && path.resolve(oneDrive).toLowerCase().startsWith(normalizedPath.toLowerCase())) {
-            result.isOneDrive = true;
+          if (oneDrive) {
+            const normalizedInput = path.resolve(inputPath).toLowerCase();
+            const normalizedOneDrive = path.resolve(oneDrive).toLowerCase();
+            // Check if the normalized OneDrive path is a parent of the input path
+            if (normalizedInput.startsWith(normalizedOneDrive)) {
+              result.isOneDrive = true;
+            }
           }
 
           // Check if path is on non-default drive
@@ -118,17 +122,15 @@ export function registerPathHandlers() {
         result.error = `${error}`;
       }
 
-      result.isValid = true; // Start with true and set to false if any validation fails
-      if (
+      result.isValid =
         result.cannotWrite ||
         result.parentMissing ||
         result.freeSpace < requiredSpace ||
         result.error ||
         result.isOneDrive ||
         result.isNonDefaultDrive
-      ) {
-        result.isValid = false;
-      }
+          ? false
+          : true;
       return result;
     }
   );

--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -34,6 +34,12 @@ export function registerPathHandlers() {
     // Remove OneDrive from documents path if present
     if (process.platform === 'win32') {
       documentsPath = documentsPath.replace(/OneDrive\\/, '');
+      // We should use path.win32.join for Windows paths
+      return {
+        appData: app.getPath('appData'),
+        appPath: app.getAppPath(),
+        defaultInstallPath: path.win32.join(documentsPath, 'ComfyUI'),
+      };
     }
 
     return {

--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -73,7 +73,9 @@ export function registerPathHandlers() {
       try {
         if (process.platform === 'win32') {
           // Check if path is in OneDrive
-          if (inputPath.toLowerCase().includes('onedrive')) {
+          const { oneDrive } = process.env;
+          const normalizedPath = path.resolve(inputPath);
+          if (oneDrive && path.resolve(oneDrive).toLowerCase().startsWith(normalizedPath.toLowerCase())) {
             result.isOneDrive = true;
           }
 

--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -73,11 +73,13 @@ export function registerPathHandlers() {
       try {
         if (process.platform === 'win32') {
           // Check if path is in OneDrive
-          const { oneDrive } = process.env;
-          if (oneDrive) {
+          const { OneDrive } = process.env;
+          if (OneDrive) {
             const normalizedInput = path.resolve(inputPath).toLowerCase();
-            const normalizedOneDrive = path.resolve(oneDrive).toLowerCase();
+            const normalizedOneDrive = path.resolve(OneDrive).toLowerCase();
             // Check if the normalized OneDrive path is a parent of the input path
+            process.stdout.write(`normalizedInput: ${normalizedInput}\n`);
+            process.stdout.write(`normalizedOneDrive: ${normalizedOneDrive}\n`);
             if (normalizedInput.startsWith(normalizedOneDrive)) {
               result.isOneDrive = true;
             }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -78,6 +78,10 @@ export type PathValidationResult = {
   exists?: boolean;
   /** `true` if the selected path is not writable. */
   cannotWrite?: boolean;
+  /** `true` if the selected path is within OneDrive. */
+  isOneDrive?: boolean;
+  /** `true` if the selected path is on a non-default drive. */
+  isNonDefaultDrive?: boolean;
   /** The amount of free space in the path. `-1` if this could not be determined. */
   freeSpace: number;
   /** The amount of space in bytes required to install ComfyUI. */

--- a/tests/unit/handlers/pathHandler.test.ts
+++ b/tests/unit/handlers/pathHandler.test.ts
@@ -166,11 +166,10 @@ describe('PathHandlers', () => {
       mockFileSystem({ exists: true, writable: true, contentLength: 0, isDirectory: true });
 
       const result = await validateHandler({}, '/valid/path');
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         isValid: true,
         exists: false,
         freeSpace: DEFAULT_FREE_SPACE,
-        requiredSpace: REQUIRED_SPACE,
       });
     });
 

--- a/tests/unit/handlers/pathHandler.test.ts
+++ b/tests/unit/handlers/pathHandler.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComfyConfigManager } from '@/config/comfyConfigManager';
 import { ComfyServerConfig } from '@/config/comfyServerConfig';
 import { IPC_CHANNELS } from '@/constants';
-import { REQUIRED_SPACE, registerPathHandlers } from '@/handlers/pathHandlers';
+import { WIN_REQUIRED_SPACE, registerPathHandlers } from '@/handlers/pathHandlers';
 import type { SystemPaths } from '@/preload';
 
 import { electronMock } from '../setup';
@@ -128,7 +128,7 @@ describe('PathHandlers', () => {
         isValid: true,
         exists: true,
         freeSpace: DEFAULT_FREE_SPACE,
-        requiredSpace: REQUIRED_SPACE,
+        requiredSpace: WIN_REQUIRED_SPACE,
       });
     });
 
@@ -153,7 +153,7 @@ describe('PathHandlers', () => {
         isValid: false,
         exists: true,
         freeSpace: LOW_FREE_SPACE,
-        requiredSpace: REQUIRED_SPACE,
+        requiredSpace: WIN_REQUIRED_SPACE,
       });
     });
 
@@ -165,7 +165,7 @@ describe('PathHandlers', () => {
         isValid: false,
         parentMissing: true,
         freeSpace: DEFAULT_FREE_SPACE,
-        requiredSpace: REQUIRED_SPACE,
+        requiredSpace: WIN_REQUIRED_SPACE,
       });
     });
 
@@ -178,7 +178,7 @@ describe('PathHandlers', () => {
         cannotWrite: true,
         exists: true,
         freeSpace: DEFAULT_FREE_SPACE,
-        requiredSpace: REQUIRED_SPACE,
+        requiredSpace: WIN_REQUIRED_SPACE,
       });
     });
 
@@ -194,7 +194,7 @@ describe('PathHandlers', () => {
         isValid: false,
         error: 'Error: Test error',
         freeSpace: -1,
-        requiredSpace: REQUIRED_SPACE,
+        requiredSpace: WIN_REQUIRED_SPACE,
       });
       expect(log.error).toHaveBeenCalledWith('Error validating install path:', mockError);
     });


### PR DESCRIPTION
- Have separate requirements for free space for mac and Windows (5gb vs 10gb)
- Replace OneDrive in the default install path for Windows
- Validate install path does not contain OneDrive
- Validate install path does not contain a non system drive (eg. Must be C:\ drive)

FE PR here: https://github.com/Comfy-Org/ComfyUI_frontend/pull/3059

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1059-Install-Path-Validation-Improvements-1b66d73d365081f683a1c4e11dbbbbfb) by [Unito](https://www.unito.io)
