### PR TITLE
Check if directory is empty before installation warning.

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -55,9 +55,14 @@ export function registerPathHandlers() {
           result.parentMissing = true;
         }
 
-        // Check if path exists
+        // Check if path exists and is not an empty directory
         if (fs.existsSync(inputPath)) {
-          result.exists = true;
+          if (fs.statSync(inputPath).isDirectory()) {
+            const contents = fs.readdirSync(inputPath);
+            result.exists = contents.length > 0;
+          } else {
+            result.exists = true;
+          }
         }
 
         // Check if path is writable


### PR DESCRIPTION
Only return "exists" when the directory is not empty.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1060-Check-if-directory-is-empty-before-installation-warning-1b76d73d365081bc8b2bef6d3bdc3cc7) by [Unito](https://www.unito.io)
