### PR TITLE
Check response of shell.openPath for errors.

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -25,7 +25,22 @@ export function registerPathHandlers() {
   ipcMain.on(IPC_CHANNELS.OPEN_PATH, (event, folderPath: string): void => {
     log.info(`Opening path: ${folderPath}`);
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    shell.openPath(folderPath);
+    shell.openPath(folderPath).then((errorStr) => {
+      if (errorStr !== '') {
+        log.error(`Error opening path: ${errorStr}`);
+        dialog
+          .showMessageBox({
+            title: 'Error Opening File',
+            message: `Could not open file: ${folderPath}. Error: ${errorStr}`,
+          })
+          .then((response) => {
+            log.info(`Open message box response: ${response.response}`);
+          })
+          .catch((error) => {
+            log.error(`Error showing message box: ${error}`);
+          });
+      }
+    });
   });
 
   ipcMain.handle(IPC_CHANNELS.GET_SYSTEM_PATHS, (): SystemPaths => {


### PR DESCRIPTION
Open a message box showing user there was an error.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1066-Check-response-of-shell-openPath-for-errors-1b96d73d365081c7b019f674da6a16e3) by [Unito](https://www.unito.io)
