### PR TITLE
[API] Publish types for version 0.4.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
- Automated minor version bump to: 0.4.31
- Triggers npm publish workflow of API types

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1067-API-Publish-types-for-version-0-4-31-1b96d73d36508173afdccc6d8e2503c9) by [Unito](https://www.unito.io)
