### PR TITLE
Add support for loading vue devtools extension

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -21,3 +21,7 @@ LOG_LEVEL=debug
 
 # Send events to Sentry
 SENTRY_ENABLED=false
+
+# The path to the Chrome Vue DevTools extension. Install the extension, then to find the path follow this:
+# https://www.electronjs.org/docs/latest/tutorial/devtools-extension#manually-loading-a-devtools-extension
+VUE_DEVTOOLS_PATH=%LOCALAPPDATA%\Google\Chrome\User Data\Default\Extensions\nhdogjmejiglipccpnnnanhbledajbpd\{version}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/prefer-top-level-await */
 import dotenv from 'dotenv';
-import { app, shell } from 'electron';
+import { app, session, shell } from 'electron';
 import { LevelOption } from 'electron-log';
 import log from 'electron-log/main';
 
@@ -59,6 +59,16 @@ async function startApp() {
   }
 
   telemetry.loadGenerationCount(config);
+
+  // Load the Vue DevTools extension
+  if (process.env.VUE_DEVTOOLS_PATH) {
+    try {
+      await session.defaultSession.loadExtension(process.env.VUE_DEVTOOLS_PATH);
+    } catch (error) {
+      log.error('Error loading Vue DevTools extension', error);
+    }
+  }
+
   const desktopApp = new DesktopApp(overrides, config);
   await desktopApp.showLoadingPage();
   await desktopApp.start();


### PR DESCRIPTION
Lets you use vue devtools from within the electron app devtools by specifying the path the the extension in your env vars

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1080-Add-support-for-loading-vue-devtools-extension-1c46d73d3650810999c2f531c863e3f1) by [Unito](https://www.unito.io)
