### PR TITLE
Support Blackwell GPUs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,7 @@ export const IPC_CHANNELS = {
   CAN_ACCESS_URL: 'can-access-url',
   START_TROUBLESHOOTING: 'start-troubleshooting',
   DISABLE_CUSTOM_NODES: 'disable-custom-nodes',
+  CHECK_BLACKWELL: 'check-blackwell',
 } as const;
 
 export enum ProgressStatus {
@@ -134,6 +135,8 @@ export enum TorchMirrorUrl {
   Default = 'https://pypi.org/simple/',
   /** PyTorch CUDA mirror. */
   Cuda = 'https://download.pytorch.org/whl/cu126',
+  /** PyTorch Nightly CUDA mirror. */
+  NightlyCuda = 'https://download.pytorch.org/whl/nightly/cu128',
   /** PyTorch nightly CPU mirror. */
   NightlyCpu = 'https://download.pytorch.org/whl/nightly/cpu',
 }

--- a/src/desktopApp.ts
+++ b/src/desktopApp.ts
@@ -5,6 +5,7 @@ import { ProgressStatus } from './constants';
 import { IPC_CHANNELS } from './constants';
 import { registerAppHandlers } from './handlers/AppHandlers';
 import { registerAppInfoHandlers } from './handlers/appInfoHandlers';
+import { registerGpuHandlers } from './handlers/gpuHandlers';
 import { registerNetworkHandlers } from './handlers/networkHandlers';
 import { registerPathHandlers } from './handlers/pathHandlers';
 import { FatalError } from './infrastructure/fatalError';
@@ -136,6 +137,7 @@ export class DesktopApp implements HasTelemetry {
       registerNetworkHandlers();
       registerAppInfoHandlers();
       registerAppHandlers();
+      registerGpuHandlers();
 
       ipcMain.handle(IPC_CHANNELS.START_TROUBLESHOOTING, async () => await this.showTroubleshootingPage());
     } catch (error) {

--- a/src/handlers/gpuHandlers.ts
+++ b/src/handlers/gpuHandlers.ts
@@ -1,0 +1,22 @@
+import { ipcMain } from 'electron';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { IPC_CHANNELS } from '../constants';
+
+const execAsync = promisify(exec);
+
+/**
+ * Handles GPU-related IPC channels.
+ */
+// Note: GET_GPU is handled in appInfoHandlers.ts
+export function registerGpuHandlers() {
+  ipcMain.handle(IPC_CHANNELS.CHECK_BLACKWELL, async () => {
+    try {
+      const { stdout } = await execAsync('nvidia-smi -q');
+      return /Product Architecture\s*:\s*Blackwell/.test(stdout);
+    } catch {
+      return false;
+    }
+  });
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -422,6 +422,13 @@ const electronAPI = {
     await ipcRenderer.invoke(IPC_CHANNELS.DISABLE_CUSTOM_NODES);
   },
 
+  /**
+   * Checks if the system is running on NVIDIA's Blackwell architecture.
+   */
+  isBlackwell: (): Promise<boolean> => {
+    return ipcRenderer.invoke(IPC_CHANNELS.CHECK_BLACKWELL);
+  },
+
   uv: {
     /**
      * Install the requirements for the ComfyUI server.

--- a/tests/unit/handlers/gpuHandlers.test.ts
+++ b/tests/unit/handlers/gpuHandlers.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecAsync = vi.fn();
+vi.mock('node:util', () => ({ promisify: () => mockExecAsync }));
+
+describe('registerGpuHandlers', () => {
+  let ipcMainHandleSpy: ReturnType<typeof vi.spyOn>;
+  let IPC_CHANNELS: typeof import('@/constants').IPC_CHANNELS;
+  let registerGpuHandlers: typeof import('@/handlers/gpuHandlers').registerGpuHandlers;
+
+  beforeEach(async () => {
+    const constantsModule = await import('@/constants');
+    IPC_CHANNELS = constantsModule.IPC_CHANNELS;
+    const electron = await import('electron');
+    ipcMainHandleSpy = vi.spyOn(electron.ipcMain, 'handle').mockImplementation(() => undefined);
+    const gpuModule = await import('@/handlers/gpuHandlers');
+    registerGpuHandlers = gpuModule.registerGpuHandlers;
+    mockExecAsync.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers exactly one handler for CHECK_BLACKWELL', () => {
+    registerGpuHandlers();
+    expect(ipcMainHandleSpy).toHaveBeenCalledTimes(1);
+    expect(ipcMainHandleSpy).toHaveBeenCalledWith(IPC_CHANNELS.CHECK_BLACKWELL, expect.any(Function));
+  });
+
+  describe('CHECK_BLACKWELL handler callback', () => {
+    let handler: () => Promise<boolean>;
+
+    beforeEach(() => {
+      registerGpuHandlers();
+      const call = ipcMainHandleSpy.mock.calls.find(([channel]) => channel === IPC_CHANNELS.CHECK_BLACKWELL)!;
+      handler = call[1] as any;
+    });
+
+    it('invokes execAsync with the correct command', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: 'Product Architecture : Blackwell' });
+      await handler();
+      expect(mockExecAsync).toHaveBeenCalledOnce();
+      expect(mockExecAsync).toHaveBeenCalledWith('nvidia-smi -q');
+    });
+
+    it('returns true when stdout contains "Blackwell" with exact casing', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: '...Product Architecture : Blackwell\n...' });
+      await expect(handler()).resolves.toBe(true);
+    });
+
+    it('returns false when stdout does not contain "Blackwell"', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: 'Product Architecture : Ampere' });
+      await expect(handler()).resolves.toBe(false);
+    });
+
+    it('is case-sensitive and returns false for lowercase "blackwell"', async () => {
+      mockExecAsync.mockResolvedValue({ stdout: 'Product Architecture : blackwell' });
+      await expect(handler()).resolves.toBe(false);
+    });
+
+    it('returns false when execAsync throws an error', async () => {
+      mockExecAsync.mockRejectedValue(new Error('execution failed'));
+      await expect(handler()).resolves.toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Adds TorchMirrorUrl.NightlyCuda as 'https://download.pytorch.org/whl/nightly/cu128'
Exposes CHECK_BLACKWELL IPC handler


Related: https://github.com/Comfy-Org/ComfyUI_frontend/pull/3480
┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1090-Support-Blackwell-GPUs-1d76d73d365081b98570ff6766a4c24f) by [Unito](https://www.unito.io)
