### PR TITLE
Fix all templates missing on Windows first launch

### DIFF
--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -40,6 +40,9 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
+comfyui-workflow-templates==0.1.1
+    # via -r assets/ComfyUI/requirements.txt
+    # from https://pypi.org/simple
 cryptography==44.0.0
     # via pyjwt
     # from https://pypi.org/simple


### PR DESCRIPTION
### Current

Templates are missing after a fresh install on Windows.  Templates window opens after installation completes, however none are visible.

![image](https://github.com/user-attachments/assets/d76588a1-3d2c-413a-a5e7-2eed7b94fde7)

### Proposed

Include templates in compiled requirements and download during installation.

- Resolves #1092

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1095-Fix-all-templates-missing-on-Windows-first-launch-1d96d73d365081e3aa4fdeacf052e6b5) by [Unito](https://www.unito.io)
