### PR TITLE
Fix typo `extra_model_config` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ On Linux: `~/.config/ComfyUI/config.json`
 
 #### Model Paths
 
-This directory is also written as the `base_path` in `extra_model_config.yaml`. The Desktop app will look for model checkpoints here by default, but you can add additional models to the search path by editing this file.
+This directory is also written as the `base_path` in `extra_models_config.yaml`. The Desktop app will look for model checkpoints here by default, but you can add additional models to the search path by editing this file.
 
-On Windows: `%APPDATA%\ComfyUI\extra_model_config.yaml`
+On Windows: `%APPDATA%\ComfyUI\extra_models_config.yaml`
 
-On macOS: `~/Library/Application Support/ComfyUI/extra_model_config.yaml`
+On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
 
-On Linux: `~/.config/ComfyUI/extra_model_config.yaml`
+On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
 
 ### Logs
 


### PR DESCRIPTION
Change `extra_model_config` to `extra_models_config`

![Selection_1260](https://github.com/user-attachments/assets/6d406a9f-9465-4a81-b73d-51739cb9f611)

![Selection_1261](https://github.com/user-attachments/assets/970f727a-7813-418e-8ea4-2f6a864dc2c7)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1099-Fix-typo-extra_model_config-in-README-1da6d73d36508125a32fdddb46fc8311) by [Unito](https://www.unito.io)
