### PR TITLE
[API] Publish types for version 0.4.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
- Automated minor version bump to: 0.4.37

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1101-API-Publish-types-for-version-0-4-37-1da6d73d36508118817ad4588ae1beca) by [Unito](https://www.unito.io)
