### PR TITLE
Promise version in checkForUpdates

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.4.37",
+  "version": "0.4.38",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -453,7 +453,8 @@ const electronAPI = {
    * Manually check for application updates.
    * @returns A promise that resolves to true if an update is available, false otherwise
    */
-  checkForUpdates: (): Promise<boolean> => ipcRenderer.invoke(IPC_CHANNELS.CHECK_FOR_UPDATES),
+  checkForUpdates: (): Promise<{ isUpdateAvailable: boolean; version?: string }> =>
+    ipcRenderer.invoke(IPC_CHANNELS.CHECK_FOR_UPDATES),
 
   /**
    * Restarts and installs updates using todesktop.autoUpdater.restartAndInstall().


### PR DESCRIPTION
Oops, forgot to update the checkForUpdates() promise to include the version.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1102-Promise-version-in-checkForUpdates-1db6d73d3650814fb159c450ce455d1c) by [Unito](https://www.unito.io)
