### PR TITLE
Allow options to be passed to checkForUpdates

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -451,10 +451,11 @@ const electronAPI = {
 
   /**
    * Manually check for application updates.
-   * @returns A promise that resolves to true if an update is available, false otherwise
+   * @param options Optional option args, see todesktop docs.
+   * @returns A promise that resolves to update availability and version.
    */
-  checkForUpdates: (): Promise<{ isUpdateAvailable: boolean; version?: string }> =>
-    ipcRenderer.invoke(IPC_CHANNELS.CHECK_FOR_UPDATES),
+  checkForUpdates: (options?: object): Promise<{ isUpdateAvailable: boolean; version?: string }> =>
+    ipcRenderer.invoke(IPC_CHANNELS.CHECK_FOR_UPDATES, options),
 
   /**
    * Restarts and installs updates using todesktop.autoUpdater.restartAndInstall().


### PR DESCRIPTION
Used to prevent todesktop from handling the update prompts since frontend already has a confirm dialog to prompt restart and install.

sorry about the pr/npm spam 😖

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1103-Allow-options-to-be-passed-to-checkForUpdates-1db6d73d365081f28c1ff0ba21ca477c) by [Unito](https://www.unito.io)
