### PR TITLE
Fix template upgrade triggers troubleshooting

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -571,7 +571,7 @@ export class VirtualEnvironment implements HasTelemetry {
       let adds = 0;
       for (const line of lines) {
         // Reject upgrade if removing an unrecognised package
-        if (line.search(/^\s*- (?!aiohttp|av|yarl).*==/) !== -1) return false;
+        if (line.search(/^\s*- (?!aiohttp|av|yarl|comfyui-workflow-templates).*==/) !== -1) return false;
         if (line.search(/^\s*\+ /) !== -1) {
           if (line.search(/^\s*\+ (aiohttp|av|yarl|comfyui-workflow-templates)==/) === -1) return false;
           adds++;


### PR DESCRIPTION
Silent auto-update not triggered when upgrading templates pip package.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1111-Fix-template-upgrade-triggers-troubleshooting-1dd6d73d365081f79942dd001e52a1a0) by [Unito](https://www.unito.io)
