### PR TITLE
Add compound launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,5 +30,11 @@
       "webRoot": "${workspaceFolder}",
       "timeout": 30000
     }
+  ],
+  "compounds": [
+    {
+      "name": "Electron: All",
+      "configurations": ["Electron: Main", "Electron: Renderer"]
+    }
   ]
 }


### PR DESCRIPTION
Just a shortcut to launch both main and renderer at once.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1112-Add-compound-launch-config-1dd6d73d365081129e35d39c4e21739e) by [Unito](https://www.unito.io)
