### PR TITLE
[chore] Update frontend to 1.17.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.17.9",
+    "frontendVersion": "1.17.10",
     "comfyUI": {
       "version": "0.3.29",
       "optionalBranch": "api-nodes"


### PR DESCRIPTION
Automated frontend update to 1.17.10: https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.17.10

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1120-chore-Update-frontend-to-1-17-10-1de6d73d365081f8a0adcb0f83c9034f) by [Unito](https://www.unito.io)
