### PR TITLE
[chore] Update frontend to 1.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.17.10",
+    "frontendVersion": "1.17.11",
     "comfyUI": {
       "version": "0.3.29",
       "optionalBranch": "desktop-release-apr242025"


### PR DESCRIPTION
Automated frontend update to 1.17.11: https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.17.11

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1124-chore-Update-frontend-to-1-17-11-1de6d73d365081559344c4360c26fccf) by [Unito](https://www.unito.io)
