### PR TITLE
Patched: Check user consent before incrementing property.

### DIFF
--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -144,7 +144,12 @@ export class MixpanelTelemetry implements ITelemetry {
     });
 
     ipcMain.on(IPC_CHANNELS.INCREMENT_USER_PROPERTY, (event, propertyName: string, number: number) => {
-      this.mixpanelClient.people.increment(this.distinctId, propertyName, number);
+      if (this.hasConsent) {
+        if (propertyName.includes('execution') && this.hasGeneratedSuccessfully) {
+          return;
+        }
+        this.mixpanelClient.people.increment(this.distinctId, propertyName, number);
+      }
     });
   }
 


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1128-Patched-Check-user-consent-before-incrementing-property-1e06d73d365081a7a5a1df0548ea391f) by [Unito](https://www.unito.io)
