### PR TITLE
Fix UV fails on macOS install path with spaces

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -371,7 +371,8 @@ export class VirtualEnvironment implements HasTelemetry {
    * @returns
    */
   private async runUvCommandAsync(args: string[], callbacks?: ProcessCallbacks): Promise<{ exitCode: number | null }> {
-    const uvCommand = os.platform() === 'win32' ? `& "${this.uvPath}"` : this.uvPath;
+    const psPrefix = os.platform() === 'win32' ? '& ' : '';
+    const uvCommand = `${psPrefix}"${this.uvPath}"`;
     const command = `${uvCommand} ${args.map((a) => `"${a}"`).join(' ')}`;
     log.info('Running uv command:', command);
     return this.runPtyCommandAsync(command, callbacks?.onStdout);


### PR DESCRIPTION
Resolves auto-update & troubleshooting failures.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1140-Fix-UV-fails-on-macOS-install-path-with-spaces-1e86d73d3650818c8fcfc474e8465aef) by [Unito](https://www.unito.io)
