### PR TITLE
Fix `rejects Windows with AMD GPU` unit test

### DIFF
--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -43,6 +43,17 @@ describe('validateHardware', () => {
       controllers: [{ vendor: 'AMD', model: 'Radeon RX 6800' }],
     } as Systeminformation.GraphicsData);
 
+    vi.mock('node:child_process', async () => {
+      const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      return {
+        ...actual,
+        exec: (_cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+          setImmediate(() => callback(new Error('mocked exec failure'), '', ''));
+          return { kill: () => {}, on: () => {} } as any;
+        },
+      };
+    });
+
     const result = await validateHardware();
     expect(result).toStrictEqual({
       isValid: false,


### PR DESCRIPTION
The `rejects Windows with AMD GPU` unit test fails on a Windows/Nvidia machine because we only mocked `si.graphics`, but the code has a fallback to check with `nvidia-smi`.

This PR suggests mocking both execAsync processes to fail, better simulating what would happen if a user had an AMD gpu on a Windows machine.

https://github.com/Comfy-Org/desktop/blob/df5ae706e7f914a7bb6ccc7ab50a5abebf7170de/src/utils.ts#L160-L189