### PR TITLE
Change wording of NVIDIA GPU detection error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,7 +172,7 @@ export async function validateHardware(): Promise<HardwareValidation> {
           const res = await execAsync(
             'powershell.exe -c "$n = \'*NVIDIA*\'; Get-CimInstance win32_videocontroller | ? { $_.Name -like $n -or $_.VideoProcessor -like $n -or $_.AdapterCompatibility -like $n }"'
           );
-          if (!res?.stdout) throw new Error('No video card');
+          if (!res?.stdout) throw new Error('No NVIDIA GPU detected');
         } catch {
           try {
             await execAsync('nvidia-smi');


### PR DESCRIPTION
The error message of "No video card" is slightly misleading, as the res checks specifically for NVIDIA GPUs.

This PR suggests changing this error message slightly to more accurately reflect the check done.

https://github.com/Comfy-Org/desktop/blob/df5ae706e7f914a7bb6ccc7ab50a5abebf7170de/src/utils.ts#L172-L175