### PR TITLE
[chore] Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: yarn run test:unit
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           directory: ./coverage/
           fail_ci_if_error: false


### PR DESCRIPTION
Replace version tags with commit SHAs for third-party GitHub Actions to improve security and ensure reproducible builds. This prevents unexpected changes from new releases and protects against potential supply chain attacks.

Updated:
- codecov/codecov-action: v4 -> b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238

Note: JP250552/setup-node was already using commit SHA (0c618ceb2e48275dc06e86901822fd966ce75ba2)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1185-chore-Pin-third-party-GitHub-Actions-to-commit-SHAs-2086d73d3650817fb7cdf75454746c04) by [Unito](https://www.unito.io)
