### PR TITLE
Bumping ComfyUI core to v0.3.40

### DIFF
--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -43,7 +43,10 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.22
+comfyui-embedded-docs==0.2.0
+    # via -r assets/ComfyUI/requirements.txt
+    # from https://pypi.org/simple
+comfyui-workflow-templates==0.1.25
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -44,7 +44,10 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://download.pytorch.org/whl/cu128
-comfyui-workflow-templates==0.1.22
+comfyui-embedded-docs==0.2.0
+    # via -r assets/ComfyUI/requirements.txt
+    # from https://pypi.org/simple
+comfyui-workflow-templates==0.1.25
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "packageManager": "yarn@4.5.0",
   "type": "module",
   "config": {
-    "frontendVersion": "1.20.6",
+    "frontendVersion": "1.21.7",
     "comfyUI": {
-      "version": "0.3.38",
+      "version": "0.3.40",
       "optionalBranch": "desktop-release-may292025"
     },
     "managerCommit": "402e2c384f338d0ed0a7fb19caa93f29a0dc35fd",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "frontendVersion": "1.21.7",
     "comfyUI": {
       "version": "0.3.40",
-      "optionalBranch": "desktop-release-may292025"
+      "optionalBranch": ""
     },
     "managerCommit": "402e2c384f338d0ed0a7fb19caa93f29a0dc35fd",
     "uvVersion": "0.5.31"

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -6,4 +6,3 @@ diff --git a/requirements.txt b/requirements.txt
  comfyui-workflow-templates==0.1.25
  comfyui-embedded-docs==0.2.0
  torch
- torchsde

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.20.7
- comfyui-workflow-templates==0.1.22
+-comfyui-frontend-package==1.21.7
+ comfyui-workflow-templates==0.1.25
+ comfyui-embedded-docs==0.2.0
  torch
- torchsde

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -1,8 +1,9 @@
 diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
-@@ -1,4 +1,3 @@
--comfyui-frontend-package==1.20.7
- comfyui-workflow-templates==0.1.22
+@@ -1,5 +1,4 @@
+-comfyui-frontend-package==1.21.7
+ comfyui-workflow-templates==0.1.25
+ comfyui-embedded-docs==0.2.0
  torch
  torchsde

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -1,8 +1,8 @@
 diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
-@@ -1,5 +1,4 @@
--comfyui-frontend-package==1.21.7
- comfyui-workflow-templates==0.1.25
- comfyui-embedded-docs==0.2.0
+@@ -1,4 +1,3 @@
+-comfyui-frontend-package==1.20.7
+ comfyui-workflow-templates==0.1.22
  torch
+ torchsde


### PR DESCRIPTION
## Summary
- Updated ComfyUI from v0.3.38 to v0.3.40 with latest frontend version 1.21.7
- Updated all dependency files including core-requirements.patch and Windows compiled requirements
- Added new comfyui-embedded-docs package and updated workflow templates to v0.1.25

## Test plan
- [ ] Verify application builds successfully
- [ ] Test ComfyUI functionality with updated core version
- [ ] Confirm all dependencies resolve correctly

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1186-Bumping-ComfyUI-core-to-v0-3-40-2096d73d36508146b628d830ab1df9d3) by [Unito](https://www.unito.io)
