### PR TITLE
Ignore Claude configuration files in CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
       - '.cursor/**'
       - '.husky/**'
       - '.vscode/**'
+      - '.claude/**'
+      - 'CLAUDE.md'
       - '*_example'
   push:
     branches: [main]
@@ -16,6 +18,8 @@ on:
       - '.cursor/**'
       - '.husky/**'
       - '.vscode/**'
+      - '.claude/**'
+      - 'CLAUDE.md'
       - '*_example'
 
 jobs:

--- a/.github/workflows/debug_all.yml
+++ b/.github/workflows/debug_all.yml
@@ -15,6 +15,8 @@ on:
       - 'todesktop.json'
       - '.github/ISSUE_TEMPLATE/**'
       - '.cursor/**'
+      - '.claude/**'
+      - 'CLAUDE.md'
       - '*_example'
       - 'tests/unit/**'
   push:
@@ -31,6 +33,8 @@ on:
       - 'todesktop.json'
       - '.github/ISSUE_TEMPLATE/**'
       - '.cursor/**'
+      - '.claude/**'
+      - 'CLAUDE.md'
       - '*_example'
       - 'tests/unit/**'
 


### PR DESCRIPTION
## Summary
- Added `.claude/**` and `CLAUDE.md` to paths-ignore in CI workflows that don't need to run for Claude configuration changes
- Updated `ci.yaml` (unit tests, linting, formatting) to skip Claude files
- Updated `debug_all.yml` (build testing) to skip Claude files

## Test plan
- [ ] Verify workflows correctly ignore changes to Claude configuration files
- [ ] Confirm workflows still trigger for actual code changes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1188-Ignore-Claude-configuration-files-in-CI-workflows-2096d73d36508115bd6ec3f3297b4074) by [Unito](https://www.unito.io)
