### PR TITLE
[feat] add optional bypass for disk space validation during installation

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -70,7 +70,7 @@ export function registerPathHandlers() {
    */
   ipcMain.handle(
     IPC_CHANNELS.VALIDATE_INSTALL_PATH,
-    async (event, inputPath: string): Promise<PathValidationResult> => {
+    async (event, inputPath: string, bypassSpaceCheck = false): Promise<PathValidationResult> => {
       // Determine required space based on OS
       const requiredSpace = process.platform === 'darwin' ? MAC_REQUIRED_SPACE : WIN_REQUIRED_SPACE;
 
@@ -142,7 +142,7 @@ export function registerPathHandlers() {
       result.isValid =
         result.cannotWrite ||
         result.parentMissing ||
-        result.freeSpace < requiredSpace ||
+        (!bypassSpaceCheck && result.freeSpace < requiredSpace) ||
         result.error ||
         result.isOneDrive
           ? false

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -31,6 +31,8 @@ export interface InstallOptions {
   /** pip mirrors */
   pypiMirror?: string; // Common pip install mirror
   torchMirror?: string; // Torch install mirror
+  /** Whether to bypass disk space requirements during installation */
+  bypassSpaceCheck?: boolean;
 }
 
 export interface SystemPaths {
@@ -261,9 +263,11 @@ const electronAPI = {
   /**
    * Validate the install path for the application. Check whether the path is valid
    * and writable. The disk should have enough free space to install the application.
+   * @param path The path to validate
+   * @param bypassSpaceCheck Optional flag to bypass disk space requirement
    */
-  validateInstallPath: (path: string): Promise<PathValidationResult> => {
-    return ipcRenderer.invoke(IPC_CHANNELS.VALIDATE_INSTALL_PATH, path);
+  validateInstallPath: (path: string, bypassSpaceCheck?: boolean): Promise<PathValidationResult> => {
+    return ipcRenderer.invoke(IPC_CHANNELS.VALIDATE_INSTALL_PATH, path, bypassSpaceCheck);
   },
   /**
    * Validate whether the given path is a valid ComfyUI source path.


### PR DESCRIPTION
Allows users to bypass the 10GB (Windows) / 5GB (macOS) disk space requirement when selecting an installation path. The bypass only affects disk space validation while preserving all other path validation checks.