### PR TITLE
[System Pop Up] Add release tracking configuration to Comfy Settings

### DIFF
--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -13,7 +13,12 @@ export const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy-Desktop.UV.PythonInstallMirror': '',
   'Comfy-Desktop.UV.PypiInstallMirror': '',
   'Comfy-Desktop.UV.TorchInstallMirror': '',
+  'Comfy.Release.Version': '',
+  'Comfy.Release.Status': 'skipped',
+  'Comfy.Release.Timestamp': 0,
 } as const;
+
+export type ReleaseStatus = 'skipped' | 'changelog seen' | "what's new seen";
 
 export interface ComfySettingsData {
   'Comfy-Desktop.AutoUpdate': boolean;
@@ -26,6 +31,9 @@ export interface ComfySettingsData {
   'Comfy-Desktop.UV.PythonInstallMirror': string;
   'Comfy-Desktop.UV.PypiInstallMirror': string;
   'Comfy-Desktop.UV.TorchInstallMirror': string;
+  'Comfy.Release.Version': string;
+  'Comfy.Release.Status': ReleaseStatus;
+  'Comfy.Release.Timestamp': number;
   [key: string]: unknown;
 }
 

--- a/tests/unit/config/comfySettings.test.ts
+++ b/tests/unit/config/comfySettings.test.ts
@@ -90,6 +90,9 @@ describe('ComfySettings', () => {
         'Comfy-Desktop.UV.PythonInstallMirror': '',
         'Comfy-Desktop.UV.PypiInstallMirror': '',
         'Comfy-Desktop.UV.TorchInstallMirror': '',
+        'Comfy.Release.Version': '1.0.0',
+        'Comfy.Release.Status': 'skipped',
+        'Comfy.Release.Timestamp': Date.now(),
       };
 
       vi.mocked(fsPromises.access).mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
Adds release tracking configuration to ComfySettings to support the release notification system in the desktop application.

## Changes
- **New Settings**: Added 3 new release-related configuration keys:
  - `Comfy.Release.Version`: Tracks the current/last seen release version
  - `Comfy.Release.Status`: Tracks user interaction with releases (`skipped`, `changelog seen`, `what's new seen`)
  - `Comfy.Release.Timestamp`: Records when the release was processed

- **Type Safety**: Added `ReleaseStatus` type for better type checking
- **Test Coverage**: Updated unit tests to include the new configuration fields

## Integration
This configuration enables the desktop app to:
- Track which releases the user has seen
- Remember user preferences for release notifications
- Persist release interaction state across app sessions
- Support the "What's New" popup and changelog features

## Technical Details
- Maintains backward compatibility with existing settings
- Uses typed configuration approach consistent with existing desktop settings
- Default values ensure clean initialization for new users