### PR TITLE
Delete config.json on uninstall.

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -78,5 +78,6 @@
 
     FileClose $0
     Delete "$APPDATA\ComfyUI\extra_models_config.yaml"
+    Delete "$APPDATA\ComfyUI\config.json"
   ${endIf}
 !macroend


### PR DESCRIPTION
This allows the user to do a clean uninstall, and when they reinstall, they will be prompted to start from scratch.

Currently, user uninstalls and since config.json is still present, the app will try to start ComfyUI from the previously installed location. Which is now missing the .venv + extra_models_config.yaml.