### PR TITLE
Update ComfyUI core to v0.3.45

### DIFF
--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -49,7 +49,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.2.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.35
+comfyui-workflow-templates==0.1.39
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -50,7 +50,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.2.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.35
+comfyui-workflow-templates==0.1.39
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.3.44",
+      "version": "0.3.45",
       "optionalBranch": ""
     },
     "managerCommit": "402e2c384f338d0ed0a7fb19caa93f29a0dc35fd",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.23.4
- comfyui-workflow-templates==0.1.35
+ comfyui-workflow-templates==0.1.39
  comfyui-embedded-docs==0.2.4
  torch


### PR DESCRIPTION
## Updated versions
| Component     | Version               |
| ------------- | --------------------- |
| ComfyUI core  | [v0.3.45](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.45) |
| Templates     | [v0.1.39](https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.1.39) |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1225-Update-ComfyUI-core-to-v0-3-45-2376d73d3650814fbb30c68f5f46c3df) by [Unito](https://www.unito.io)
