### PR TITLE
Update bump-stable command

### DIFF
--- a/.claude/commands/bump-stable.md
+++ b/.claude/commands/bump-stable.md
@@ -19,7 +19,7 @@ Please update the version of ComfyUI to the latest:
      | Frontend      | FRONTEND_VERSION      |
      | Templates     | TEMPLATES_VERSION     |
      | Embedded docs | EMBEDDED_DOCS_VERSION |
-8. Wait for all tests to pass, regularly checking until they do, then squash-merge the PR.
+8. Wait for all tests to pass, actively monitoring and checking the PR status periodically until tests complete, then squash-merge the PR.
 9. Switch to main branch and git pull
 10. Bump the version using `npm version` with the `--no-git-tag-version` arg
 11. Create a version bump PR with the title `vVERSION` e.g. `v0.4.10`. It must have the `Release` label, and no content in the PR description.


### PR DESCRIPTION
Fix Claude Code workflow: add explicit instruction to regularly check test status instead of stopping and waiting for user input after PR creation

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1227-Update-bump-stable-command-2376d73d365081cc877bde2d9c2ac8c4) by [Unito](https://www.unito.io)
