### PR TITLE
Update bump-stable command to use --admin flag for version bump PR

### DIFF
--- a/.claude/commands/bump-stable.md
+++ b/.claude/commands/bump-stable.md
@@ -23,7 +23,7 @@ Please update the version of ComfyUI to the latest:
 9. Switch to main branch and git pull
 10. Bump the version using `npm version` with the `--no-git-tag-version` arg
 11. Create a version bump PR with the title `vVERSION` e.g. `v0.4.10`. It must have the `Release` label, and no content in the PR description.
-12. Squash-merge the PR - do not wait for tests, as bumping package version will not cause test breakage.
+12. Squash-merge the PR using `gh pr merge --squash --admin` to bypass branch protection rules - do not wait for tests, as bumping package version will not cause test breakage.
 13. Publish a GitHub Release:
     - Set to pre-release (not latest)
     - The tag should be `vVERSION` e.g. `v0.4.10`


### PR DESCRIPTION
## Description

Updates the bump-stable Claude command to use the `--admin` flag when merging the version bump PR.

## Use Case

The version bump PR (step 12) needs to bypass branch protection rules since:
- It only changes the version number in package.json
- This change will not cause test failures
- Waiting for all CI checks would delay the release process unnecessarily

Using `gh pr merge --squash --admin` allows the PR to be merged immediately after creation, streamlining the release workflow.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1239-Update-bump-stable-command-to-use-admin-flag-for-version-bump-PR-2406d73d365081ddb82bdde412734275) by [Unito](https://www.unito.io)
