### PR TITLE
Update ComfyUI core to v0.3.48

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -43,7 +43,7 @@ click==8.1.7
 comfyui-embedded-docs==0.2.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.41
+comfyui-workflow-templates==0.1.45
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==43.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -49,7 +49,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.2.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.41
+comfyui-workflow-templates==0.1.45
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -50,7 +50,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.2.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.41
+comfyui-workflow-templates==0.1.45
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.3.47",
+      "version": "0.3.48",
       "optionalBranch": ""
     },
     "managerCommit": "402e2c384f338d0ed0a7fb19caa93f29a0dc35fd",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.23.4
- comfyui-workflow-templates==0.1.41
+ comfyui-workflow-templates==0.1.45
  comfyui-embedded-docs==0.2.4
  torch


### PR DESCRIPTION
## Updated versions
| Component     | Version               |
| ------------- | --------------------- |
| ComfyUI core  | [v0.3.48](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.48)       |
| Templates     | [v0.1.45](https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.1.45)     |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1240-Update-ComfyUI-core-to-v0-3-48-2436d73d3650814681a6c4bc08c4c2ed) by [Unito](https://www.unito.io)
