### PR TITLE
Update ComfyUI core to v0.3.50

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -40,10 +40,10 @@ charset-normalizer==3.4.0
 click==8.1.7
     # via typer
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.2.4
+comfyui-embedded-docs==0.2.6
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.51
+comfyui-workflow-templates==0.1.59
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==43.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -46,10 +46,10 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.2.4
+comfyui-embedded-docs==0.2.6
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.51
+comfyui-workflow-templates==0.1.59
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -47,10 +47,10 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://download.pytorch.org/whl/cu128
-comfyui-embedded-docs==0.2.4
+comfyui-embedded-docs==0.2.6
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.51
+comfyui-workflow-templates==0.1.59
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.3.49",
+      "version": "0.3.50",
       "optionalBranch": ""
     },
     "managerCommit": "402e2c384f338d0ed0a7fb19caa93f29a0dc35fd",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.23.4
- comfyui-workflow-templates==0.1.51
- comfyui-embedded-docs==0.2.4
+ comfyui-workflow-templates==0.1.59
+ comfyui-embedded-docs==0.2.6
  torch


### PR DESCRIPTION
## Updated versions
| Component     | Version                                                                             |
| ------------- | ----------------------------------------------------------------------------------- |
| ComfyUI core  | [v0.3.50](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.50)         |
| Templates     | [v0.1.59](https://github.com/Comfy-Org/workflow-templates/releases/tag/v0.1.59)   |
| Embedded docs | [v0.2.6](https://github.com/Comfy-Org/embedded-docs/releases/tag/v0.2.6)          |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1246-Update-ComfyUI-core-to-v0-3-50-24e6d73d365081bcb4b2fdfd61762d85) by [Unito](https://www.unito.io)
