### PR TITLE
[CI] Remove unstable frontend from Claude release

### DIFF
--- a/.claude/commands/bump-stable.md
+++ b/.claude/commands/bump-stable.md
@@ -2,12 +2,14 @@ Please update the version of ComfyUI to the latest:
 
 1. Reference this PR as an example. https://github.com/Comfy-Org/desktop/commit/7cba9c25b95b30050dfd6864088ca91493bfd00b
 2. Go to [ComfyUI](https://github.com/comfyanonymous/ComfyUI/) Github repo and see what the latest Github Release is
-3. Update the ComfyUI version version in @package.json based on what is in the latest Github Release. Don't update the optional branch.
-4. Get the latest stable [frontend](https://github.com/Comfy-Org/ComfyUI_frontend) release, and use it to update `frontendVersion` in @package.json.
-5. Update the versions in `scripts/core-requirements.patch` to match those in `requirements.txt` from the ComfyUI repo.
+   - If there is a `prerelease` or a draft release that is newer than the release marked as `latest`, AND this new version is a either a single major, minor, or patch version increment on the `latest` release, use that version instead of latest.
+3. Read the `requirements.txt` file from that release
+4. Update the ComfyUI version version in @package.json based on what is in the latest Github Release. If config.ComfyUI.optionalBranch is set in @package.json, change it to an empty string ("").
+5. Update the frontend version in @package.json (`frontendVersion`) to the version specified in `requirements.txt`
+6. Update the versions in `scripts/core-requirements.patch` to match those in `requirements.txt` from the ComfyUI repo.
    - Context: The patch is used to removes the frontend package, as the desktop app includes it in the build process instead.
-6. Update `assets/requirements/windows_nvidia.compiled` and `assets/requirements/windows_cpu.compiled`, and `assets/requirements/macos.compiled` accordingly. You just need to update the comfycomfyui-frontend-package, [comfyui-workflow-templates](https://github.com/Comfy-Org/workflow_templates), [comfyui-embedded-docs](https://github.com/Comfy-Org/embedded-docs) versions.
-7. Please make a PR by checking out a new branch from main, adding a commit message and then use GH CLI to create a PR.
+7. Update `assets/requirements/windows_nvidia.compiled` and `assets/requirements/windows_cpu.compiled`, and `assets/requirements/macos.compiled` accordingly. You just need to update the comfycomfyui-frontend-package, [comfyui-workflow-templates](https://github.com/Comfy-Org/workflow_templates), [comfyui-embedded-docs](https://github.com/Comfy-Org/embedded-docs) versions.
+8. Please make a PR by checking out a new branch from main, adding a commit message and then use GH CLI to create a PR.
    - Make the versions in the PR body as links to the relevant github releases
    - Include only the PR body lines that were updated
    - PR Title: Update ComfyUI core to v{VERSION}
@@ -19,16 +21,16 @@ Please update the version of ComfyUI to the latest:
      | Frontend      | FRONTEND_VERSION      |
      | Templates     | TEMPLATES_VERSION     |
      | Embedded docs | EMBEDDED_DOCS_VERSION |
-8. Wait for all tests to pass, actively monitoring and checking the PR status periodically until tests complete, then squash-merge the PR.
-9. Switch to main branch and git pull
-10. Bump the version using `npm version` with the `--no-git-tag-version` arg
-11. Create a version bump PR with the title `vVERSION` e.g. `v0.4.10`. It must have the `Release` label, and no content in the PR description.
-12. Squash-merge the PR - do not wait for tests, as bumping package version will not cause test breakage.
-13. Publish a GitHub Release:
+9. Wait for all tests to pass, actively monitoring and checking the PR status periodically until tests complete, then squash-merge the PR (only if required, use the `--admin` flag).
+10. Switch to main branch and git pull
+11. Bump the version using `npm version` with the `--no-git-tag-version` arg
+12. Create a version bump PR with the title `vVERSION` e.g. `v0.4.10`. It must have the `Release` label, and no content in the PR description.
+13. Squash-merge the PR (only if required, use the `--admin` flag) - do not wait for tests, as bumping package version will not cause test breakage.
+14. Publish a GitHub Release:
     - Set to pre-release (not latest)
     - The tag should be `vVERSION` e.g. `v0.4.10`
     - Use GitHub's generate release notes option
-14. Remove merged local branches
+15. Remove merged local branches
 
 ## Commit messages
 


### PR DESCRIPTION
Updates the Claude command to run a release.  Now set to use the same frontend release as is in the stable release of ComfyUI core.  The latest release on the frontend repo is a dev version.

If this needs to be changed in future, it should likely be done on a version-by-version basis, rather than as the baseline.