### PR TITLE
[chore] Update typescript to 5.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "ts-node": "^10.0.0",
-    "typescript": "^5.7.2",
+    "typescript": "^5.9.2",
     "typescript-eslint": "^8.18.1",
     "vite": "^5.4.11",
     "vite-plugin-dts": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,7 +271,7 @@ __metadata:
     tar: "npm:^7.4.3"
     tmp: "npm:^0.2.3"
     ts-node: "npm:^10.0.0"
-    typescript: "npm:^5.7.2"
+    typescript: "npm:^5.9.2"
     typescript-eslint: "npm:^8.18.1"
     vite: "npm:^5.4.11"
     vite-plugin-dts: "npm:^4.3.0"
@@ -11936,13 +11936,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.4.3, typescript@npm:^5.7.2":
+"typescript@npm:^5.4.3":
   version: 5.7.3
   resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.9.2":
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
   languageName: node
   linkType: hard
 
@@ -11956,13 +11966,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.4.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.4.3#optional!builtin<compat/typescript>":
   version: 5.7.3
   resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/3b56d6afa03d9f6172d0b9cdb10e6b1efc9abc1608efd7a3d2f38773d5d8cfb9bbc68dfb72f0a7de5e8db04fc847f4e4baeddcd5ad9c9feda072234f0d788896
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>":
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=8c6c40"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/66fc07779427a7c3fa97da0cf2e62595eaff2cea4594d45497d294bfa7cb514d164f0b6ce7a5121652cf44c0822af74e29ee579c771c405e002d1f23cf06bfde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1269-chore-Update-typescript-to-5-9-2-25c6d73d3650810cb645e079179a52ae) by [Unito](https://www.unito.io)
