### PR TITLE
Update ComfyUI-Manager to desktop branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "version": "0.3.52",
       "optionalBranch": ""
     },
-    "managerCommit": "402e2c384f338d0ed0a7fb19caa93f29a0dc35fd",
+    "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",
     "uvVersion": "0.8.13"
   },
   "scripts": {


### PR DESCRIPTION
Updates ComfyUI-Manager to the latest commit, and reverts the following PRs:

- https://github.com/Comfy-Org/ComfyUI-Manager/pull/2025
- Follow-up commit: https://github.com/Comfy-Org/ComfyUI-Manager/commit/4834874091f6e272d7e7d093d71cd383530a245f

This removes the requirement for every desktop user to download several new packages for the matrix share feature.  This is an inconvenience for users wanting to use matrix share, however including this update will cause major update pain for many international users with network issues.

The planned feature to defer updates would also provide adequate coverage for this, once merged.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1272-Update-ComfyUI-Manager-to-desktop-branch-25c6d73d36508110a0d6c6b754484e2a) by [Unito](https://www.unito.io)
