### PR TITLE
[CI] Add automatic release generating GitHub Action

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -52,7 +52,7 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \
-            --latest \
+            --prerelease \
             --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Generates pre-release with title / tag format: `v0.0.0`
- Automatically runs agains PRs with `Release` label that touch package.json
- Can be run manually (against main, typically - great for correcting human error)
- Fail fast - throws if the release already exists

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1278-CI-Add-automatic-release-generating-GitHub-Action-25d6d73d36508181b753e8b599b78ba9) by [Unito](https://www.unito.io)
