### PR TITLE
Allow manual ElectronAPI publishing

### DIFF
--- a/.github/workflows/release_types.yml
+++ b/.github/workflows/release_types.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Node.js 20.x
-        uses: JP250552/setup-node@0c618ceb2e48275dc06e86901822fd966ce75ba2
+        uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          corepack: true
+          cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
Adds manual workflow trigger to ElectronAPI publish action.

- Enables workflow_dispatch for on-demand publishing
- Replaces JP250552/setup-node fork with official actions/setup-node@v4
- Removes unnecessary corepack (not needed for npm publish)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1290-Allow-manual-ElectronAPI-publishing-2636d73d36508119b293d0535c6d95fb) by [Unito](https://www.unito.io)
