### PR TITLE
Follow-up on #1290 - API type publish using yarn v4

### DIFF
--- a/.github/workflows/release_types.yml
+++ b/.github/workflows/release_types.yml
@@ -23,11 +23,24 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Enable Corepack
         run: corepack enable
+
+      - name: Enable Corepack and pin Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.0 --activate
+          yarn --version
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
Fixes issue where default setup action requires additional steps over 3rd party.

- Follow-up on #1290

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1292-Follow-up-on-1290-API-type-publish-using-yarn-v4-2646d73d3650813a87e5e55c4f8ecf8c) by [Unito](https://www.unito.io)
