### PR TITLE
Automatically recover from partial venv installation

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -572,7 +572,7 @@ export class VirtualEnvironment implements HasTelemetry {
   async hasRequirements(): Promise<'OK' | 'error' | 'package-upgrade'> {
     const checkRequirements = async (requirementsPath: string) => {
       const args = ['pip', 'install', '--dry-run', '-r', requirementsPath];
-      log.info(`Running direct process command: ${args.join(' ')}`);
+      log.info(`Running uv command directly: ${args.join(' ')}`);
 
       // Get packages as json string
       let output = '';


### PR DESCRIPTION
### Current

Installer assumes that if the virtual environment dir exists, it is a full working venv with all packages.  If that is not the case, the server will most likely crash the app on start.  Requires exist, restart app, and troubleshooting card to resolve.

This also happens in edge cases, such as installing a newer Comfy version to a directory that had an older version installed.

### Proposed

If the directory is present, assumes that it is at least a baseline venv.  Installs required packages automatically (user was warned that the dir exists when they selected the dir).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1299-Examine-venv-during-re-install-2686d73d36508166ac1cfdfcbc01e526) by [Unito](https://www.unito.io)
