### PR TITLE
Fix empty .venv folder breaks install

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 import log from 'electron-log/main';
 import pty from 'node-pty';
 import { ChildProcess, spawn } from 'node:child_process';
-import { rm } from 'node:fs/promises';
+import { readdir, rm } from 'node:fs/promises';
 import os, { EOL } from 'node:os';
 import path from 'node:path';
 


### PR DESCRIPTION
Prevents installation from treating an empty .venv directory as a valid virtual environment.

- Checks both directory existence and non-empty contents
- Adds JSDoc documentation for the exists() method

Resolves issue where an empty .venv folder would incorrectly pass existence check.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1302-Fix-empty-venv-folder-breaks-install-2696d73d365081f7a581c5a279a86c8b) by [Unito](https://www.unito.io)
