### PR TITLE
Fix cannot reinstall from troubleshooting page

### DIFF
--- a/src/main-process/comfyInstallation.ts
+++ b/src/main-process/comfyInstallation.ts
@@ -229,7 +229,9 @@ export class ComfyInstallation {
    * @todo Allow normal removal of the app and its effects.
    */
   async uninstall(): Promise<void> {
-    await rm(ComfyServerConfig.configPath);
+    if (await pathAccessible(ComfyServerConfig.configPath)) {
+      await rm(ComfyServerConfig.configPath);
+    }
     await useDesktopConfig().permanentlyDeleteConfigFile();
   }
 }


### PR DESCRIPTION
Fixes an issue where users cannot reinstall from the troubleshooting page if their extra_models_config.yaml file does not exist.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1317-Fix-cannot-reinstall-from-troubleshooting-page-26d6d73d365081cf87eed27f5f557b99) by [Unito](https://www.unito.io)
