### PR TITLE
List changed files when formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "download-frontend": "node scripts/downloadFrontend.js",
     "make:frontend": "yarn run download-frontend",
     "format": "prettier --write --cache --list-different .",
-    "format:check": "prettier --check --list-different .",
+    "format:check": "prettier --check .",
     "lint": "eslint --fix --cache src",
     "lint:check": "eslint --max-warnings 0 src",
     "make": "yarn run vite:compile && electron-builder build --config=builder-debug.config.ts && yarn run verify:build",


### PR DESCRIPTION
Replaces `--log-level warn` with `--list-different` in format scripts.

- Shows only files that are modified during formatting
- Reduces noise in CI/CD output
- Allows agents to actually use the tool output instead of ignoring it due to size

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1319-List-changed-files-when-formatting-2706d73d36508184ab18c3107bf1bec7) by [Unito](https://www.unito.io)
