### PR TITLE
Add Dialog API to preload for custom dialogs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,6 +54,7 @@ export const IPC_CHANNELS = {
   CHECK_BLACKWELL: 'check-blackwell',
   GET_INSTALL_STAGE: 'get-install-stage',
   INSTALL_STAGE_UPDATE: 'install-stage-update',
+  DIALOG_CLICK_BUTTON: 'dialog-click-button',
 } as const;
 
 export enum ProgressStatus {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -496,6 +496,18 @@ const electronAPI = {
    */
   // "Fire and forget", code on desktop side will catch errors pre-restart
   restartAndInstall: (): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.RESTART_AND_INSTALL),
+
+  /**
+   * Dialog API for custom dialogs
+   */
+  Dialog: {
+    /**
+     * Sends a button click result back to the main process
+     * @param returnValue The value to return from the dialog
+     */
+    clickButton: (returnValue: string): Promise<boolean> =>
+      ipcRenderer.invoke(IPC_CHANNELS.DIALOG_CLICK_BUTTON, returnValue),
+  },
 } as const;
 
 export type ElectronAPI = typeof electronAPI;


### PR DESCRIPTION
Adds the API required for the following PRs ahead of time.  Pre-requisite for the frontend PR, which can land before the desktop API goes in.

- Frontend: https://github.com/Comfy-Org/ComfyUI_frontend/pull/5605
- Desktop (branch): https://github.com/Comfy-Org/desktop/tree/custom-dialog

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1320-Add-Dialog-API-to-preload-for-custom-dialogs-2706d73d3650810db453f2806e5ad573) by [Unito](https://www.unito.io)
