### PR TITLE
Add verbose logging to path validation

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -71,6 +71,7 @@ export function registerPathHandlers() {
   ipcMain.handle(
     IPC_CHANNELS.VALIDATE_INSTALL_PATH,
     async (event, inputPath: string, bypassSpaceCheck = false): Promise<PathValidationResult> => {
+      log.verbose('Handling VALIDATE_INSTALL_PATH: inputPath: [', inputPath, '] bypassSpaceCheck: ', bypassSpaceCheck);
       // Determine required space based on OS
       const requiredSpace = process.platform === 'darwin' ? MAC_REQUIRED_SPACE : WIN_REQUIRED_SPACE;
 
@@ -93,8 +94,7 @@ export function registerPathHandlers() {
             const normalizedInput = path.resolve(inputPath).toLowerCase();
             const normalizedOneDrive = path.resolve(OneDrive).toLowerCase();
             // Check if the normalized OneDrive path is a parent of the input path
-            process.stdout.write(`normalizedInput: ${normalizedInput}\n`);
-            process.stdout.write(`normalizedOneDrive: ${normalizedOneDrive}\n`);
+            log.verbose('normalizedInput [', normalizedInput, ']', 'normalizedOneDrive [', normalizedOneDrive, ']');
             if (normalizedInput.startsWith(normalizedOneDrive)) {
               result.isOneDrive = true;
             }
@@ -102,6 +102,7 @@ export function registerPathHandlers() {
 
           // Check if path is on non-default drive
           const systemDrive = process.env.SystemDrive || 'C:';
+          log.verbose('systemDrive [', systemDrive, ']');
           if (!inputPath.toUpperCase().startsWith(systemDrive)) {
             result.isNonDefaultDrive = true;
           }
@@ -132,7 +133,9 @@ export function registerPathHandlers() {
 
         // Check available disk space
         const disks = await si.fsSize();
+        log.verbose('SystemInformation [fsSize]:', disks);
         const disk = disks.find((disk) => inputPath.startsWith(disk.mount));
+        log.verbose('SystemInformation [disk]:', disk);
         if (disk) result.freeSpace = disk.available;
       } catch (error) {
         log.error('Error validating install path:', error);
@@ -147,6 +150,8 @@ export function registerPathHandlers() {
         result.isOneDrive
           ? false
           : true;
+
+      log.verbose('VALIDATE_INSTALL_PATH [result]: ', result);
       return result;
     }
   );


### PR DESCRIPTION
### Current

- Ref: #1277

Users are shown erroneous "insufficient space" errors during installation.

### Proposed

- Adds verbose logging to the path validation
- Replaces stdout writes with verbose logging in install path validation.

This PR should allow us to track down the cause of the elusive insufficient disk space error, and any other path validation issues on the install wizard path selection screen.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1326-Add-verbose-logging-to-path-validation-2736d73d3650810fa0fbca3d992c98fa) by [Unito](https://www.unito.io)
