### PR TITLE
Skip disk space check when fsSize undefined

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -133,10 +133,14 @@ export function registerPathHandlers() {
 
         // Check available disk space
         const disks = await si.fsSize();
-        log.verbose('SystemInformation [fsSize]:', disks);
-        const disk = disks.find((disk) => inputPath.startsWith(disk.mount));
-        log.verbose('SystemInformation [disk]:', disk);
-        if (disk) result.freeSpace = disk.available;
+        if (disks) {
+          log.verbose('SystemInformation [fsSize]:', disks);
+          const disk = disks.find((disk) => inputPath.startsWith(disk.mount));
+          log.verbose('SystemInformation [disk]:', disk);
+          if (disk) result.freeSpace = disk.available;
+        } else {
+          log.warn('SystemInformation [fsSize] is undefined. Skipping disk space check.');
+        }
       } catch (error) {
         log.error('Error validating install path:', error);
         result.error = `${error}`;


### PR DESCRIPTION
Prevents invalid path errors when SystemInformation cannot determine disk size.

- Adds null check for fsSize result
- Logs warning when disk info unavailable
- Allows installation to proceed without space validation
- Resolves #1277

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1327-Skip-disk-space-check-when-fsSize-undefined-2736d73d365081c2a5eef3eac4e0b102) by [Unito](https://www.unito.io)
