### PR TITLE
Fix empty disks array check

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -133,7 +133,7 @@ export function registerPathHandlers() {
 
         // Check available disk space
         const disks = await si.fsSize();
-        if (disks) {
+        if (disks.length) {
           log.verbose('SystemInformation [fsSize]:', disks);
           const disk = disks.find((disk) => inputPath.startsWith(disk.mount));
           log.verbose('SystemInformation [disk]:', disk);


### PR DESCRIPTION
Fixes check for empty fsSize result array.

- Follow-up on #1327

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1328-Fix-empty-disks-array-check-2736d73d3650816ca3e7fdb56301fb62) by [Unito](https://www.unito.io)
