### PR TITLE
Add workaround for installation blocked by frontend

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -140,6 +140,7 @@ export function registerPathHandlers() {
           if (disk) result.freeSpace = disk.available;
         } else {
           log.warn('SystemInformation [fsSize] is undefined. Skipping disk space check.');
+          result.freeSpace = result.requiredSpace;
         }
       } catch (error) {
         log.error('Error validating install path:', error);


### PR DESCRIPTION
### Current

Actual validation happens in the desktop code, but the decision to continue / block install is currently owned by the frontend.

- Ref: https://github.com/Comfy-Org/desktop/issues/1277#issuecomment-3314373089

### Proposed

Work around the issue by setting a fake number to force the front end to ignore the issue.

### Follow-up

This needs to be properly cleaned up so that desktop controls what desktop does. It is illogical for the front end to be the owner of the decision to allow the desktop app to install or not.

Double-validation provides excellent UX when a delay between frontend and backend is _possible_ (e.g. web app).  This validation logic needs to be owned solely by the Electron code.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1329-Add-workaround-for-installation-blocked-by-frontend-2746d73d365081108051ca422a391a52) by [Unito](https://www.unito.io)
