### PR TITLE
Fix intermittent CI failure in app close test

### DIFF
--- a/tests/integration/shared/appWindow.spec.ts
+++ b/tests/integration/shared/appWindow.spec.ts
@@ -8,6 +8,7 @@ test('App window has title', async ({ app }) => {
 test('App quits when window is closed', async ({ app }) => {
   const window = await app.firstWindow();
 
+  const closePromise = app.app.waitForEvent('close');
   await window.close();
-  await app.app.waitForEvent('close');
+  await closePromise;
 });


### PR DESCRIPTION
Prevents intermittent CI failures by capturing close promise before triggering window close.

The test was calling `waitForEvent` after `window.close()`, creating a race condition where the event could fire before the listener was attached.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1336-Fix-intermittent-CI-failure-in-app-close-test-2776d73d3650811282d0cb47ba03384a) by [Unito](https://www.unito.io)
