### PR TITLE
Fix NSIS installer build error

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -11,25 +11,29 @@
 
 # Custom finish page that skips when in update mode
 !macro customFinishPage
-  ${if} ${isUpdated}
-    # Skip finish page during updates - just complete silently
-  ${else}
-    # Show normal finish page for fresh installs
-    !ifndef HIDE_RUN_AFTER_FINISH
-      Function StartApp
-        ${if} ${isUpdated}
-          StrCpy $1 "--updated"
-        ${else}
-          StrCpy $1 ""
-        ${endif}
-        ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
-      FunctionEnd
+  !ifndef HIDE_RUN_AFTER_FINISH
+    Function StartApp
+      ${if} ${isUpdated}
+        StrCpy $1 "--updated"
+      ${else}
+        StrCpy $1 ""
+      ${endif}
+      ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
+    FunctionEnd
 
-      !define MUI_FINISHPAGE_RUN
-      !define MUI_FINISHPAGE_RUN_FUNCTION "StartApp"
-    !endif
-    !insertmacro MUI_PAGE_FINISH
-  ${endif}
+    !define MUI_FINISHPAGE_RUN
+    !define MUI_FINISHPAGE_RUN_FUNCTION "StartApp"
+  !endif
+
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE FinishPagePreCheck
+  !insertmacro MUI_PAGE_FINISH
+
+  # Skip finish page during updates
+  Function FinishPagePreCheck
+    ${if} ${isUpdated}
+      Abort
+    ${endif}
+  FunctionEnd
 !macroend
 
 !ifdef BUILD_UNINSTALLER


### PR DESCRIPTION
Fixes NSIS compilation error preventing v0.4.74 from building.

The `${if} ${isUpdated}` macro cannot be used at compile-time in NSIS - it expands to runtime commands that are only valid inside Functions or Sections.

Uses `MUI_PAGE_CUSTOMFUNCTION_PRE` callback to skip finish page during updates.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1340-Fix-NSIS-installer-build-error-2776d73d36508132ad00ffd2a5b59574) by [Unito](https://www.unito.io)
