### PR TITLE
Ensure app is re-opened after update

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -31,6 +31,7 @@
   # Skip finish page during updates
   Function FinishPagePreCheck
     ${if} ${isUpdated}
+      ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "--updated"
       Abort
     ${endif}
   FunctionEnd


### PR DESCRIPTION
Ensure the app is re-opened after an automatic update.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1342-Ensure-app-is-re-opened-after-update-2776d73d365081dda47cf91fec680105) by [Unito](https://www.unito.io)
