### PR TITLE
Fix installer regression: unable to choose app install path

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -4,6 +4,9 @@
 !include 'nsDialogs.nsh'
 !include 'WinMessages.nsh'
 
+# Define allowToChangeInstallationDirectory to show the directory page
+!define allowToChangeInstallationDirectory
+
 # Per-user install
 !macro customInstallMode
   StrCpy $isForceCurrentInstall "1"


### PR DESCRIPTION
The Windows installer was automatically proceeding without showing the directory selection page, preventing users from choosing where to install the app.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1349-Fix-installer-regression-unable-to-choose-app-install-path-27e6d73d36508161a40fe6b95b340f68) by [Unito](https://www.unito.io)
