### PR TITLE
Update ComfyUI core to v0.3.64

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -43,7 +43,7 @@ click==8.1.7
 comfyui-embedded-docs==0.2.6
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.93
+comfyui-workflow-templates==0.1.94
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==43.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -49,7 +49,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.2.6
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.93
+comfyui-workflow-templates==0.1.94
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -50,7 +50,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.2.6
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.1.93
+comfyui-workflow-templates==0.1.94
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.27.9",
+      "version": "1.27.10",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.3.63",
+      "version": "0.3.64",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.27.7
- comfyui-workflow-templates==0.1.93
+-comfyui-frontend-package==1.27.10
+ comfyui-workflow-templates==0.1.94
  comfyui-embedded-docs==0.2.6
  torch


### PR DESCRIPTION
## Updated versions
| Component     | Version               |
| ------------- | --------------------- |
| ComfyUI core  | [v0.3.64](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.64) |
| Frontend      | [v1.27.10](https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.27.10) |
| Templates     | [v0.1.94](https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.1.94) |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1363-Update-ComfyUI-core-to-v0-3-64-2866d73d3650818ca698f30661aad95e) by [Unito](https://www.unito.io)
