### PR TITLE
Enable CI validation for test expectation updates

### DIFF
--- a/.github/workflows/update_test_expectations.yml
+++ b/.github/workflows/update_test_expectations.yml
@@ -50,5 +50,5 @@ jobs:
           git fetch origin ${{ github.head_ref }}
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
           git add tests
-          git commit -m "Update test expectations [skip ci]" || echo "No changes to commit"
+          git commit -m "Update test expectations" || echo "No changes to commit"
           git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
Removes `[skip ci]` from automated test expectation commits.

When test expectations are updated via the workflow, CI will now validate the changes instead of being skipped.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1375-Enable-CI-validation-for-test-expectation-updates-2936d73d36508155911ad52b64d55eea) by [Unito](https://www.unito.io)
