### PR TITLE
Skip atomic rename during updates

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -482,26 +482,6 @@
 
 !macro customRemoveFiles
   ${if} ${isUpdated}
-    # App is updating, rather than uninstalling
-  
-    # START Default electron-builder behaviour
-    CreateDirectory "$PLUGINSDIR\old-install"
-
-    Push ""
-    Call un.atomicRMDir
-    Pop $R0
-
-    ${if} $R0 != 0
-      DetailPrint "File is busy, aborting: $R0"
-
-      # Attempt to restore previous directory
-      Push ""
-      Call un.restoreFiles
-      Pop $R0
-
-      Abort `Can't rename "$INSTDIR" to "$PLUGINSDIR\old-install".`
-    ${endif}
-    # END Default electron-builder behaviour
   ${else}
     # Manually uninstalling the app
     Call un.ResolveBasePath


### PR DESCRIPTION
- Remove un.atomicRMDir/restoreFiles path under `${isUpdated}` in customRemoveFiles
- Prevents cross-drive copy+delete into %TEMP% and junction/symlink traversal under `$INSTDIR`
- Avoids stranded %TEMP%\nsq*.tmp\old-install on interruption
- Leave manual uninstall and basePath deletion unchanged

the explanation that helped me:

```
• - INSTDIR is the live installation directory that NSIS sets when the app is installed (for us it ends up at
    something like C:\Users\<user>\AppData\Local\Programs\ComfyUI Desktop). When electron-builder reuses our
    uninstaller during an update, ${isUpdated} is true and INSTDIR still points to that live location.
  - Stock electron-builder logic “cleans” that directory by first renaming it to $PLUGINSDIR\old-install (a temp
    folder inside %TEMP%\nsq*.tmp) and only then deleting it. The rename is meant to give the new installer an
    empty target even if some files are locked, and it acts as a crude fallback: if deletion fails, the old files
    at least live somewhere else while the new version is laid down.
  - Renaming instead of deleting lets the update continue when files are in use. A straight RMDir $INSTDIR would
    abort the update the moment anything is locked; the rename succeeds more often because Windows allows moving a
    directory even when child files are open, postponing deletion to the temp copy.
  - For Comfy Desktop, that “clean slate” assumption breaks down because our models/workflows/venv live inside
    or under INSTDIR (default basePath is beneath it). So the rename effectively moves user data into %TEMP%, the
    later delete removes it, and if the update is interrupted the only copy is stranded in %TEMP%.
  - By removing the un.atomicRMDir path (scripts/installer.nsh:483–486), updates no longer rename or delete
    INSTDIR; the new build just overlays files in place. That sacrifices the “always empty directory” guarantee
    but protects user content, reflects our actual layout, and any partially-updated binaries can be repaired by
    rerunning the installer.
```


Refs: #1324

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1380-Skip-atomic-rename-during-updates-29c6d73d36508151b396c1956ae2ba64) by [Unito](https://www.unito.io)
