### PR TITLE
chore: relax required fields in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -80,7 +80,7 @@ body:
         </details>
       render: powershell
     validations:
-      required: true
+      required: false
   - type: textarea
     attributes:
       label: Browser Logs
@@ -97,7 +97,7 @@ body:
 
         </details>
     validations:
-      required: true
+      required: false
   - type: textarea
     attributes:
       label: Settings JSON
@@ -112,7 +112,7 @@ body:
 
         </details>
     validations:
-      required: true
+      required: false
   - type: textarea
     attributes:
       label: Other


### PR DESCRIPTION
Tones down the Bug Report template requirements.

- Only `Actual Behavior` and `Steps to Reproduce` are required.
- All other fields are optional to reduce friction.

This aligns the template with our frontend standards for bug report requirements.

Changed: `.github/ISSUE_TEMPLATE/bug-report.yaml`.

Ref: https://github.com/Comfy-Org/desktop/issues/1390

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1391-chore-relax-required-fields-in-bug-report-template-29c6d73d3650816abb42e60b01706da6) by [Unito](https://www.unito.io)
