### PR TITLE
chore: add issue types to bug/feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -2,6 +2,7 @@ name: Bug Report
 description: 'Something is not behaving as expected.'
 title: '[Bug]: '
 labels: ['Potential Bug']
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -2,6 +2,7 @@ name: Feature Request
 description: Suggest an idea for this project
 title: '[Feature Request]: '
 labels: ['enhancement']
+type: Feature
 
 body:
   - type: checkboxes


### PR DESCRIPTION
This PR adds GitHub Issue Types to the existing templates while keeping labels unchanged.

- .github/ISSUE_TEMPLATE/bug-report.yaml: added `type: Bug`
- .github/ISSUE_TEMPLATE/feature-request.yaml: added `type: Feature`

Rationale
- Aligns with our frontend templates (../frontend/.github/ISSUE_TEMPLATE) that already use `type: Bug` and `type: Feature`.
- Preserves current labels to avoid any workflow changes.

Validation
- Verified YAML shape by comparing with frontend templates.
- Ran `yarn run lint:check` and `yarn run typescript` locally; both pass.