### PR TITLE
Add workflow concurrency cancellation to prefer newest runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,10 @@ on:
       - 'CLAUDE.md'
       - '*_example'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-format:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/debug_all.yml
+++ b/.github/workflows/debug_all.yml
@@ -38,6 +38,10 @@ on:
       - '*_example'
       - 'tests/unit/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test-e2e-windows:
     secrets: inherit

--- a/.github/workflows/debug_macos.yml
+++ b/.github/workflows/debug_macos.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-macos-debug:
     runs-on: macos-latest

--- a/.github/workflows/integration_test_windows.yml
+++ b/.github/workflows/integration_test_windows.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration-windows-test:
     runs-on: windows-latest

--- a/.github/workflows/publish_all.yml
+++ b/.github/workflows/publish_all.yml
@@ -10,6 +10,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.release_tag || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-todesktop:
     if: |

--- a/.github/workflows/publish_staging.yml
+++ b/.github/workflows/publish_staging.yml
@@ -3,6 +3,10 @@ name: Publish Staging Application
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-staging-todesktop:
     if: |

--- a/.github/workflows/release_types.yml
+++ b/.github/workflows/release_types.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - 'package.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/todesktop.yml
+++ b/.github/workflows/todesktop.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-windows-debug:
     runs-on: windows-latest

--- a/.github/workflows/update_test_expectations.yml
+++ b/.github/workflows/update_test_expectations.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- add `concurrency` blocks with `cancel-in-progress: true` to PR-triggered and reusable CI workflows so newer pushes supersede older runs on the same ref
- guard dispatch/release workflows with per-ref/per-input concurrency groups to avoid overlapping executions of the same ref/tag
- keep existing `update_compiled_requirements` concurrency as-is

## Testing
- not run (workflow-only changes)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1437-Add-workflow-concurrency-cancellation-to-prefer-newest-runs-2b56d73d365081a58a34f89b7e91c5fc) by [Unito](https://www.unito.io)
