### PR TITLE
Fix reusable workflow concurrency grouping

### DIFF
--- a/.github/workflows/debug_macos.yml
+++ b/.github/workflows/debug_macos.yml
@@ -5,7 +5,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Ensure the macOS build run doesn't cancel other reusable callers
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration_test_windows.yml
+++ b/.github/workflows/integration_test_windows.yml
@@ -5,7 +5,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Ensure the Windows e2e run doesn't share a group with other reusable callers
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- set unique concurrency groups for the Windows e2e workflow and macOS debug workflow using `github.workflow_ref`
- prevent reusable calls from sharing a group and cancelling each other when triggered together (e.g., Build - All Platforms)

## Why
In PR #1440 the required Windows e2e job was cancelled immediately when macOS started because both reusable workflows used the same concurrency key. Giving each workflow its own key keeps both runs active when invoked concurrently while still cancelling superseded runs on the same ref.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1441-Fix-reusable-workflow-concurrency-grouping-2b56d73d365081069354eb307696be50) by [Unito](https://www.unito.io)
