### PR TITLE
Update ComfyUI core to v0.3.73

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -43,7 +43,7 @@ click==8.1.7
 comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.9
+comfyui-workflow-templates==0.7.20
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==43.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -49,7 +49,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.9
+comfyui-workflow-templates==0.7.20
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -50,7 +50,7 @@ colorama==0.4.6
 comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.9
+comfyui-workflow-templates==0.7.20
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.3.72",
+      "version": "0.3.73",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.30.6
- comfyui-workflow-templates==0.7.9
+ comfyui-workflow-templates==0.7.20
  comfyui-embedded-docs==0.3.1
  torch


### PR DESCRIPTION
## Updated versions
| Component     | Version               |
| ------------- | --------------------- |
| ComfyUI core  | [v0.3.73](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.73) |
| Frontend      | [v1.30.6](https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v1.30.6) |
| Templates     | [v0.7.20](https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.7.20) |
| Embedded docs | [v0.3.1](https://github.com/Comfy-Org/embedded-docs) |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1448-Update-ComfyUI-core-to-v0-3-73-2b66d73d365081618d1fee779588d193) by [Unito](https://www.unito.io)
