### PR TITLE
Guard macOS exe path loop

### DIFF
--- a/src/handlers/pathHandlers.ts
+++ b/src/handlers/pathHandlers.ts
@@ -89,7 +89,9 @@ const buildRestrictedPaths = (): RestrictedPathEntry[] => {
     // Walk up until we find the .app bundle
     let current = exePath;
     while (current && current !== '/' && !current.endsWith('.app')) {
-      current = path.dirname(current);
+      const next = path.dirname(current);
+      if (next === current) break; // Guard against dirname('.') or other non-progress cases
+      current = next;
     }
     if (current.endsWith('.app')) {
       addRestrictedPath('appInstallDir', current);


### PR DESCRIPTION
## Summary
- prevent infinite loop when walking macOS exe path by breaking if dirname stops progressing
- keep fallback unchanged otherwise

## Testing
- npm test (hooks: prettier/eslint/tsc via pre-commit)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1457-Guard-macOS-exe-path-loop-2bf6d73d365081d4906edf6ce06a36a0) by [Unito](https://www.unito.io)
