### PR TITLE
chore: format todesktop action whitespace

### DIFF
--- a/.github/actions/build/todesktop/action.yml
+++ b/.github/actions/build/todesktop/action.yml
@@ -51,12 +51,12 @@ runs:
       run: |
         echo "🚀 Building ToDesktop package..."
         yarn run publish | tee build.log
-        
+
         # Extract build ID from the log
         BUILD_URL=$(grep "Build complete!" build.log | head -n1 | cut -d' ' -f3)
         BUILD_ID=$(echo $BUILD_URL | cut -d'/' -f6)
         APP_ID=$(echo $BUILD_URL | cut -d'/' -f5)
-        
+
         # Only update release notes if RELEASE_TAG is provided
         if [ -n "${{ inputs.RELEASE_TAG }}" ]; then
           # Create download links section


### PR DESCRIPTION
## Summary
- run repo format/lint pass
- whitespace cleanup in `.github/actions/build/todesktop/action.yml`
