### PR TITLE
Remove codecov references

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,16 +56,5 @@ jobs:
       - name: Run Unit Tests
         run: yarn run test:unit
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
-        with:
-          directory: ./coverage/
-          fail_ci_if_error: false
-          files: ./cobertura-coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-
       - name: Check Prettier Formatting
         run: yarn run format:check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ComfyUI Desktop
 
-[![codecov](https://codecov.io/github/Comfy-Org/electron/graph/badge.svg?token=S64WJWD2ZX)](https://codecov.io/github/Comfy-Org/electron)
 ![Beta](https://img.shields.io/badge/beta-blue.svg)
 
 # USER GUIDE


### PR DESCRIPTION
## Summary
- remove Codecov badge from README
- drop Codecov upload step from CI workflow

## Testing
- yarn lint
- yarn typescript