### PR TITLE
add distribution flag when building frontend

### DIFF
--- a/scripts/downloadFrontend.js
+++ b/scripts/downloadFrontend.js
@@ -48,7 +48,7 @@ if (frontend.optionalBranch) {
     const output = execSync(command, {
       cwd,
       encoding: 'utf8',
-      env: { ...process.env, ...env }
+      env: { ...process.env, ...env },
     });
     console.log(output);
   }


### PR DESCRIPTION
Allows the frontend to use buildtime var instead of relying on runtime check to know it's being used for desktop. Prereq for https://github.com/Comfy-Org/ComfyUI_frontend/pull/7374.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1479-add-distribution-flag-when-building-frontend-2c86d73d36508104afe8dc0674e7dbe5) by [Unito](https://www.unito.io)
