### PR TITLE
Update ComfyUI core to v0.6.0

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -44,25 +44,25 @@ click==8.1.7
 comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.0.3b5
+comfyui-manager==4.0.3b7
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.59
+comfyui-workflow-templates==0.7.63
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.43
+comfyui-workflow-templates-core==0.3.58
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.22
+comfyui-workflow-templates-media-api==0.3.31
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.36
+comfyui-workflow-templates-media-image==0.3.43
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.47
+comfyui-workflow-templates-media-other==0.3.61
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.19
+comfyui-workflow-templates-media-video==0.3.22
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==43.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -48,25 +48,25 @@ colorama==0.4.6
 comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.0.3b5
+comfyui-manager==4.0.3b7
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.59
+comfyui-workflow-templates==0.7.63
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.43
+comfyui-workflow-templates-core==0.3.58
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.22
+comfyui-workflow-templates-media-api==0.3.31
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.36
+comfyui-workflow-templates-media-image==0.3.43
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.47
+comfyui-workflow-templates-media-other==0.3.61
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.19
+comfyui-workflow-templates-media-video==0.3.22
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -49,25 +49,25 @@ colorama==0.4.6
 comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.0.3b5
+comfyui-manager==4.0.3b7
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.59
+comfyui-workflow-templates==0.7.63
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.43
+comfyui-workflow-templates-core==0.3.58
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.22
+comfyui-workflow-templates-media-api==0.3.31
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.36
+comfyui-workflow-templates-media-image==0.3.43
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.47
+comfyui-workflow-templates-media-other==0.3.61
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.19
+comfyui-workflow-templates-media-video==0.3.22
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==44.0.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.34.9
- comfyui-workflow-templates==0.7.59
+ comfyui-workflow-templates==0.7.63
  comfyui-embedded-docs==0.3.1
  torch


### PR DESCRIPTION
Bump the bundled ComfyUI core to v0.6.0.

## What changed
- Updated the bundled ComfyUI core version and the requirements patch to the v0.6.0 workflow templates.
- Regenerated the macOS and Windows compiled requirements to align with the v0.6.0 dependency set (including comfyui-manager 4.0.3b7).

## Why
- Keep the desktop bundle aligned with the latest stable ComfyUI core release so users get upstream fixes and updates.
- Regenerate platform lockfiles directly from the upstream v0.6.0 requirements to keep dependency resolution consistent.
- Tradeoffs: still uses the existing frontend version; follow-ups may be needed if future core releases add new optional deps.

## Evidence
- Tests: `yarn format`, `yarn lint`, `yarn typescript`

## References
- ComfyUI v0.6.0 release: https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.6.0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1496-Update-ComfyUI-core-to-v0-6-0-2d36d73d365081a29cf5c16d53a4ae87) by [Unito](https://www.unito.io)
