### PR TITLE
Handle noisy output in python import verification

### DIFF
--- a/src/services/pythonImportVerifier.ts
+++ b/src/services/pythonImportVerifier.ts
@@ -66,6 +66,16 @@ function extractMarkedJson(output: string): string | undefined {
   return line.trim();
 }
 
+function extractTrailingJsonLine(output: string): string | undefined {
+  const lines = output.split(/\r?\n/).reverse();
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) continue;
+    return trimmed;
+  }
+}
+
 function interpretPythonValidationOutput(
   output: string
 ):
@@ -73,7 +83,7 @@ function interpretPythonValidationOutput(
   | { type: 'invalid_format'; message: string }
   | { type: 'ok'; value: PythonValidationResult } {
   try {
-    const candidate = extractMarkedJson(output) ?? output.trim();
+    const candidate = extractMarkedJson(output) ?? extractTrailingJsonLine(output) ?? output.trim();
     const parsedOutput: unknown = JSON.parse(candidate);
     const verificationResult = getPythonVerificationSchema().validate(parsedOutput);
 

--- a/tests/unit/services/pythonImportVerifier.test.ts
+++ b/tests/unit/services/pythonImportVerifier.test.ts
@@ -97,6 +97,13 @@ describe('runPythonImportVerifyScript', () => {
     expect(result).toEqual({ success: true });
   });
 
+  test('parses trailing JSON line without marker', async () => {
+    const output = '[WARNING] failed to run amdgpu-arch: binary not found.\n{"failed_imports": [], "success": true}\n';
+    const { venv } = createMockVenv({ stdout: output });
+    const result = await runPythonImportVerifyScript(venv, ['yaml']);
+    expect(result).toEqual({ success: true });
+  });
+
   test('parses JSON from stderr as well as stdout', async () => {
     const json = withMarker({ failed_imports: [], success: true });
     const { venv } = createMockVenv({ stderr: json });


### PR DESCRIPTION
## Summary
- add sentinel marker to python import verification output
- parse marked JSON to ignore noisy warnings
- update unit tests for marker/noisy output

fixes https://github.com/Comfy-Org/desktop/issues/1508

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1509-Handle-noisy-output-in-python-import-verification-2df6d73d3650812294cbcdc9428398a5) by [Unito](https://www.unito.io)
