### PR TITLE
Remove rocm-sdk-devel from AMD requirements

### DIFF
--- a/assets/requirements/amd_requirements.txt
+++ b/assets/requirements/amd_requirements.txt
@@ -1,5 +1,4 @@
 # AMD ROCm SDK packages for Windows
 rocm-sdk-core @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_core-0.1.dev0-py3-none-win_amd64.whl
-rocm-sdk-devel @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_devel-0.1.dev0-py3-none-win_amd64.whl
 rocm-sdk-libraries-custom @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_libraries_custom-0.1.dev0-py3-none-win_amd64.whl
 rocm @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm-0.1.dev0.tar.gz

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -235,8 +235,6 @@ rocm-sdk-core @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_cor
     # via
     #   -r assets/requirements/amd_requirements.txt
     #   rocm
-rocm-sdk-devel @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_devel-0.1.dev0-py3-none-win_amd64.whl
-    # via -r assets/requirements/amd_requirements.txt
 rocm-sdk-libraries-custom @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_libraries_custom-0.1.dev0-py3-none-win_amd64.whl
     # via
     #   -r assets/requirements/amd_requirements.txt


### PR DESCRIPTION
## Summary
- drop `rocm-sdk-devel` from AMD Windows requirements
- update compiled AMD lockfile accordingly

## Testing
- `yarn format`
- `yarn lint`
- `yarn typescript`

Relates to #1510

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1511-Remove-rocm-sdk-devel-from-AMD-requirements-2df6d73d3650815d8de7f7d35b09d2d8) by [Unito](https://www.unito.io)
