### PR TITLE
Update ComfyUI core to v0.8.2

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -47,7 +47,7 @@ comfyui-embedded-docs==0.3.1
 comfyui-manager==4.0.3b7
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.64
+comfyui-workflow-templates==0.7.69
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-workflow-templates-core==0.3.58

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -51,7 +51,7 @@ comfyui-embedded-docs==0.3.1
 comfyui-manager==4.0.3b7
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.64
+comfyui-workflow-templates==0.7.69
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-workflow-templates-core==0.3.58

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -52,7 +52,7 @@ comfyui-embedded-docs==0.3.1
 comfyui-manager==4.0.4
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.7.64
+comfyui-workflow-templates==0.7.69
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-workflow-templates-core==0.3.61

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.7.0",
+      "version": "0.8.2",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.35.9
- comfyui-workflow-templates==0.7.64
+ comfyui-workflow-templates==0.7.69
  comfyui-embedded-docs==0.3.1
  torch


### PR DESCRIPTION
## Updated versions
| Component     | Version               |
| ------------- | --------------------- |
| ComfyUI core  | [v0.8.2](https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.8.2) |
| Templates     | [v0.7.69](https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.7.69) |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1514-Update-ComfyUI-core-to-v0-8-2-2e26d73d3650814ba397e3acf644aba9) by [Unito](https://www.unito.io)
