### PR TITLE
hotfix: migrate legacy torch mirror

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -181,6 +181,9 @@ export enum TorchMirrorUrl {
   NightlyCpu = 'https://download.pytorch.org/whl/nightly/cpu',
 }
 
+/** Legacy NVIDIA torch mirror used by older installs (CUDA 12.9). */
+export const LEGACY_NVIDIA_TORCH_MIRROR = 'https://download.pytorch.org/whl/cu129';
+
 /** @deprecated Use {@link TorchMirrorUrl} instead. */
 export const CUDA_TORCH_URL = TorchMirrorUrl.Cuda;
 /** @deprecated Use {@link TorchMirrorUrl} instead. */

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -11,6 +11,7 @@ import {
   AMD_ROCM_SDK_PACKAGES,
   AMD_TORCH_PACKAGES,
   InstallStage,
+  LEGACY_NVIDIA_TORCH_MIRROR,
   NVIDIA_TORCHVISION_VERSION,
   NVIDIA_TORCH_PACKAGES,
   NVIDIA_TORCH_VERSION,
@@ -110,6 +111,9 @@ function fixDeviceMirrorMismatch(device: TorchDeviceType, mirror: string | undef
   if (mirror === TorchMirrorUrl.Default) {
     if (device === 'nvidia') return TorchMirrorUrl.Cuda;
     else if (device === 'mps') return TorchMirrorUrl.NightlyCpu;
+  }
+  if (device === 'nvidia' && mirror === LEGACY_NVIDIA_TORCH_MIRROR) {
+    return TorchMirrorUrl.Cuda;
   }
   return mirror;
 }


### PR DESCRIPTION


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1516-hotfix-migrate-legacy-torch-mirror-2e26d73d365081aea675e07942b97505) by [Unito](https://www.unito.io)
