### PR TITLE
Remove rocm-sdk-devel from AMD ROCm SDK install

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -193,7 +193,6 @@ export const DEFAULT_PYPI_INDEX_URL = TorchMirrorUrl.Default;
 
 export const AMD_ROCM_SDK_PACKAGES: string[] = [
   'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_core-0.1.dev0-py3-none-win_amd64.whl',
-  'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_devel-0.1.dev0-py3-none-win_amd64.whl',
   'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_libraries_custom-0.1.dev0-py3-none-win_amd64.whl',
   'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm-0.1.dev0.tar.gz',
 ];


### PR DESCRIPTION
Remove rocm-sdk-devel from AMD ROCm SDK install list.

## What changed
- Drop the rocm_sdk_devel wheel from the AMD ROCm SDK package list used during Windows AMD installs.

## Why
- AMD ROCm installs still pulled rocm-sdk-devel via the SDK install path after it was removed from requirements and the compiled lockfile.
- This aligns actual install behavior with the intended package set and avoids pulling the devel package.
- Tradeoff: if any downstream step depended on rocm_sdk_devel being present, it will no longer be available by default.

## Evidence
- Tests: `yarn lint`, `yarn typescript`

## References
- Related PR: #1511 (removed rocm-sdk-devel from AMD requirements/compiled lockfile, but not the SDK install list)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1519-Remove-rocm-sdk-devel-from-AMD-ROCm-SDK-install-2e26d73d365081f2bf8cd1eacae44fbf) by [Unito](https://www.unito.io)
