### PR TITLE
fix: Update repository reference comfyanonymous/ComfyUI → Comfy-Org/ComfyUI

### DIFF
--- a/.github/workflows/update_compiled_requirements.yml
+++ b/.github/workflows/update_compiled_requirements.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Checkout ComfyUI
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
-          repository: comfyanonymous/ComfyUI
+          repository: Comfy-Org/ComfyUI
           ref: v${{ steps.versions.outputs.comfyui_version }}
           path: assets/ComfyUI
 
@@ -185,7 +185,7 @@ jobs:
       - name: Checkout ComfyUI
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
-          repository: comfyanonymous/ComfyUI
+          repository: Comfy-Org/ComfyUI
           ref: v${{ steps.versions.outputs.comfyui_version }}
           path: assets/ComfyUI
 


### PR DESCRIPTION
Updates repository reference after the official rename. GitHub API calls don't follow redirects, which can break CI workflows using actions/checkout with the old repository name.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1531-fix-Update-repository-reference-comfyanonymous-ComfyUI-Comfy-Org-ComfyUI-2e86d73d365081cc802cd2f6033dca47) by [Unito](https://www.unito.io)
