### PR TITLE
Revert "Update ComfyUI core to v0.9.1 (#1528)"

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -41,13 +41,13 @@ charset-normalizer==3.4.0
 click==8.1.7
     # via typer
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.4.0
+comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-manager==4.0.3b7
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.8.4
+comfyui-workflow-templates==0.7.69
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-workflow-templates-core==0.3.58

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -45,13 +45,13 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.4.0
+comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-manager==4.0.3b5
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.8.4
+comfyui-workflow-templates==0.7.64
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-workflow-templates-core==0.3.43

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -45,13 +45,13 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.4.0
+comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-manager==4.0.3b7
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.8.4
+comfyui-workflow-templates==0.7.69
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-workflow-templates-core==0.3.58

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -46,13 +46,13 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://download.pytorch.org/whl/cu130
-comfyui-embedded-docs==0.4.0
+comfyui-embedded-docs==0.3.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-manager==4.0.4
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.8.4
+comfyui-workflow-templates==0.7.69
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-workflow-templates-core==0.3.61

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.36.14",
+      "version": "1.35.9",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.9.1",
+      "version": "0.8.2",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.36.14
- comfyui-workflow-templates==0.8.4
- comfyui-embedded-docs==0.4.0
+-comfyui-frontend-package==1.35.9
+ comfyui-workflow-templates==0.7.69
+ comfyui-embedded-docs==0.3.1
  torch


### PR DESCRIPTION
Reverts the ComfyUI core bump to v0.9.1.

Reason: https://github.com/Comfy-Org/desktop/issues/1532

This is to unblock release that contains the PyPI mirror fallback

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1533-Revert-Update-ComfyUI-core-to-v0-9-1-1528-2e96d73d365081e5ac26ff80c95b5cf3) by [Unito](https://www.unito.io)
