### PR TITLE
Update venv troubleshooting E2E expectation

### DIFF
--- a/tests/integration/post-install/troubleshootingVenv.spec.ts
+++ b/tests/integration/post-install/troubleshootingVenv.spec.ts
@@ -11,21 +11,20 @@ test.describe('Troubleshooting - broken venv', () => {
     await expect(window).toHaveScreenshot('troubleshooting-venv.png');
   });
 
-  test('Can fix venv', async ({ troubleshooting, installedApp }) => {
+  test('Can fix venv', async ({ troubleshooting, installedApp, window }) => {
     test.slow();
 
     await troubleshooting.expectReady();
-    const { resetVenvCard, installPythonPackagesCard } = troubleshooting;
+    const { resetVenvCard } = troubleshooting;
     await expect(resetVenvCard.rootEl).toBeVisible();
 
     await resetVenvCard.button.click();
     await troubleshooting.confirmRecreateVenvButton.click();
     await expect(resetVenvCard.isRunningIndicator).toBeVisible();
 
-    await expect(installPythonPackagesCard.rootEl).toBeVisible({ timeout: 60 * 1000 });
-    await installPythonPackagesCard.button.click();
-    await troubleshooting.confirmInstallPythonPackagesButton.click();
-    await expect(installPythonPackagesCard.isRunningIndicator).toBeVisible();
+    await expect(window.getByRole('heading', { name: 'Updating ComfyUI Desktop' })).toBeVisible({
+      timeout: 60 * 1000,
+    });
 
     // Venv fixed - server should start
     await installedApp.waitUntilLoaded(3 * 60 * 1000);


### PR DESCRIPTION
Fixes CI on main, previous test expectation expected: "Fix venv --> Install packages", now package install is automatic, so it's just "Fix venv".

## Summary
- align venv troubleshooting E2E with auto-upgrade flow
- assert the desktop update screen appears instead of manual package install

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1545-Update-venv-troubleshooting-E2E-expectation-2eb6d73d365081b89dd2de5a37bcc0f1) by [Unito](https://www.unito.io)
