### PR TITLE
Disable forced PyTorch upgrades

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -382,7 +382,8 @@ export class InstallationManager implements HasTelemetry {
       await installation.virtualEnvironment.installComfyUIRequirements(callbacks);
       await installation.virtualEnvironment.installComfyUIManagerRequirements(callbacks);
       await this.warnIfNvidiaDriverTooOld(installation);
-      await installation.virtualEnvironment.ensureRecommendedNvidiaTorch(callbacks);
+      // Disabled forced PyTorch upgrades - users should control when large package downloads occur
+      // await installation.virtualEnvironment.ensureRecommendedNvidiaTorch(callbacks);
       await installation.validate();
     } catch (error) {
       log.error('Error auto-updating packages:', error);


### PR DESCRIPTION
Disables automatic PyTorch version upgrades by commenting out the ensureRecommendedNvidiaTorch() call in updatePackages().

Changed src/install/installationManager.ts:385 from:
  await installation.virtualEnvironment.ensureRecommendedNvidiaTorch(callbacks);

To:
  // Disabled forced PyTorch upgrades - users should control when large package downloads occur
  // await installation.virtualEnvironment.ensureRecommendedNvidiaTorch(callbacks);

This prevents automatic 1.5GB PyTorch package downloads on app startup. NVIDIA users will keep their current PyTorch versions until they manually upgrade or a future PR adds opt-in upgrade prompts with user consent dialogs.

Tested: ESLint, TypeScript compilation, and pre-commit hooks all pass.

Related: PR #1513 (introduced the forced upgrade), PR #1525 (will add guided UX)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1550-Disable-forced-PyTorch-upgrades-2ec6d73d36508160a435dae80f31bcc6) by [Unito](https://www.unito.io)
