### PR TITLE
docs: update Windows install paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ The app packages these components:
 
 ## Platform-Specific Paths
 
-- **Windows**: `%APPDATA%\ComfyUI` (config), `%APPDATA%\Local\Programs\comfyui-electron` (app)
+- **Windows**: `%APPDATA%\ComfyUI` (config), `%LOCALAPPDATA%\Programs\ComfyUI` (app)
 - **macOS**: `~/Library/Application Support/ComfyUI`
 - **Linux**: `~/.config/ComfyUI`
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ The desktop application comes bundled with:
 
 We use the [NSIS installer](https://www.electron.build/nsis.html) for Windows and it will install files in these locations:
 
-Bundled Resources: `%APPDATA%\Local\Programs\comfyui-electron`
+Bundled Resources: `%LOCALAPPDATA%\Programs\ComfyUI`
 
 ![screenshot of resources directory](https://github.com/user-attachments/assets/0e1d4a9a-7b7e-4536-ad4b-9e6123873706)
 
 User files are stored here: `%APPDATA%\ComfyUI`
 
-Automatic Updates: `%APPDATA%\Local\comfyui-electron-updater`
+Automatic Updates: `%LOCALAPPDATA%\comfyui-electron-updater` or `%LOCALAPPDATA%\@comfyorgcomfyui-electron-updater`
 
 **macOS**
 


### PR DESCRIPTION
## Summary
- update Windows install path to `%LOCALAPPDATA%\Programs\ComfyUI`
- document both updater cache folder names

## Testing
- not run (docs-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows file path references in documentation to reflect current installation and bundled resource locations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1561-docs-update-Windows-install-paths-2f46d73d365081b8a09fddcb5311fa12) by [Unito](https://www.unito.io)
