### PR TITLE
Update AMD ROCm 7.2 package pins

### DIFF
--- a/assets/override_amd.txt
+++ b/assets/override_amd.txt
@@ -1,4 +1,4 @@
 # ensure usage of AMD ROCm PyTorch wheels
-torch @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torch-2.9.0+rocmsdk20251116-cp312-cp312-win_amd64.whl
-torchaudio @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torchaudio-2.9.0+rocmsdk20251116-cp312-cp312-win_amd64.whl
-torchvision @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torchvision-0.24.0+rocmsdk20251116-cp312-cp312-win_amd64.whl
+torch @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torch-2.9.1+rocmsdk20260116-cp312-cp312-win_amd64.whl
+torchaudio @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torchaudio-2.9.1+rocmsdk20260116-cp312-cp312-win_amd64.whl
+torchvision @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torchvision-0.24.1+rocmsdk20260116-cp312-cp312-win_amd64.whl

--- a/assets/requirements/amd_requirements.txt
+++ b/assets/requirements/amd_requirements.txt
@@ -1,4 +1,4 @@
 # AMD ROCm SDK packages for Windows
-rocm-sdk-core @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_core-0.1.dev0-py3-none-win_amd64.whl
-rocm-sdk-libraries-custom @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_libraries_custom-0.1.dev0-py3-none-win_amd64.whl
-rocm @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm-0.1.dev0.tar.gz
+rocm-sdk-core @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm_sdk_core-7.2.0.dev0-py3-none-win_amd64.whl
+rocm-sdk-libraries-custom @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm_sdk_libraries_custom-7.2.0.dev0-py3-none-win_amd64.whl
+rocm @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm-7.2.0.dev0.tar.gz

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -227,15 +227,15 @@ rich==14.2.0
     #   comfyui-manager
     #   typer
     # from https://pypi.org/simple
-rocm @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm-0.1.dev0.tar.gz
+rocm @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm-7.2.0.dev0.tar.gz
     # via
     #   -r assets/requirements/amd_requirements.txt
     #   torch
-rocm-sdk-core @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_core-0.1.dev0-py3-none-win_amd64.whl
+rocm-sdk-core @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm_sdk_core-7.2.0.dev0-py3-none-win_amd64.whl
     # via
     #   -r assets/requirements/amd_requirements.txt
     #   rocm
-rocm-sdk-libraries-custom @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_libraries_custom-0.1.dev0-py3-none-win_amd64.whl
+rocm-sdk-libraries-custom @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm_sdk_libraries_custom-7.2.0.dev0-py3-none-win_amd64.whl
     # via
     #   -r assets/requirements/amd_requirements.txt
     #   rocm
@@ -281,7 +281,7 @@ tokenizers==0.22.1
 toml==0.10.2
     # via comfyui-manager
     # from https://pypi.org/simple
-torch @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torch-2.9.0+rocmsdk20251116-cp312-cp312-win_amd64.whl
+torch @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torch-2.9.1+rocmsdk20260116-cp312-cp312-win_amd64.whl
     # via
     #   --override assets/override_amd.txt
     #   -r assets/ComfyUI/requirements.txt
@@ -290,14 +290,14 @@ torch @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torch-2.9.0+rocmsdk2
     #   torchaudio
     #   torchsde
     #   torchvision
-torchaudio @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torchaudio-2.9.0+rocmsdk20251116-cp312-cp312-win_amd64.whl
+torchaudio @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torchaudio-2.9.1+rocmsdk20260116-cp312-cp312-win_amd64.whl
     # via
     #   --override assets/override_amd.txt
     #   -r assets/ComfyUI/requirements.txt
 torchsde==0.2.6
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-torchvision @ https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torchvision-0.24.0+rocmsdk20251116-cp312-cp312-win_amd64.whl
+torchvision @ https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torchvision-0.24.1+rocmsdk20260116-cp312-cp312-win_amd64.whl
     # via
     #   --override assets/override_amd.txt
     #   -r assets/ComfyUI/requirements.txt

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -198,15 +198,15 @@ export const PYPI_FALLBACK_INDEX_URLS: string[] = [
 ];
 
 export const AMD_ROCM_SDK_PACKAGES: string[] = [
-  'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_core-0.1.dev0-py3-none-win_amd64.whl',
-  'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm_sdk_libraries_custom-0.1.dev0-py3-none-win_amd64.whl',
-  'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/rocm-0.1.dev0.tar.gz',
+  'https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm_sdk_core-7.2.0.dev0-py3-none-win_amd64.whl',
+  'https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm_sdk_libraries_custom-7.2.0.dev0-py3-none-win_amd64.whl',
+  'https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm-7.2.0.dev0.tar.gz',
 ];
 
 export const AMD_TORCH_PACKAGES: string[] = [
-  'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torch-2.9.0+rocmsdk20251116-cp312-cp312-win_amd64.whl',
-  'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torchaudio-2.9.0+rocmsdk20251116-cp312-cp312-win_amd64.whl',
-  'https://repo.radeon.com/rocm/windows/rocm-rel-7.1.1/torchvision-0.24.0+rocmsdk20251116-cp312-cp312-win_amd64.whl',
+  'https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torch-2.9.1+rocmsdk20260116-cp312-cp312-win_amd64.whl',
+  'https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torchaudio-2.9.1+rocmsdk20260116-cp312-cp312-win_amd64.whl',
+  'https://repo.radeon.com/rocm/windows/rocm-rel-7.2/torchvision-0.24.1+rocmsdk20260116-cp312-cp312-win_amd64.whl',
 ];
 
 export const NVIDIA_TORCH_VERSION = '2.9.1+cu130';


### PR DESCRIPTION
## Summary
- update Windows AMD ROCm SDK URLs to 7.2.0.dev0 packages
- update AMD ROCm torch/torchaudio/torchvision wheel URLs to the 7.2 build
- keep override and compiled requirements in sync with installer constants

Links here: https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installryz/windows/install-pytorch.html

Tested on an RDNA4 machine and install works, packages resolve, inference happens

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1564-Update-AMD-ROCm-7-2-package-pins-2f66d73d3650815bbc98d06330a0d5b9) by [Unito](https://www.unito.io)
