### PR TITLE
fix: force frontend sourcemaps in desktop builds

### DIFF
--- a/scripts/downloadFrontend.js
+++ b/scripts/downloadFrontend.js
@@ -33,6 +33,7 @@ if (frontend.optionalBranch) {
     execAndLog(`pnpm exec nx build`, frontendDir, {
       COREPACK_ENABLE_STRICT: '0',
       DISTRIBUTION: 'desktop',
+      GENERATE_SOURCEMAP: 'true',
       NODE_OPTIONS: '--max-old-space-size=8192',
     });
     await fs.mkdir('assets/ComfyUI/web_custom_versions/desktop_app', { recursive: true });


### PR DESCRIPTION
Ensure desktop source builds explicitly set `GENERATE_SOURCEMAP=true` when building the frontend so Sentry can resolve stack traces even if release zips omit maps.

Tests: `yarn typecheck`, `yarn lint:check`, `yarn format`, `yarn lint`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1570-fix-force-frontend-sourcemaps-in-desktop-builds-2f86d73d365081198876c963525d0105) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to enable source map generation for improved debugging and development processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->