### PR TITLE
Warn about outdated NVIDIA drivers during fresh install

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -213,6 +213,7 @@ export class InstallationManager implements HasTelemetry {
     useDesktopConfig().set('basePath', installOptions.installPath);
     useDesktopConfig().set('versionConsentedMetrics', __COMFYUI_DESKTOP_VERSION__);
     useDesktopConfig().set('selectedDevice', device);
+    await this.warnIfNvidiaDriverTooOld(device);
 
     // Load the next page
     const page = device === 'unsupported' ? 'not-supported' : 'server-start';
@@ -381,7 +382,7 @@ export class InstallationManager implements HasTelemetry {
     try {
       await installation.virtualEnvironment.installComfyUIRequirements(callbacks);
       await installation.virtualEnvironment.installComfyUIManagerRequirements(callbacks);
-      await this.warnIfNvidiaDriverTooOld(installation);
+      await this.warnIfNvidiaDriverTooOld(installation.virtualEnvironment.selectedDevice);
       // Disable automatic NVIDIA torch upgrades so users control large downloads.
       // await installation.virtualEnvironment.ensureRecommendedNvidiaTorch(callbacks);
       await installation.validate();
@@ -393,11 +394,11 @@ export class InstallationManager implements HasTelemetry {
 
   /**
    * Warns the user if their NVIDIA driver is too old for the required CUDA build.
-   * @param installation The current installation.
+   * @param device The device selected for installation.
    */
-  private async warnIfNvidiaDriverTooOld(installation: ComfyInstallation): Promise<void> {
+  private async warnIfNvidiaDriverTooOld(device: InstallOptions['device'] | undefined): Promise<void> {
     if (process.platform !== 'win32') return;
-    if (installation.virtualEnvironment.selectedDevice !== 'nvidia') return;
+    if (device !== 'nvidia') return;
 
     const driverVersion =
       (await this.getNvidiaDriverVersionFromSmi()) ?? (await this.getNvidiaDriverVersionFromSmiFallback());


### PR DESCRIPTION
## Summary
- show the NVIDIA driver warning immediately after install options are chosen
- reuse the same warning logic for updatePackages with the selected device

The bug was that this wasn't shown early enough in the install process that new users who do not have the latest NVIDIA driver for pytorch 2.10 is that they would crash during install without a good error code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal device handling in the installation management system for improved code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1581-Warn-about-outdated-NVIDIA-drivers-during-fresh-install-2fc6d73d365081b0a0bae2e8b582abdb) by [Unito](https://www.unito.io)
