### PR TITLE
Bump desktop version to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump desktop app version to 0.8.1

DO NOT MERGE UNTIL THESE TWO PRS ARE MERGED
1. https://github.com/Comfy-Org/desktop/pull/1581
2. https://github.com/Comfy-Org/desktop/pull/1583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version update (0.8.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1584-Bump-desktop-version-to-0-8-1-2fc6d73d365081ae830dd16019dd7479) by [Unito](https://www.unito.io)
