### PR TITLE
Bump ComfyUI to v0.12.2

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -298,7 +298,7 @@ torch==2.10.0
     #   torchsde
     #   torchvision
     # from https://pypi.org/simple
-torchaudio==2.9.1
+torchaudio==2.10.0
     # via
     #   --override assets/override.txt
     #   -r assets/ComfyUI/requirements.txt


### PR DESCRIPTION
## Summary
- bump ComfyUI core version to v0.12.2
- regenerate macOS compiled requirements

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated torchaudio to version 2.9.1
  * Bumped comfyUI dependency to version 0.12.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1586-Bump-ComfyUI-to-v0-12-2-2fd6d73d365081a5b776c8416e619c0a) by [Unito](https://www.unito.io)
