### PR TITLE
Bump desktop version to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- Bump desktop version in package.json to 0.8.2

Merge after:
- https://github.com/Comfy-Org/desktop/pull/1586

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1587-Bump-desktop-version-to-0-8-2-2fd6d73d365081ceb496d39272e14450) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.8.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->