### PR TITLE
Add IPC close confirmation flow for Desktop

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,6 +55,8 @@ export const IPC_CHANNELS = {
   GET_INSTALL_STAGE: 'get-install-stage',
   INSTALL_STAGE_UPDATE: 'install-stage-update',
   DIALOG_CLICK_BUTTON: 'dialog-click-button',
+  CLOSE_REQUESTED: 'close-requested',
+  CLOSE_REQUEST_RESPONSE: 'close-request-response',
 } as const;
 
 export enum ProgressStatus {

--- a/src/handlers/AppHandlers.ts
+++ b/src/handlers/AppHandlers.ts
@@ -1,5 +1,5 @@
 import todesktop from '@todesktop/runtime';
-import { app, dialog } from 'electron';
+import { BrowserWindow, app, dialog } from 'electron';
 import log from 'electron-log/main';
 
 import { strictIpcMain as ipcMain } from '@/infrastructure/ipcChannels';
@@ -8,8 +8,13 @@ import { IPC_CHANNELS } from '../constants';
 
 export function registerAppHandlers() {
   ipcMain.handle(IPC_CHANNELS.QUIT, () => {
-    log.info('Received quit IPC request. Quitting app...');
-    app.quit();
+    log.info('Received quit IPC request. Closing app window...');
+    const targetWindow = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+    if (!targetWindow) {
+      app.quit();
+      return;
+    }
+    targetWindow.close();
   });
 
   ipcMain.handle(

--- a/src/infrastructure/ipcChannels.ts
+++ b/src/infrastructure/ipcChannels.ts
@@ -307,6 +307,16 @@ export interface IpcChannels {
     return: boolean;
   };
 
+  [IPC_CHANNELS.CLOSE_REQUESTED]: {
+    params: [];
+    return: void;
+  };
+
+  [IPC_CHANNELS.CLOSE_REQUEST_RESPONSE]: {
+    params: [allow: boolean];
+    return: boolean;
+  };
+
   [IPC_CHANNELS.LOADING_PROGRESS]: {
     params: [progress: { status: ProgressStatus; message?: string }];
     return: void;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -517,6 +517,27 @@ const electronAPI = {
     clickButton: (returnValue: string): Promise<boolean> =>
       ipcRenderer.invoke(IPC_CHANNELS.DIALOG_CLICK_BUTTON, returnValue),
   },
+
+  /**
+   * Listen for app close requests from the main process.
+   * @param callback Called when the main process requests a close confirmation
+   * @returns A function to remove the event listener
+   */
+  onCloseRequested: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on(IPC_CHANNELS.CLOSE_REQUESTED, handler);
+
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.CLOSE_REQUESTED, handler);
+    };
+  },
+
+  /**
+   * Respond to a close request with whether the app should close.
+   * @param allow Whether to allow the app to close
+   */
+  respondToCloseRequest: (allow: boolean): Promise<boolean> =>
+    ipcRenderer.invoke(IPC_CHANNELS.CLOSE_REQUEST_RESPONSE, allow),
 } as const;
 
 export type ElectronAPI = typeof electronAPI;


### PR DESCRIPTION
## Summary
- Add IPC close-request/response so the main process asks the renderer whether to close
- Gate all close paths (window close, tray quit, IPC quit) through the confirmation flow
- Add timeout + sender validation for safety

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`

## Linked PRs
- Comfy-Org/ComfyUI_frontend#8607

Fixes #1585

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1588-Add-IPC-close-confirmation-flow-for-Desktop-2fd6d73d3650817ba36ef06da005d247) by [Unito](https://www.unito.io)
