### PR TITLE
Improve GPU driver reporting for Sentry and telemetry

### DIFF
--- a/src/install/installationManager.ts
+++ b/src/install/installationManager.ts
@@ -1,7 +1,5 @@
 import { Notification, app, dialog, shell } from 'electron';
 import log from 'electron-log/main';
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
 
 import { strictIpcMain as ipcMain } from '@/infrastructure/ipcChannels';
 
@@ -13,38 +11,23 @@ import { ComfyInstallation } from '../main-process/comfyInstallation';
 import { createInstallStageInfo } from '../main-process/installStages';
 import type { InstallOptions, InstallValidation } from '../preload';
 import { CmCli } from '../services/cmCli';
+import {
+  getNvidiaDriverVersionFromSmi,
+  isNvidiaDriverBelowMinimum as isNvidiaDriverBelowMinimumFromGpuInfo,
+} from '../services/gpuInfo';
 import { captureSentryException } from '../services/sentry';
 import { type HasTelemetry, ITelemetry, trackEvent } from '../services/telemetry';
 import { type DesktopConfig, useDesktopConfig } from '../store/desktopConfig';
-import { canExecuteShellCommand, compareVersions, validateHardware } from '../utils';
+import { canExecuteShellCommand, validateHardware } from '../utils';
 import type { ProcessCallbacks, VirtualEnvironment } from '../virtualEnvironment';
 import { createProcessCallbacks } from './createProcessCallbacks';
 import { InstallWizard } from './installWizard';
 import { Troubleshooting } from './troubleshooting';
 
-const execAsync = promisify(exec);
 const NVIDIA_DRIVER_MIN_VERSION = '580';
 
-/**
- * Extracts the NVIDIA driver version from `nvidia-smi` output.
- * @param output The `nvidia-smi` output to parse.
- * @returns The driver version, if present.
- */
-export function parseNvidiaDriverVersionFromSmiOutput(output: string): string | undefined {
-  const match = output.match(/driver version\s*:\s*([\d.]+)/i);
-  return match?.[1];
-}
-
-/**
- * Returns `true` when the NVIDIA driver version is below the minimum.
- * @param driverVersion The detected driver version.
- * @param minimumVersion The minimum required driver version.
- */
-export function isNvidiaDriverBelowMinimum(
-  driverVersion: string,
-  minimumVersion: string = NVIDIA_DRIVER_MIN_VERSION
-): boolean {
-  return compareVersions(driverVersion, minimumVersion) < 0;
+export function isNvidiaDriverBelowMinimum(driverVersion: string, minimumVersion: string = NVIDIA_DRIVER_MIN_VERSION) {
+  return isNvidiaDriverBelowMinimumFromGpuInfo(driverVersion, minimumVersion);
 }
 
 /** High-level / UI control over the installation of ComfyUI server. */
@@ -400,11 +383,10 @@ export class InstallationManager implements HasTelemetry {
     if (process.platform !== 'win32') return;
     if (device !== 'nvidia') return;
 
-    const driverVersion =
-      (await this.getNvidiaDriverVersionFromSmi()) ?? (await this.getNvidiaDriverVersionFromSmiFallback());
+    const driverVersion = await getNvidiaDriverVersionFromSmi();
     if (!driverVersion) return;
 
-    if (!isNvidiaDriverBelowMinimum(driverVersion)) return;
+    if (!isNvidiaDriverBelowMinimum(driverVersion, NVIDIA_DRIVER_MIN_VERSION)) return;
 
     await this.appWindow.showMessageBox({
       type: 'warning',
@@ -413,36 +395,6 @@ export class InstallationManager implements HasTelemetry {
       detail: `Detected driver version: ${driverVersion}\nRecommended minimum: ${NVIDIA_DRIVER_MIN_VERSION}\n\nPlease consider updating your NVIDIA drivers and retrying if you run into issues.`,
       buttons: ['OK'],
     });
-  }
-
-  /**
-   * Reads the NVIDIA driver version from nvidia-smi query output.
-   */
-  private async getNvidiaDriverVersionFromSmi(): Promise<string | undefined> {
-    try {
-      const { stdout } = await execAsync('nvidia-smi --query-gpu=driver_version --format=csv,noheader');
-      const version = stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .find(Boolean);
-      return version || undefined;
-    } catch (error) {
-      log.debug('Failed to read NVIDIA driver version via nvidia-smi query.', error);
-      return undefined;
-    }
-  }
-
-  /**
-   * Reads the NVIDIA driver version from nvidia-smi standard output.
-   */
-  private async getNvidiaDriverVersionFromSmiFallback(): Promise<string | undefined> {
-    try {
-      const { stdout } = await execAsync('nvidia-smi');
-      return parseNvidiaDriverVersionFromSmiOutput(stdout);
-    } catch (error) {
-      log.debug('Failed to read NVIDIA driver version via nvidia-smi output.', error);
-      return undefined;
-    }
   }
 
   static setReinstallHandler(installation: ComfyInstallation) {
@@ -457,3 +409,5 @@ export class InstallationManager implements HasTelemetry {
     app.quit();
   }
 }
+
+export { parseNvidiaDriverVersionFromSmiOutput } from '../services/gpuInfo';

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ async function startApp() {
   log.debug('App ready');
   telemetry.registerHandlers();
   telemetry.track('desktop:app_ready');
+  await SentryLogging.setSentryGpuContext();
 
   // Load config or exit
   const config = await DesktopConfig.load(shell);

--- a/src/services/gpuInfo.ts
+++ b/src/services/gpuInfo.ts
@@ -1,0 +1,115 @@
+import log from 'electron-log/main';
+import { exec } from 'node:child_process';
+import si from 'systeminformation';
+
+import { compareVersions } from '../utils';
+
+/** Unified GPU metadata used for telemetry and error reporting. */
+export interface GpuInfo {
+  model: string;
+  vendor: string;
+  vram: number | null;
+  driverVersion: string | null;
+}
+
+const normalizeDriverVersion = (version: string | null | undefined): string | null => version?.trim() || null;
+
+const isNvidiaVendor = (vendor: string): boolean => vendor.toLowerCase().includes('nvidia');
+
+const runExec = (command: string): Promise<{ stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+
+/**
+ * Extracts the NVIDIA driver version from `nvidia-smi` output.
+ * @param output The `nvidia-smi` output to parse.
+ * @returns The driver version, if present.
+ */
+export function parseNvidiaDriverVersionFromSmiOutput(output: string): string | undefined {
+  const match = output.match(/driver version\s*:\s*([\d.]+)/i);
+  return match?.[1];
+}
+
+/**
+ * Returns `true` when the NVIDIA driver version is below the minimum.
+ * @param driverVersion The detected driver version.
+ * @param minimumVersion The minimum required driver version.
+ */
+export function isNvidiaDriverBelowMinimum(driverVersion: string, minimumVersion: string): boolean {
+  return compareVersions(driverVersion, minimumVersion) < 0;
+}
+
+/**
+ * Reads the NVIDIA driver version from nvidia-smi query output.
+ * @returns The first non-empty driver version line, if available.
+ */
+async function getNvidiaDriverVersionFromSmiQuery(): Promise<string | undefined> {
+  try {
+    const { stdout } = await runExec('nvidia-smi --query-gpu=driver_version --format=csv,noheader');
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => normalizeDriverVersion(line))
+      .find((line) => line !== null);
+  } catch (error) {
+    log.debug('Failed to read NVIDIA driver version via nvidia-smi query.', error);
+    return undefined;
+  }
+}
+
+/**
+ * Reads the NVIDIA driver version from nvidia-smi standard output.
+ * @returns The parsed driver version, if available.
+ */
+async function getNvidiaDriverVersionFromSmiFallback(): Promise<string | undefined> {
+  try {
+    const { stdout } = await runExec('nvidia-smi');
+    return normalizeDriverVersion(parseNvidiaDriverVersionFromSmiOutput(stdout)) ?? undefined;
+  } catch (error) {
+    log.debug('Failed to read NVIDIA driver version via nvidia-smi output.', error);
+    return undefined;
+  }
+}
+
+/**
+ * Reads the NVIDIA driver version using the preferred query and fallback parser.
+ * @returns The detected driver version, if available.
+ */
+export async function getNvidiaDriverVersionFromSmi(): Promise<string | undefined> {
+  return (await getNvidiaDriverVersionFromSmiQuery()) ?? (await getNvidiaDriverVersionFromSmiFallback());
+}
+
+/**
+ * Collects GPU metadata and normalizes driver versions.
+ * Missing NVIDIA driver versions are backfilled using `nvidia-smi`.
+ * @returns Normalized GPU metadata for all detected controllers.
+ */
+export async function collectGpuInformation(): Promise<GpuInfo[]> {
+  const gpuData = await si.graphics();
+  const gpus = gpuData.controllers.map((gpu) => ({
+    model: gpu.model,
+    vendor: gpu.vendor,
+    vram: gpu.vram,
+    driverVersion: normalizeDriverVersion(gpu.driverVersion),
+  }));
+
+  const hasMissingNvidiaDriver = gpus.some((gpu) => isNvidiaVendor(gpu.vendor) && !gpu.driverVersion);
+  if (!hasMissingNvidiaDriver) return gpus;
+
+  const nvidiaDriverVersion = await getNvidiaDriverVersionFromSmi();
+  if (!nvidiaDriverVersion) return gpus;
+
+  return gpus.map((gpu) => {
+    if (!isNvidiaVendor(gpu.vendor) || gpu.driverVersion) return gpu;
+    return {
+      ...gpu,
+      driverVersion: nvidiaDriverVersion,
+    };
+  });
+}

--- a/tests/unit/services/gpuInfo.test.ts
+++ b/tests/unit/services/gpuInfo.test.ts
@@ -1,0 +1,157 @@
+import type { ChildProcess } from 'node:child_process';
+import { exec } from 'node:child_process';
+import type { Systeminformation } from 'systeminformation';
+import si from 'systeminformation';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { collectGpuInformation, parseNvidiaDriverVersionFromSmiOutput } from '@/services/gpuInfo';
+
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('systeminformation', () => ({
+  __esModule: true,
+  default: {
+    graphics: vi.fn(),
+  },
+}));
+
+const execMock = vi.mocked(exec);
+const graphicsMock = vi.mocked(si.graphics);
+
+const createChildProcess = (): ChildProcess =>
+  ({
+    kill: vi.fn(),
+    on: vi.fn(),
+  }) as unknown as ChildProcess;
+
+type ExecResponse = {
+  error?: Error | null;
+  stdout?: string;
+  stderr?: string;
+};
+
+const withExecResponses = (responses: Array<[RegExp, ExecResponse]>, fallback: ExecResponse = {}) => {
+  execMock.mockImplementation(((
+    command: string,
+    callback: (error: Error | null, stdout: string, stderr: string) => void
+  ) => {
+    const matched = responses.find(([pattern]) => pattern.test(command));
+    const { error = null, stdout = '', stderr = '' } = matched?.[1] ?? fallback;
+    setImmediate(() => callback(error, stdout, stderr));
+    return createChildProcess();
+  }) as typeof exec);
+};
+
+describe('gpuInfo', () => {
+  beforeEach(() => {
+    execMock.mockReset();
+    graphicsMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parses driver version from nvidia-smi output', () => {
+    const output = 'NVIDIA-SMI 591.59 Driver Version: 591.59 CUDA Version: 13.1';
+
+    expect(parseNvidiaDriverVersionFromSmiOutput(output)).toBe('591.59');
+  });
+
+  it('normalizes driver version from systeminformation', async () => {
+    graphicsMock.mockResolvedValue({
+      controllers: [
+        {
+          model: 'NVIDIA RTX 4090',
+          vendor: 'NVIDIA',
+          vram: 24_576,
+          driverVersion: ' 551.61 ',
+        },
+      ],
+    } as Systeminformation.GraphicsData);
+
+    const result = await collectGpuInformation();
+
+    expect(result).toEqual([
+      {
+        model: 'NVIDIA RTX 4090',
+        vendor: 'NVIDIA',
+        vram: 24_576,
+        driverVersion: '551.61',
+      },
+    ]);
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('backfills missing NVIDIA driver version via nvidia-smi query on Windows', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    graphicsMock.mockResolvedValue({
+      controllers: [
+        {
+          model: 'NVIDIA RTX 5090',
+          vendor: 'NVIDIA Corporation',
+          vram: 32_768,
+        },
+        {
+          model: 'AMD Radeon RX 7900 XTX',
+          vendor: 'AMD',
+          vram: 24_576,
+        },
+      ],
+    } as Systeminformation.GraphicsData);
+
+    withExecResponses([[/--query-gpu=driver_version/, { stdout: ' 591.59 \n' }]]);
+
+    const result = await collectGpuInformation();
+
+    expect(result).toEqual([
+      {
+        model: 'NVIDIA RTX 5090',
+        vendor: 'NVIDIA Corporation',
+        vram: 32_768,
+        driverVersion: '591.59',
+      },
+      {
+        model: 'AMD Radeon RX 7900 XTX',
+        vendor: 'AMD',
+        vram: 24_576,
+        driverVersion: null,
+      },
+    ]);
+    expect(execMock).toHaveBeenCalledTimes(1);
+    platformSpy.mockRestore();
+  });
+
+  it('uses nvidia-smi text fallback when query fails', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    graphicsMock.mockResolvedValue({
+      controllers: [
+        {
+          model: 'NVIDIA RTX 5090',
+          vendor: 'NVIDIA Corporation',
+          vram: 32_768,
+        },
+      ],
+    } as Systeminformation.GraphicsData);
+
+    withExecResponses([
+      [/--query-gpu=driver_version/, { error: new Error('query failed') }],
+      [/^nvidia-smi$/, { stdout: 'Driver Version: 591.59 CUDA Version: 13.1' }],
+    ]);
+
+    const result = await collectGpuInformation();
+
+    expect(result).toEqual([
+      {
+        model: 'NVIDIA RTX 5090',
+        vendor: 'NVIDIA Corporation',
+        vram: 32_768,
+        driverVersion: '591.59',
+      },
+    ]);
+    expect(execMock).toHaveBeenCalledTimes(2);
+    platformSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared GPU metadata collector used by both Sentry and telemetry
- normalize `driverVersion` values and backfill missing NVIDIA driver versions with `nvidia-smi` query + fallback parse
- initialize Sentry GPU context earlier in startup and make context setup idempotent
- reuse the shared NVIDIA driver-version utility in `InstallationManager` to remove duplicate detection logic

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn vitest run tests/unit/services/gpuInfo.test.ts tests/unit/services/telemetry.test.ts tests/unit/install/installationManager.test.ts`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1594-Improve-GPU-driver-reporting-for-Sentry-and-telemetry-3006d73d365081e59772f8e19cc35f6c) by [Unito](https://www.unito.io)
