### PR TITLE
chore: bump desktop version to 0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump desktop app version in `package.json` from `0.8.3` to `0.8.4`

## Testing
- yarn format
- yarn lint
- yarn typecheck

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1600-chore-bump-desktop-version-to-0-8-4-3036d73d365081e08735e1b9392da499) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.8.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->