### PR TITLE
[chore] bump desktop version to 0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump desktop app version in `package.json` from `0.8.4` to `0.8.5`

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1608-chore-bump-desktop-version-to-0-8-5-30a6d73d365081d9b1d6f244b8ae0a72) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.8.5 for maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->