### PR TITLE
Bump ComfyUI to v0.14.2 and frontend to v1.38.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.37.11",
+      "version": "1.38.14",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.14.1",
+      "version": "0.14.2",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",


### PR DESCRIPTION
## Summary
- bump `package.json` `config.comfyUI.version` from `0.14.1` to `0.14.2`
- bump `package.json` `config.frontend.version` from `1.37.11` to `1.38.14`
- align frontend pin with the target core tag (`v0.14.2`) `requirements.txt` (`comfyui-frontend-package==1.38.14`)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1612-Bump-ComfyUI-to-v0-14-2-and-frontend-to-v1-38-14-30c6d73d36508171bbd5f5a6e5c396ed) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend and ComfyUI component versions for maintenance and stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->