### PR TITLE
[chore] bump desktop version to 0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
Merge after https://github.com/Comfy-Org/desktop/pull/1612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.8.6

---

**Note:** This is a patch release with no end-user facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1613-chore-bump-desktop-version-to-0-8-6-30c6d73d3650818aa281c7fa8c6bf041) by [Unito](https://www.unito.io)
