### PR TITLE
Bump ComfyUI to v0.15.0 and frontend to v1.39.16 (package.json only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.38.14",
+      "version": "1.39.16",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.14.2",
+      "version": "0.15.0",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",


### PR DESCRIPTION
## Summary
- bump `package.json` `config.comfyUI.version` from `0.14.2` to `0.15.0`
- bump `package.json` `config.frontend.version` from `1.38.14` to `1.39.16`
- intentionally limit this PR to `package.json` only

## Testing
- `yarn lint`
- `yarn typecheck`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1615-Bump-ComfyUI-to-v0-15-0-and-frontend-to-v1-39-16-package-json-only-3126d73d365081caae21e207416115af) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend version to 1.39.16
  * Updated ComfyUI version to 0.15.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->