### PR TITLE
[chore] bump desktop version to 0.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump `package.json` `version` from `0.8.6` to `0.8.7`

## Testing
- `yarn lint`
- `yarn typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.8.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1616-chore-bump-desktop-version-to-0-8-7-3126d73d365081b7918af9d8e58ff8ac) by [Unito](https://www.unito.io)
