### PR TITLE
Bump frontend version to 1.39.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.39.16",
+      "version": "1.39.17",
       "optionalBranch": ""
     },
     "comfyUI": {


### PR DESCRIPTION
## Summary
- bump `config.frontend.version` from `1.39.16` to `1.39.17`
- intentionally keep this one patch ahead of the current ComfyUI-pinned frontend version

## Testing
- `yarn lint`
- `yarn typecheck`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1617-Bump-frontend-version-to-1-39-17-3126d73d36508134a4d2d513f50da8d0) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 1.39.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->