### PR TITLE
Bump desktop version to 0.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump top-level desktop app version in `package.json` from `0.8.7` to `0.8.8`
- keep this PR scoped to desktop versioning only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.8.8 (patch update).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1618-Bump-desktop-version-to-0-8-8-3126d73d365081739266ca1a54d3ad96) by [Unito](https://www.unito.io)
