### PR TITLE
chore: bump frontend to 1.39.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.39.18",
+      "version": "1.39.19",
       "optionalBranch": ""
     },
     "comfyUI": {


### PR DESCRIPTION
## Summary
- bump frontend version in package.json from 1.39.18 to 1.39.19

## Validation
- yarn format
- yarn lint
- yarn typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 1.39.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1624-chore-bump-frontend-to-1-39-19-3136d73d36508110a0b4dc5d07b26272) by [Unito](https://www.unito.io)
