### PR TITLE
chore: bump frontend to 1.41.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.39.19",
+      "version": "1.41.6",
       "optionalBranch": ""
     },
     "comfyUI": {


### PR DESCRIPTION
## Summary
- bump frontend version in package.json from 1.39.19 to 1.41.6

## Validation
- yarn format
- yarn lint
- yarn typecheck

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1625-chore-bump-frontend-to-1-41-6-3136d73d365081c4b026cfe072baaab5) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend version to 1.41.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->