### PR TITLE
chore: bump desktop version to 0.8.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.8.11

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1627-chore-bump-desktop-version-to-0-8-11-3146d73d365081928b01e2cb4331940b) by [Unito](https://www.unito.io)
