### PR TITLE
chore: bump ComfyUI to 0.16.0

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -61,10 +61,10 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.7
+comfyui-workflow-templates==0.9.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.156
+comfyui-workflow-templates-core==0.3.157
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.57
@@ -76,7 +76,7 @@ comfyui-workflow-templates-media-image==0.3.96
 comfyui-workflow-templates-media-other==0.3.129
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.55
+comfyui-workflow-templates-media-video==0.3.56
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -57,10 +57,10 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.7
+comfyui-workflow-templates==0.9.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.156
+comfyui-workflow-templates-core==0.3.157
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.57
@@ -72,7 +72,7 @@ comfyui-workflow-templates-media-image==0.3.96
 comfyui-workflow-templates-media-other==0.3.129
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.55
+comfyui-workflow-templates-media-video==0.3.56
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -66,10 +66,10 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.7
+comfyui-workflow-templates==0.9.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.156
+comfyui-workflow-templates-core==0.3.157
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.57
@@ -81,7 +81,7 @@ comfyui-workflow-templates-media-image==0.3.96
 comfyui-workflow-templates-media-other==0.3.129
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.55
+comfyui-workflow-templates-media-video==0.3.56
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.16.0",
+      "version": "0.16.1",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.39.19
- comfyui-workflow-templates==0.9.7
+ comfyui-workflow-templates==0.9.8
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump `config.comfyUI.version` to `0.16.0` (tag-based)
- keep `config.comfyUI.optionalBranch` empty (no SHA or branch pin)
- update `scripts/core-requirements.patch` for `v0.16.0` requirements (`comfyui-workflow-templates==0.9.7`)

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core application version and supporting package dependencies to latest releases
  * Removed unused package dependency to streamline installation and improve dependency management
  * Updated dependency versions across platform-specific configurations for consistent behavior across macOS and Windows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->