### PR TITLE
chore: bump desktop version to 0.8.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump desktop app version in `package.json` from `0.8.11` to `0.8.12`

Merge after https://github.com/Comfy-Org/desktop/pull/1633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.8.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1634-chore-bump-desktop-version-to-0-8-12-31a6d73d36508136a798ff5d4d8f747b) by [Unito](https://www.unito.io)
