### PR TITLE
chore: bump comfyui-workflow-templates to 0.9.10

### DIFF
--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.39.19
- comfyui-workflow-templates==0.9.8
+ comfyui-workflow-templates==0.9.10
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- Bumps `comfyui-workflow-templates` from 0.9.8 to 0.9.10 in `scripts/core-requirements.patch`

## Test plan
- [ ] Verify workflow templates load correctly with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1635-chore-bump-comfyui-workflow-templates-to-0-9-10-31a6d73d3650810596bbc7b795093322) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->