### PR TITLE
fix: properly replace workflow-templates version in patch file

### DIFF
--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,7 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.39.19
- comfyui-workflow-templates==0.9.10
+-comfyui-workflow-templates==0.9.8
++comfyui-workflow-templates==0.9.10
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- Fixes the `core-requirements.patch` so `applyPatch` can match the upstream `requirements.txt`
- The previous change put `comfyui-workflow-templates==0.9.10` as a context line (space-prefixed), but upstream still has `0.9.8` — so the patch couldn't be applied
- Now uses a proper `-`/`+` replacement to change `0.9.8` → `0.9.10`

## Test plan
- [ ] Verify `yarn make:assets` succeeds (runs `patch:core:frontend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management scripts with no net changes to user-facing components or dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->