### PR TITLE
chore: bump ComfyUI to 0.16.2

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -49,7 +49,7 @@ click==8.3.1
     #   typer
     #   typer-slim
     # from https://pypi.org/simple
-comfy-aimdo==0.2.6
+comfy-aimdo==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.7
@@ -61,19 +61,19 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.8
+comfyui-workflow-templates==0.9.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.157
+comfyui-workflow-templates-core==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.57
+comfyui-workflow-templates-media-api==0.3.58
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.96
+comfyui-workflow-templates-media-image==0.3.97
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.129
+comfyui-workflow-templates-media-other==0.3.130
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.56

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -45,7 +45,7 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.6
+comfy-aimdo==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.7
@@ -57,19 +57,19 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.8
+comfyui-workflow-templates==0.9.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.157
+comfyui-workflow-templates-core==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.57
+comfyui-workflow-templates-media-api==0.3.58
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.96
+comfyui-workflow-templates-media-image==0.3.97
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.129
+comfyui-workflow-templates-media-other==0.3.130
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.56

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -53,7 +53,7 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.2
+comfy-aimdo==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.7
@@ -65,22 +65,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.4
+comfyui-workflow-templates==0.9.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.153
+comfyui-workflow-templates-core==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.55
+comfyui-workflow-templates-media-api==0.3.58
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.93
+comfyui-workflow-templates-media-image==0.3.97
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.127
+comfyui-workflow-templates-media-other==0.3.130
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.52
+comfyui-workflow-templates-media-video==0.3.56
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4
@@ -233,9 +233,6 @@ pynacl==1.6.2
     # via pygithub
     # from https://pypi.org/simple
 pyopengl==3.1.10
-    # via -r assets/ComfyUI/requirements.txt
-    # from https://pypi.org/simple
-pyopengl-accelerate==3.1.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 python-dotenv==1.2.1

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -54,7 +54,7 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://download.pytorch.org/whl/cu130
-comfy-aimdo==0.2.6
+comfy-aimdo==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.7
@@ -66,19 +66,19 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.8
+comfyui-workflow-templates==0.9.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.157
+comfyui-workflow-templates-core==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.57
+comfyui-workflow-templates-media-api==0.3.58
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.96
+comfyui-workflow-templates-media-image==0.3.97
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.129
+comfyui-workflow-templates-media-other==0.3.130
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.56

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.16.1",
+      "version": "0.16.2",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,7 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.39.19
--comfyui-workflow-templates==0.9.8
-+comfyui-workflow-templates==0.9.10
+ comfyui-workflow-templates==0.9.10
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump `config.comfyUI.version` in `package.json` to `0.16.2`
- keep `config.frontend.version` at `1.39.19` to match upstream `ComfyUI v0.16.2` requirements
- refresh `scripts/core-requirements.patch` and regenerate platform compiled requirements files

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1639-chore-bump-ComfyUI-to-0-16-2-31a6d73d3650819f8fcfd2df116d089f) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

- Updated multiple core packages and workflow template dependencies across all supported platforms (macOS and all Windows variants) to ensure enhanced system compatibility and improved stability across different hardware configurations
- Upgraded the comfyUI framework to version 0.16.2 for better performance and enhanced reliability
- Removed obsolete and unused dependencies to simplify the installation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->