### PR TITLE
chore: bump ComfyUI to 0.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.16.2",
+      "version": "0.16.3",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",


### PR DESCRIPTION
## Summary
- bump `config.comfyUI.version` in `package.json` to `0.16.3`
- regenerate bundled assets for `ComfyUI v0.16.3`
- no additional tracked asset changes were produced because the patched upstream requirements matched `v0.16.2`

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated ComfyUI dependency to version 0.16.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1641-chore-bump-ComfyUI-to-0-16-3-31b6d73d3650813384a2d56d186878f3) by [Unito](https://www.unito.io)
