### PR TITLE
chore: bump desktop version to 0.8.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump desktop app version in `package.json` from `0.8.15` to `0.8.16`

Merge after https://github.com/Comfy-Org/desktop/pull/1641

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers for the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1642-chore-bump-desktop-version-to-0-8-16-31b6d73d365081fdbc78de5c04453c3d) by [Unito](https://www.unito.io)
