### PR TITLE
Bump ComfyUI to v0.17.0 and frontend to v1.41.18

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -27,6 +27,9 @@ attrs==25.4.0
 av==16.1.0
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
+blake3==1.0.8
+    # via -r assets/ComfyUI/requirements.txt
+    # from https://pypi.org/simple
 certifi==2026.1.4
     # via
     #   httpcore
@@ -49,34 +52,34 @@ click==8.3.1
     #   typer
     #   typer-slim
     # from https://pypi.org/simple
-comfy-aimdo==0.2.8
+comfy-aimdo==0.2.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfy-kitchen==0.2.7
+comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b1
+comfyui-manager==4.1b2
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.11
+comfyui-workflow-templates==0.9.21
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.159
+comfyui-workflow-templates-core==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.59
+comfyui-workflow-templates-media-api==0.3.64
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.98
+comfyui-workflow-templates-media-image==0.3.104
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.131
+comfyui-workflow-templates-media-other==0.3.141
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.57
+comfyui-workflow-templates-media-video==0.3.60
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4
@@ -89,6 +92,7 @@ einops==0.8.2
     # from https://pypi.org/simple
 filelock==3.20.3
     # via
+    #   -r assets/ComfyUI/requirements.txt
     #   huggingface-hub
     #   torch
     #   transformers

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -23,6 +23,9 @@ attrs==25.4.0
 av==16.0.1
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
+blake3==1.0.8
+    # via -r assets/ComfyUI/requirements.txt
+    # from https://pypi.org/simple
 certifi==2025.11.12
     # via requests
     # from https://pypi.org/simple
@@ -45,34 +48,34 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.8
+comfy-aimdo==0.2.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfy-kitchen==0.2.7
+comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b1
+comfyui-manager==4.1b2
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.11
+comfyui-workflow-templates==0.9.21
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.159
+comfyui-workflow-templates-core==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.59
+comfyui-workflow-templates-media-api==0.3.64
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.98
+comfyui-workflow-templates-media-image==0.3.104
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.131
+comfyui-workflow-templates-media-other==0.3.141
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.57
+comfyui-workflow-templates-media-video==0.3.60
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3
@@ -85,6 +88,7 @@ einops==0.8.1
     # from https://pypi.org/simple
 filelock==3.20.1
     # via
+    #   -r assets/ComfyUI/requirements.txt
     #   huggingface-hub
     #   torch
     #   transformers

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -26,6 +26,9 @@ attrs==25.4.0
 av==16.1.0
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
+blake3==1.0.8
+    # via -r assets/ComfyUI/requirements.txt
+    # from https://pypi.org/simple
 certifi==2026.1.4
     # via
     #   httpcore
@@ -53,34 +56,34 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.8
+comfy-aimdo==0.2.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfy-kitchen==0.2.7
+comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b1
+comfyui-manager==4.1b2
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.11
+comfyui-workflow-templates==0.9.21
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.159
+comfyui-workflow-templates-core==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.59
+comfyui-workflow-templates-media-api==0.3.64
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.98
+comfyui-workflow-templates-media-image==0.3.104
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.131
+comfyui-workflow-templates-media-other==0.3.141
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.57
+comfyui-workflow-templates-media-video==0.3.60
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4
@@ -93,6 +96,7 @@ einops==0.8.2
     # from https://pypi.org/simple
 filelock==3.20.3
     # via
+    #   -r assets/ComfyUI/requirements.txt
     #   huggingface-hub
     #   torch
     #   transformers

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -27,6 +27,9 @@ attrs==25.4.0
 av==16.1.0
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
+blake3==1.0.8
+    # via -r assets/ComfyUI/requirements.txt
+    # from https://pypi.org/simple
 certifi==2026.1.4
     # via
     #   httpcore
@@ -54,34 +57,34 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://download.pytorch.org/whl/cu130
-comfy-aimdo==0.2.8
+comfy-aimdo==0.2.10
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfy-kitchen==0.2.7
+comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b1
+comfyui-manager==4.1b2
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.11
+comfyui-workflow-templates==0.9.21
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.159
+comfyui-workflow-templates-core==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.59
+comfyui-workflow-templates-media-api==0.3.64
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.98
+comfyui-workflow-templates-media-image==0.3.104
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.131
+comfyui-workflow-templates-media-other==0.3.141
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.57
+comfyui-workflow-templates-media-video==0.3.60
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4
@@ -94,6 +97,7 @@ einops==0.8.2
     # from https://pypi.org/simple
 filelock==3.20.3
     # via
+    #   -r assets/ComfyUI/requirements.txt
     #   huggingface-hub
     #   torch
     #   transformers

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.39.19",
+      "version": "1.41.18",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.16.4",
+      "version": "0.17.0",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.39.19
- comfyui-workflow-templates==0.9.11
+-comfyui-frontend-package==1.41.18
+ comfyui-workflow-templates==0.9.21
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump `package.json` `config.comfyUI.version` from `0.16.4` to `0.17.0`
- bump `package.json` `config.frontend.version` from `1.39.19` to `1.41.18` to match ComfyUI `v0.17.0`
- update `scripts/core-requirements.patch` to match ComfyUI `v0.17.0` `requirements.txt`
- regenerate compiled requirements for macOS and Windows (AMD/CPU/NVIDIA)

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1649-Bump-ComfyUI-to-v0-17-0-and-frontend-to-v1-41-18-3226d73d365081de9c05f2ba4d6809ab) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new blake3 dependency
  * Updated frontend version to 1.41.18
  * Updated ComfyUI core version to 0.17.0
  * Updated multiple dependency package versions across macOS and Windows platform configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->