### PR TITLE
chore: bump ComfyUI to 0.17.1 and desktop to 0.8.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.17.0",
+      "version": "0.17.1",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.41.18
+-comfyui-frontend-package==1.41.19
  comfyui-workflow-templates==0.9.21
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI from `0.17.0` to `0.17.1`
- bump desktop app version from `0.8.19` to `0.8.20`
- update `scripts/core-requirements.patch` to remove the new upstream `comfyui-frontend-package==1.41.19` line

## Notes
- I intentionally left `config.frontend.version` at `1.41.18`.
- Upstream `ComfyUI v0.17.1` references `comfyui-frontend-package==1.41.19`, but there is not currently a published `ComfyUI_frontend` `v1.41.19` release/tag artifact to download, so bumping the desktop frontend pin in this PR would break `download-frontend`.
- The upstream `v0.17.0...v0.17.1` diff only changes version metadata plus the frontend-package requirement line, so no compiled requirements update was needed.

## Validation
- `yarn install`
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`
- verified `scripts/core-requirements.patch` applies cleanly against upstream `ComfyUI v0.17.1`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1652-chore-bump-ComfyUI-to-0-17-1-and-desktop-to-0-8-20-3226d73d36508113aa04ff54905797ee) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 0.8.20
  * Updated ComfyUI to version 0.17.1
  * Updated frontend package dependency to version 1.41.19

<!-- end of auto-generated comment: release notes by coderabbit.ai -->