### PR TITLE
chore: bump frontend to 1.41.19 and desktop to 0.8.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -11,7 +11,7 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.41.18",
+      "version": "1.41.19",
       "optionalBranch": ""
     },
     "comfyUI": {


### PR DESCRIPTION
## Summary
- bump the desktop frontend pin from `1.41.18` to `1.41.19`
- bump the desktop app version from `0.8.20` to `0.8.21`

## Context
- `main` already includes the `ComfyUI 0.17.1` bump.
- This PR aligns `package.json`'s frontend version with the frontend package version referenced by bundled `ComfyUI 0.17.1`.

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

## Note
- As of March 13, 2026, the official `ComfyUI_frontend` repo still does not expose a published `v1.41.19` release/tag artifact via GitHub releases, so `download-frontend` availability should be confirmed before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.8.21.
  * Updated frontend dependency to 1.41.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1653-chore-bump-frontend-to-1-41-19-and-desktop-to-0-8-21-3226d73d3650818c8251f82a6e8961e3) by [Unito](https://www.unito.io)
