### PR TITLE
fix: normalize model download paths + handle download interupts

### DIFF
--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -322,8 +322,9 @@ export class DownloadManager {
   private resolveSavePath(savePath: string, filename: string): string {
     const base = path.resolve(this.modelsDirectory);
     const resolved = path.resolve(savePath);
-    if (resolved.startsWith(base)) {
-      const rel = path.relative(base, resolved);
+    const rel = path.relative(base, resolved);
+    const inside = rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
+    if (inside) {
       return rel.endsWith(filename) ? path.dirname(rel) : rel;
     }
     return savePath;
@@ -335,9 +336,10 @@ export class DownloadManager {
   }
 
   private isPathInModelsDirectory(filePath: string): boolean {
-    const absoluteFilePath = path.resolve(filePath);
     const absoluteModelsDir = path.resolve(this.modelsDirectory);
-    return absoluteFilePath.startsWith(absoluteModelsDir);
+    const resolved = path.resolve(filePath);
+    const rel = path.relative(absoluteModelsDir, resolved);
+    return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
   }
 
   private reportProgress(report: DownloadReport): void {

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -79,7 +79,8 @@ export class DownloadManager {
           });
           if (item.canResume()) {
             setTimeout(() => {
-              if (download.item === item && item.getState() === 'interrupted') {
+              const liveEntry = this.downloads.get(url);
+              if (liveEntry?.item === item && item.getState() === 'interrupted') {
                 log.info('Auto-resuming interrupted download');
                 item.resume();
               }
@@ -135,6 +136,7 @@ export class DownloadManager {
             status: DownloadStatus.ERROR,
             savePath: download.savePath,
           });
+          this.downloads.delete(url);
         }
       });
     });
@@ -273,7 +275,7 @@ export class DownloadManager {
       case 'cancelled':
         return DownloadStatus.CANCELLED;
       case 'interrupted':
-        return DownloadStatus.ERROR;
+        return DownloadStatus.PAUSED;
       default:
         return DownloadStatus.ERROR;
     }

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -17,7 +17,7 @@ export interface Download {
   savePath: string;
   item: DownloadItem | null;
   /** Number of times we have auto-resumed after an interrupt (stops interrupt→resume loops). */
-  interruptResumeCount: number;
+  interruptResumeCount?: number;
 }
 
 export interface DownloadState {
@@ -88,7 +88,7 @@ export class DownloadManager {
             setTimeout(() => {
               const entry = this.downloads.get(url);
               if (entry?.item === item && item.getState() === 'interrupted') {
-                entry.interruptResumeCount += 1;
+                entry.interruptResumeCount = (entry.interruptResumeCount ?? 0) + 1;
                 log.info('Auto-resuming interrupted download');
                 item.resume();
               }
@@ -195,14 +195,7 @@ export class DownloadManager {
 
     log.info(`Starting download ${url} to ${localSavePath}`);
     const tempPath = this.getTempPath(filename, savePath);
-    this.downloads.set(url, {
-      url,
-      savePath: localSavePath,
-      tempPath,
-      filename,
-      item: null,
-      interruptResumeCount: 0,
-    });
+    this.downloads.set(url, { url, savePath: localSavePath, tempPath, filename, item: null });
 
     // TODO(robinhuang): Add offset support for resuming downloads.
     // Can use https://www.electronjs.org/docs/latest/api/session#sescreateinterrupteddownloadoptions

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -297,7 +297,8 @@ export class DownloadManager {
   }
 
   private getTempPath(filename: string, savePath: string): string {
-    return path.join(this.modelsDirectory, savePath, `Unconfirmed ${filename}.tmp`);
+    const subPath = this.resolveSavePath(savePath, filename);
+    return path.join(this.modelsDirectory, subPath, `Unconfirmed ${filename}.tmp`);
   }
 
   // Only allow .safetensors files to be downloaded.
@@ -320,8 +321,24 @@ export class DownloadManager {
     }
   }
 
+  /**
+   * Resolve savePath to a path under modelsDirectory.
+   * If the caller passes an absolute path that is under modelsDirectory (e.g. from the UI),
+   * we use the relative part so path.join does not duplicate the base path.
+   */
+  private resolveSavePath(savePath: string, filename: string): string {
+    const base = path.resolve(this.modelsDirectory);
+    const resolved = path.resolve(savePath);
+    if (resolved.startsWith(base)) {
+      const rel = path.relative(base, resolved);
+      return rel.endsWith(filename) ? path.dirname(rel) : rel;
+    }
+    return savePath;
+  }
+
   private getLocalSavePath(filename: string, savePath: string): string {
-    return path.join(this.modelsDirectory, savePath, filename);
+    const subPath = this.resolveSavePath(savePath, filename);
+    return path.join(this.modelsDirectory, subPath, filename);
   }
 
   private isPathInModelsDirectory(filePath: string): boolean {

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -8,12 +8,16 @@ import { strictIpcMain as ipcMain } from '@/infrastructure/ipcChannels';
 import { DownloadStatus, IPC_CHANNELS } from '../constants';
 import type { AppWindow } from '../main-process/appWindow';
 
+const MAX_AUTO_RESUME_ATTEMPTS = 2;
+
 export interface Download {
   url: string;
   filename: string;
   tempPath: string; // Temporary filename until the download is complete.
   savePath: string;
   item: DownloadItem | null;
+  /** Number of times we have auto-resumed after an interrupt (stops interrupt→resume loops). */
+  interruptResumeCount: number;
 }
 
 export interface DownloadState {
@@ -69,18 +73,22 @@ export class DownloadManager {
           log.info('Download is interrupted but can be resumed');
           const totalBytes = item.getTotalBytes();
           const progress = totalBytes > 0 ? item.getReceivedBytes() / totalBytes : 0;
+          const liveEntry = this.downloads.get(url);
+          const autoResumesLeft = MAX_AUTO_RESUME_ATTEMPTS - (liveEntry?.interruptResumeCount ?? 0);
+          const willAutoResume = item.canResume() && autoResumesLeft > 0;
           this.reportProgress({
             url,
             progress,
             filename: download.filename,
             savePath: download.savePath,
             status: DownloadStatus.PAUSED,
-            message: 'Interrupted, resuming…',
+            message: willAutoResume ? 'Interrupted, resuming…' : 'Interrupted, can be resumed',
           });
-          if (item.canResume()) {
+          if (item.canResume() && autoResumesLeft > 0) {
             setTimeout(() => {
-              const liveEntry = this.downloads.get(url);
-              if (liveEntry?.item === item && item.getState() === 'interrupted') {
+              const entry = this.downloads.get(url);
+              if (entry?.item === item && item.getState() === 'interrupted') {
+                entry.interruptResumeCount += 1;
                 log.info('Auto-resuming interrupted download');
                 item.resume();
               }
@@ -187,7 +195,14 @@ export class DownloadManager {
 
     log.info(`Starting download ${url} to ${localSavePath}`);
     const tempPath = this.getTempPath(filename, savePath);
-    this.downloads.set(url, { url, savePath: localSavePath, tempPath, filename, item: null });
+    this.downloads.set(url, {
+      url,
+      savePath: localSavePath,
+      tempPath,
+      filename,
+      item: null,
+      interruptResumeCount: 0,
+    });
 
     // TODO(robinhuang): Add offset support for resuming downloads.
     // Can use https://www.electronjs.org/docs/latest/api/session#sescreateinterrupteddownloadoptions

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -85,17 +85,19 @@ export class DownloadManager {
             message: willAutoResume ? 'Interrupted, resuming…' : 'Interrupted, can be resumed',
           });
           if (item.canResume() && autoResumesLeft > 0) {
+            if (liveEntry !== undefined) {
+              liveEntry.interruptResumeCount = (liveEntry.interruptResumeCount ?? 0) + 1;
+            }
             setTimeout(() => {
-              const entry = this.downloads.get(url);
-              if (entry?.item === item && item.getState() === 'interrupted') {
-                entry.interruptResumeCount = (entry.interruptResumeCount ?? 0) + 1;
+              if (this.downloads.get(url)?.item === item && item.getState() === 'interrupted') {
                 log.info('Auto-resuming interrupted download');
                 item.resume();
               }
             }, 500);
           }
         } else if (state === 'progressing') {
-          const progress = item.getReceivedBytes() / item.getTotalBytes();
+          const totalBytes = item.getTotalBytes();
+          const progress = totalBytes > 0 ? item.getReceivedBytes() / totalBytes : 0;
           if (item.isPaused()) {
             log.info('Download is paused');
             this.reportProgress({
@@ -136,7 +138,8 @@ export class DownloadManager {
           this.downloads.delete(url);
         } else {
           log.info(`Download failed: ${state}`);
-          const progress = item.getReceivedBytes() / item.getTotalBytes();
+          const totalBytes = item.getTotalBytes();
+          const progress = totalBytes > 0 ? item.getReceivedBytes() / totalBytes : 0;
           this.reportProgress({
             url,
             filename: download.filename,

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -67,6 +67,24 @@ export class DownloadManager {
       item.on('updated', (event, state) => {
         if (state === 'interrupted') {
           log.info('Download is interrupted but can be resumed');
+          const totalBytes = item.getTotalBytes();
+          const progress = totalBytes > 0 ? item.getReceivedBytes() / totalBytes : 0;
+          this.reportProgress({
+            url,
+            progress,
+            filename: download.filename,
+            savePath: download.savePath,
+            status: DownloadStatus.PAUSED,
+            message: 'Interrupted, resuming…',
+          });
+          if (item.canResume()) {
+            setTimeout(() => {
+              if (download.item === item && item.getState() === 'interrupted') {
+                log.info('Auto-resuming interrupted download');
+                item.resume();
+              }
+            }, 500);
+          }
         } else if (state === 'progressing') {
           const progress = item.getReceivedBytes() / item.getTotalBytes();
           if (item.isPaused()) {

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -144,7 +144,6 @@ export class DownloadManager {
             status: DownloadStatus.ERROR,
             savePath: download.savePath,
           });
-          this.downloads.delete(url);
         }
       });
     });


### PR DESCRIPTION
The model paths had to be normalized for the downloads. This fixes the download issue. But I also added better handling of interrupts in case of external issues.

An Electron event can be emitted with state === 'interrupted' when the download is paused due to an issue or network condition (e.g., a connection drop or timeout), not by the user. In that case, the download can be resumed.

Fixes https://github.com/Comfy-Org/ComfyUI/issues/12929

Now the downloads work:

<img width="615" height="235" alt="image" src="https://github.com/user-attachments/assets/b78b7c34-0d1b-4bbf-840a-003f6a3f0024" />


In case of a network interruption, the status of the download is now shown correctly when paused

<img width="609" height="331" alt="image" src="https://github.com/user-attachments/assets/35ba59c9-e933-44aa-b972-e708a888fa96" />





┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1655-fix-auto-resume-interrupted-downloads-3236d73d365081a1a167c1d515aca1c5) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads now auto-resume after interruptions with a capped retry limit and a short retry delay.
  * Interrupted downloads display a paused state with messaging indicating whether an automatic resume will be attempted.

* **Bug Fixes**
  * More accurate progress and status reporting during interruptions and errors.
  * Failed or stopped downloads are removed to avoid stale entries.
  * User-provided save paths are normalized so temp and final files land in the expected models directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->