### PR TITLE
test: add e2e regression for absolute model downloads

### DIFF
--- a/tests/integration/post-install/downloadManager.spec.ts
+++ b/tests/integration/post-install/downloadManager.spec.ts
@@ -1,0 +1,103 @@
+import { readFile, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import path from 'node:path';
+import { addRandomSuffix, pathExists } from 'tests/shared/utils';
+
+import { expect, test } from '../testExtensions';
+
+interface RendererElectronApi {
+  electronAPI: {
+    getBasePath: () => Promise<string>;
+    DownloadManager: {
+      startDownload: (url: string, directoryPath: string, filename: string) => Promise<boolean>;
+    };
+  };
+}
+
+test.describe('DownloadManager', () => {
+  test('uses the provided absolute models directory without nesting it again', async ({ window, installedApp }) => {
+    test.slow();
+
+    await installedApp.waitUntilLoaded();
+
+    const filename = `${addRandomSuffix('download-manager-regression')}.safetensors`;
+    const fileContents = Buffer.from('playwright regression fixture');
+    const server = createServer((request, response) => {
+      if (request.url !== `/${filename}`) {
+        response.writeHead(404);
+        response.end('Not Found');
+        return;
+      }
+
+      response.writeHead(200, {
+        'Content-Length': String(fileContents.byteLength),
+        'Content-Type': 'application/octet-stream',
+      });
+      response.end(fileContents);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      throw new Error('Failed to determine local download server address');
+    }
+
+    let expectedFilePath = '';
+    let nestedBrokenPath = '';
+    try {
+      const basePath = await window.evaluate(async () => {
+        const api = (globalThis as typeof globalThis & RendererElectronApi).electronAPI;
+        return await api.getBasePath();
+      });
+      const modelsDirectory = path.join(basePath, 'models');
+      const absoluteTargetDirectory = path.join(modelsDirectory, 'checkpoints');
+      expectedFilePath = path.join(absoluteTargetDirectory, filename);
+      nestedBrokenPath = path.join(modelsDirectory, absoluteTargetDirectory, filename);
+      const url = `http://127.0.0.1:${address.port}/${filename}`;
+
+      await rm(expectedFilePath, { force: true });
+
+      const started = await window.evaluate(
+        async ({ directoryPath, filename, url }) => {
+          const api = (globalThis as typeof globalThis & RendererElectronApi).electronAPI;
+          return await api.DownloadManager.startDownload(url, directoryPath, filename);
+        },
+        {
+          directoryPath: absoluteTargetDirectory,
+          filename,
+          url,
+        }
+      );
+
+      expect(started).toBe(true);
+
+      await expect
+        .poll(
+          async () => {
+            if (!(await pathExists(expectedFilePath))) return null;
+            const fileBuffer = await readFile(expectedFilePath);
+            return fileBuffer.toString('utf8');
+          },
+          { timeout: 30 * 1000, intervals: [250] }
+        )
+        .toBe(fileContents.toString('utf8'));
+
+      await expect
+        .poll(async () => await pathExists(nestedBrokenPath), { timeout: 5 * 1000, intervals: [250] })
+        .toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (expectedFilePath) {
+        await rm(expectedFilePath, { force: true });
+      }
+      if (nestedBrokenPath && nestedBrokenPath !== expectedFilePath) {
+        await rm(nestedBrokenPath, { force: true }).catch(() => undefined);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a post-install Playwright regression test for the absolute-model-directory download contract
- call the real `electronAPI.DownloadManager.startDownload(...)` bridge from the renderer
- serve a local `.safetensors` fixture from a tiny HTTP server so the test is deterministic
- assert the file is written to the requested absolute target directory and not to the old broken nested path

## Why this is stacked
This PR depends on the downloader fix in #1657 and is intentionally stacked on top of `bl/fix-missing-model-download-path`.

## Test shape
- project: `post-install`
- gets the installed `basePath` from the renderer via `electronAPI.getBasePath()`
- constructs an absolute `models/checkpoints` directory under that base path
- starts a download through the renderer bridge
- polls the filesystem until the expected file exists with the expected contents
- verifies the old nested output path remains absent
- cleans up both the expected file and any wrongly nested output if the regression ever reappears

## Local validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- attempted targeted Playwright run under Node 20 via `npx -y node@20 node_modules/playwright/cli.js test tests/integration/post-install/downloadManager.spec.ts --reporter=line`
  - locally, the shared `install` dependency timed out before the new post-install spec executed, so the e2e run was not conclusive in this environment

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1658-test-add-e2e-regression-for-absolute-model-downloads-3246d73d36508163b32ae68176ce686c) by [Unito](https://www.unito.io)
