### PR TITLE
[chore] Bump desktop version to 0.8.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
## Summary
- bump the desktop app version in `package.json` from `0.8.22` to `0.8.23`

## Testing
- not run: `yarn format`, `yarn lint`, and `yarn typecheck` are blocked in this worktree because the Yarn install state / `node_modules` is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.8.23

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1664-chore-Bump-desktop-version-to-0-8-23-3266d73d36508158a4ffc1b1389c1160) by [Unito](https://www.unito.io)
