### PR TITLE
chore: bump ComfyUI to 0.18.1 and desktop to 0.8.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.18.0",
+      "version": "0.18.1",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI from `0.18.0` to `0.18.1`
- bump the desktop app version from `0.8.24` to `0.8.25`
- keep the existing requirements patching flow unchanged after verifying the upstream `v0.18.1` requirements match `v0.18.0`

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1672-chore-bump-ComfyUI-to-0-18-1-and-desktop-to-0-8-25-32c6d73d36508164be19efd14d05bc18) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.8.25
  * ComfyUI backend updated to 0.18.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->