### PR TITLE
chore: bump ComfyUI to 0.18.2 and desktop to 0.8.26

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.26
+comfyui-workflow-templates==0.9.36
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.173
+comfyui-workflow-templates-core==0.3.185
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.64
+comfyui-workflow-templates-media-api==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.107
+comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.146
+comfyui-workflow-templates-media-other==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.62
+comfyui-workflow-templates-media-video==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.26
+comfyui-workflow-templates==0.9.36
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.173
+comfyui-workflow-templates-core==0.3.185
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.64
+comfyui-workflow-templates-media-api==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.107
+comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.146
+comfyui-workflow-templates-media-other==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.62
+comfyui-workflow-templates-media-video==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.26
+comfyui-workflow-templates==0.9.36
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.173
+comfyui-workflow-templates-core==0.3.185
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.64
+comfyui-workflow-templates-media-api==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.107
+comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.146
+comfyui-workflow-templates-media-other==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.62
+comfyui-workflow-templates-media-video==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.26
+comfyui-workflow-templates==0.9.36
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.173
+comfyui-workflow-templates-core==0.3.185
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.64
+comfyui-workflow-templates-media-api==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.107
+comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.146
+comfyui-workflow-templates-media-other==0.3.158
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.62
+comfyui-workflow-templates-media-video==0.3.67
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.18.1",
+      "version": "0.18.2",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.41.21
- comfyui-workflow-templates==0.9.26
+ comfyui-workflow-templates==0.9.36
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI from `0.18.1` to `0.18.2`
- bump the desktop app version from `0.8.25` to `0.8.26`
- sync the committed compiled requirements for the `comfyui-workflow-templates` package updates required by `0.18.2`
- update the core requirements patch context so `make:assets` still removes the bundled frontend requirement against upstream `v0.18.2`

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1675-chore-bump-ComfyUI-to-0-18-2-and-desktop-to-0-8-26-32d6d73d36508194803de87839a51722) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version from 0.8.25 to 0.8.26
  * Updated ComfyUI core version from 0.18.1 to 0.18.2
  * Updated workflow template framework and all related media packages to latest versions consistently across macOS and Windows platform configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->