### PR TITLE
chore: bump ComfyUI to 0.18.3 and desktop to 0.8.27

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,10 +64,10 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.36
+comfyui-workflow-templates==0.9.38
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.185
+comfyui-workflow-templates-core==0.3.187
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.67
@@ -76,7 +76,7 @@ comfyui-workflow-templates-media-api==0.3.67
 comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.158
+comfyui-workflow-templates-media-other==0.3.160
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.67

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,10 +60,10 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.36
+comfyui-workflow-templates==0.9.38
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.185
+comfyui-workflow-templates-core==0.3.187
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.67
@@ -72,7 +72,7 @@ comfyui-workflow-templates-media-api==0.3.67
 comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.158
+comfyui-workflow-templates-media-other==0.3.160
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.67

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,10 +68,10 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.36
+comfyui-workflow-templates==0.9.38
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.185
+comfyui-workflow-templates-core==0.3.187
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.67
@@ -80,7 +80,7 @@ comfyui-workflow-templates-media-api==0.3.67
 comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.158
+comfyui-workflow-templates-media-other==0.3.160
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.67

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,10 +69,10 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.36
+comfyui-workflow-templates==0.9.38
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.185
+comfyui-workflow-templates-core==0.3.187
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.67
@@ -81,7 +81,7 @@ comfyui-workflow-templates-media-api==0.3.67
 comfyui-workflow-templates-media-image==0.3.113
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.158
+comfyui-workflow-templates-media-other==0.3.160
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.67
@@ -101,7 +101,7 @@ filelock==3.20.3
     #   huggingface-hub
     #   torch
     #   transformers
-    # from https://pypi.org/simple
+    # from https://download.pytorch.org/whl/cu130
 frozenlist==1.8.0
     # via
     #   aiohttp
@@ -111,7 +111,7 @@ fsspec==2026.1.0
     # via
     #   huggingface-hub
     #   torch
-    # from https://pypi.org/simple
+    # from https://download.pytorch.org/whl/cu130
 gitdb==4.0.12
     # via gitpython
     # from https://pypi.org/simple
@@ -191,7 +191,7 @@ numpy==2.4.1
     #   torchsde
     #   torchvision
     #   transformers
-    # from https://pypi.org/simple
+    # from https://download.pytorch.org/whl/cu130
 packaging==26.0
     # via
     #   huggingface-hub
@@ -202,7 +202,7 @@ pillow==12.1.0
     # via
     #   -r assets/ComfyUI/requirements.txt
     #   torchvision
-    # from https://pypi.org/simple
+    # from https://download.pytorch.org/whl/cu130
 propcache==0.4.1
     # via
     #   aiohttp

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -101,7 +101,7 @@ filelock==3.20.3
     #   huggingface-hub
     #   torch
     #   transformers
-    # from https://download.pytorch.org/whl/cu130
+    # from https://pypi.org/simple
 frozenlist==1.8.0
     # via
     #   aiohttp
@@ -111,7 +111,7 @@ fsspec==2026.1.0
     # via
     #   huggingface-hub
     #   torch
-    # from https://download.pytorch.org/whl/cu130
+    # from https://pypi.org/simple
 gitdb==4.0.12
     # via gitpython
     # from https://pypi.org/simple
@@ -191,7 +191,7 @@ numpy==2.4.1
     #   torchsde
     #   torchvision
     #   transformers
-    # from https://download.pytorch.org/whl/cu130
+    # from https://pypi.org/simple
 packaging==26.0
     # via
     #   huggingface-hub
@@ -202,7 +202,7 @@ pillow==12.1.0
     # via
     #   -r assets/ComfyUI/requirements.txt
     #   torchvision
-    # from https://download.pytorch.org/whl/cu130
+    # from https://pypi.org/simple
 propcache==0.4.1
     # via
     #   aiohttp

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.18.2",
+      "version": "0.18.3",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.41.21
- comfyui-workflow-templates==0.9.36
+ comfyui-workflow-templates==0.9.38
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI to the `v0.18.3` backport tag
- bump the desktop app version to `0.8.27`
- refresh the core requirements patch context and regenerate compiled requirements

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn make:assets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Incremented package version to 0.8.27
  * Updated ComfyUI to version 0.18.3
  * Updated workflow template packages across macOS and Windows platforms
  * Removed an outdated frontend package from the pinned requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1678-chore-bump-ComfyUI-to-0-18-3-and-desktop-to-0-8-27-32f6d73d3650810694bfff9a0454c731) by [Unito](https://www.unito.io)
