### PR TITLE
feat: apply proxy settings to Electron, Python, and child processes

### DIFF
--- a/src/config/comfySettings.ts
+++ b/src/config/comfySettings.ts
@@ -13,6 +13,9 @@ export const DEFAULT_SETTINGS: ComfySettingsData = {
   'Comfy-Desktop.UV.PythonInstallMirror': '',
   'Comfy-Desktop.UV.PypiInstallMirror': '',
   'Comfy-Desktop.UV.TorchInstallMirror': '',
+  'Comfy.Network.Proxy.HttpUrl': '',
+  'Comfy.Network.Proxy.HttpsUrl': '',
+  'Comfy.Network.Proxy.NoProxy': '',
 } as const;
 
 export interface ComfySettingsData {
@@ -26,6 +29,9 @@ export interface ComfySettingsData {
   'Comfy-Desktop.UV.PythonInstallMirror': string;
   'Comfy-Desktop.UV.PypiInstallMirror': string;
   'Comfy-Desktop.UV.TorchInstallMirror': string;
+  'Comfy.Network.Proxy.HttpUrl': string;
+  'Comfy.Network.Proxy.HttpsUrl': string;
+  'Comfy.Network.Proxy.NoProxy': string;
   [key: string]: unknown;
 }
 

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -53,6 +53,15 @@ export class ComfyDesktopApp implements HasTelemetry {
     if (COMFY_HOST) serverArgs.listen = COMFY_HOST;
     if (COMFY_PORT) serverArgs.port = COMFY_PORT;
 
+    // Inject proxy settings from frontend config into server CLI args.
+    const settings = useComfySettings();
+    const httpProxy = settings.get('Comfy.Network.Proxy.HttpUrl');
+    const httpsProxy = settings.get('Comfy.Network.Proxy.HttpsUrl');
+    const noProxy = settings.get('Comfy.Network.Proxy.NoProxy');
+    if (httpProxy) serverArgs['http-proxy'] = httpProxy;
+    if (httpsProxy) serverArgs['https-proxy'] = httpsProxy;
+    if (noProxy) serverArgs['no-proxy'] = noProxy;
+
     // Find first available port (unless using external server).
     if (!useExternalServer) {
       const targetPort = Number(serverArgs.port);

--- a/src/main-process/comfyDesktopApp.ts
+++ b/src/main-process/comfyDesktopApp.ts
@@ -44,20 +44,21 @@ export class ComfyDesktopApp implements HasTelemetry {
    * @returns The server args for the ComfyUI server.
    */
   async buildServerArgs({ useExternalServer, COMFY_HOST, COMFY_PORT }: DevOverrides): Promise<ServerArgs> {
+    const settings = useComfySettings();
+
     // Shallow-clone the setting launch args to avoid mutation.
     const serverArgs: ServerArgs = {
       ...DEFAULT_SERVER_ARGS,
-      ...useComfySettings().get('Comfy.Server.LaunchArgs'),
+      ...settings.get('Comfy.Server.LaunchArgs'),
     };
 
     if (COMFY_HOST) serverArgs.listen = COMFY_HOST;
     if (COMFY_PORT) serverArgs.port = COMFY_PORT;
 
     // Inject proxy settings from frontend config into server CLI args.
-    const settings = useComfySettings();
-    const httpProxy = settings.get('Comfy.Network.Proxy.HttpUrl');
-    const httpsProxy = settings.get('Comfy.Network.Proxy.HttpsUrl');
-    const noProxy = settings.get('Comfy.Network.Proxy.NoProxy');
+    const httpProxy = settings.get('Comfy.Network.Proxy.HttpUrl').trim();
+    const httpsProxy = settings.get('Comfy.Network.Proxy.HttpsUrl').trim();
+    const noProxy = settings.get('Comfy.Network.Proxy.NoProxy').trim();
     if (httpProxy) serverArgs['http-proxy'] = httpProxy;
     if (httpsProxy) serverArgs['https-proxy'] = httpsProxy;
     if (noProxy) serverArgs['no-proxy'] = noProxy;

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,9 @@ async function startApp() {
     });
   }
 
+  // Apply proxy settings from comfy.settings.json to Electron and child processes.
+  await applyProxySettings(config);
+
   telemetry.loadGenerationCount(config);
 
   // Load the Vue DevTools extension
@@ -111,4 +114,56 @@ function trackAppQuitEvents() {
 function initializeSentry() {
   log.verbose('Initializing Sentry');
   SentryLogging.init();
+}
+
+/**
+ * Reads proxy settings from the ComfyUI settings file and applies them to
+ * Electron's Chromium network stack and process environment variables.
+ *
+ * This must be called after config is loaded (to know the basePath) but
+ * before any network requests are made.
+ */
+async function applyProxySettings(config: DesktopConfig): Promise<void> {
+  try {
+    const basePath = config.get('basePath');
+    if (!basePath) return;
+
+    const { ComfySettings } = await import('./config/comfySettings');
+    const settings = await ComfySettings.load(basePath);
+
+    const httpProxy = settings.get('Comfy.Network.Proxy.HttpUrl');
+    const httpsProxy = settings.get('Comfy.Network.Proxy.HttpsUrl');
+    const noProxy = settings.get('Comfy.Network.Proxy.NoProxy');
+
+    const effectiveProxy = httpProxy || httpsProxy;
+    if (!effectiveProxy) return;
+
+    log.info(`Applying proxy settings: HTTP=${httpProxy || '(none)'}, HTTPS=${httpsProxy || '(inherit)'}`);
+
+    // Configure Chromium's network stack (affects Electron's own requests and BrowserWindow).
+    session.defaultSession.setProxy({
+      proxyRules: effectiveProxy,
+      proxyBypassRules: noProxy || undefined,
+    });
+
+    // Set environment variables so child processes (Python, uv, git, pip) inherit them.
+    if (httpProxy) {
+      process.env.HTTP_PROXY = httpProxy;
+      process.env.http_proxy = httpProxy;
+      if (!httpsProxy) {
+        process.env.HTTPS_PROXY = httpProxy;
+        process.env.https_proxy = httpProxy;
+      }
+    }
+    if (httpsProxy) {
+      process.env.HTTPS_PROXY = httpsProxy;
+      process.env.https_proxy = httpsProxy;
+    }
+    if (noProxy) {
+      process.env.NO_PROXY = noProxy;
+      process.env.no_proxy = noProxy;
+    }
+  } catch (error) {
+    log.warn('Failed to apply proxy settings', error);
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,7 +141,7 @@ async function applyProxySettings(config: DesktopConfig): Promise<void> {
     log.info(`Applying proxy settings: HTTP=${httpProxy || '(none)'}, HTTPS=${httpsProxy || '(inherit)'}`);
 
     // Configure Chromium's network stack (affects Electron's own requests and BrowserWindow).
-    session.defaultSession.setProxy({
+    await session.defaultSession.setProxy({
       proxyRules: effectiveProxy,
       proxyBypassRules: noProxy || undefined,
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,14 +135,19 @@ async function applyProxySettings(config: DesktopConfig): Promise<void> {
     const httpsProxy = settings.get('Comfy.Network.Proxy.HttpsUrl');
     const noProxy = settings.get('Comfy.Network.Proxy.NoProxy');
 
-    const effectiveProxy = httpProxy || httpsProxy;
-    if (!effectiveProxy) return;
+    if (!httpProxy && !httpsProxy) return;
 
-    log.info(`Applying proxy settings: HTTP=${httpProxy || '(none)'}, HTTPS=${httpsProxy || '(inherit)'}`);
+    log.info(
+      `Applying proxy settings: HTTP=${redactProxyUrl(httpProxy) || '(none)'}, HTTPS=${redactProxyUrl(httpsProxy) || '(none)'}`
+    );
+
+    // Build Chromium proxy rules that respect separate HTTP/HTTPS proxies.
+    // Format: "http=<proxy>;https=<proxy>" or a single proxy for both.
+    const proxyRules = buildChromiumProxyRules(httpProxy, httpsProxy);
 
     // Configure Chromium's network stack (affects Electron's own requests and BrowserWindow).
     await session.defaultSession.setProxy({
-      proxyRules: effectiveProxy,
+      proxyRules,
       proxyBypassRules: noProxy || undefined,
     });
 
@@ -165,5 +170,35 @@ async function applyProxySettings(config: DesktopConfig): Promise<void> {
     }
   } catch (error) {
     log.warn('Failed to apply proxy settings', error);
+  }
+}
+
+/**
+ * Builds Chromium-format proxy rules from separate HTTP and HTTPS proxy URLs.
+ * When both are set, uses per-scheme syntax: "http=<proxy>;https=<proxy>".
+ * When only one is set, uses it as a catch-all.
+ */
+function buildChromiumProxyRules(httpProxy: string, httpsProxy: string): string {
+  if (httpProxy && httpsProxy) {
+    return `http=${httpProxy};https=${httpsProxy}`;
+  }
+  return httpProxy || httpsProxy;
+}
+
+/**
+ * Redacts embedded credentials from a proxy URL for safe logging.
+ * E.g. "http://user:pass@host:8080" becomes "http://***@host:8080".
+ */
+function redactProxyUrl(url: string): string {
+  if (!url) return '';
+  try {
+    const parsed = new URL(url);
+    if (parsed.username || parsed.password) {
+      parsed.username = '***';
+      parsed.password = '';
+    }
+    return parsed.toString();
+  } catch {
+    return '(invalid URL)';
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,13 @@ async function applyProxySettings(config: DesktopConfig): Promise<void> {
     const httpsProxy = settings.get('Comfy.Network.Proxy.HttpsUrl');
     const noProxy = settings.get('Comfy.Network.Proxy.NoProxy');
 
+    // Export NO_PROXY env vars even when no explicit proxy URL is configured,
+    // so a noProxy-only config works alongside OS-level or externally-provided proxies.
+    if (noProxy) {
+      process.env.NO_PROXY = noProxy;
+      process.env.no_proxy = noProxy;
+    }
+
     if (!httpProxy && !httpsProxy) return;
 
     log.info(
@@ -142,7 +149,6 @@ async function applyProxySettings(config: DesktopConfig): Promise<void> {
     );
 
     // Build Chromium proxy rules that respect separate HTTP/HTTPS proxies.
-    // Format: "http=<proxy>;https=<proxy>" or a single proxy for both.
     const proxyRules = buildChromiumProxyRules(httpProxy, httpsProxy);
 
     // Configure Chromium's network stack (affects Electron's own requests and BrowserWindow).
@@ -164,10 +170,6 @@ async function applyProxySettings(config: DesktopConfig): Promise<void> {
       process.env.HTTPS_PROXY = httpsProxy;
       process.env.https_proxy = httpsProxy;
     }
-    if (noProxy) {
-      process.env.NO_PROXY = noProxy;
-      process.env.no_proxy = noProxy;
-    }
   } catch (error) {
     log.warn('Failed to apply proxy settings', error);
   }
@@ -176,13 +178,15 @@ async function applyProxySettings(config: DesktopConfig): Promise<void> {
 /**
  * Builds Chromium-format proxy rules from separate HTTP and HTTPS proxy URLs.
  * When both are set, uses per-scheme syntax: "http=<proxy>;https=<proxy>".
- * When only one is set, uses it as a catch-all.
+ * When only one is set, uses a scheme-specific prefix to avoid unintended catch-all behaviour.
  */
 function buildChromiumProxyRules(httpProxy: string, httpsProxy: string): string {
   if (httpProxy && httpsProxy) {
     return `http=${httpProxy};https=${httpsProxy}`;
   }
-  return httpProxy || httpsProxy;
+  if (httpProxy) return `http=${httpProxy}`;
+  if (httpsProxy) return `https=${httpsProxy}`;
+  return '';
 }
 
 /**

--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -149,6 +149,11 @@ export class VirtualEnvironment implements HasTelemetry, PythonExecutor {
       // dropping them here to avoid passing them to uv.
       // `node-pty` does not support `undefined`.
       ...(this.pythonMirror ? { UV_PYTHON_INSTALL_MIRROR: this.pythonMirror } : {}),
+      // Proxy env vars are inherited from process.env (set in main.ts).
+      // Re-exporting them here ensures they are also available in PTY sessions.
+      ...(process.env.HTTP_PROXY ? { HTTP_PROXY: process.env.HTTP_PROXY } : {}),
+      ...(process.env.HTTPS_PROXY ? { HTTPS_PROXY: process.env.HTTPS_PROXY } : {}),
+      ...(process.env.NO_PROXY ? { NO_PROXY: process.env.NO_PROXY } : {}),
     };
   }
 

--- a/tests/unit/config/comfySettings.test.ts
+++ b/tests/unit/config/comfySettings.test.ts
@@ -90,6 +90,9 @@ describe('ComfySettings', () => {
         'Comfy-Desktop.UV.PythonInstallMirror': '',
         'Comfy-Desktop.UV.PypiInstallMirror': '',
         'Comfy-Desktop.UV.TorchInstallMirror': '',
+        'Comfy.Network.Proxy.HttpUrl': '',
+        'Comfy.Network.Proxy.HttpsUrl': '',
+        'Comfy.Network.Proxy.NoProxy': '',
       };
 
       vi.mocked(fsPromises.access).mockResolvedValue(undefined);

--- a/tests/unit/main-process/comfyDesktopApp.test.ts
+++ b/tests/unit/main-process/comfyDesktopApp.test.ts
@@ -15,7 +15,11 @@ import { findAvailablePort, getModelsDirectory } from '@/utils';
 // Mock dependencies
 vi.mock('@/config/comfySettings', () => {
   const mockSettings = {
-    get: vi.fn(() => true),
+    get: vi.fn((key: string) => {
+      // Proxy settings should default to empty string (no proxy configured).
+      if (key.startsWith('Comfy.Network.Proxy.')) return '';
+      return true;
+    }),
     set: vi.fn(),
     saveSettings: vi.fn(),
   };

--- a/tests/unit/main-process/comfyDesktopApp.test.ts
+++ b/tests/unit/main-process/comfyDesktopApp.test.ts
@@ -16,9 +16,10 @@ import { findAvailablePort, getModelsDirectory } from '@/utils';
 vi.mock('@/config/comfySettings', () => {
   const mockSettings = {
     get: vi.fn((key: string) => {
-      // Proxy settings should default to empty string (no proxy configured).
+      if (key === 'Comfy-Desktop.AutoUpdate') return true;
+      if (key === 'Comfy.Server.LaunchArgs') return {};
       if (key.startsWith('Comfy.Network.Proxy.')) return '';
-      return true;
+      return undefined;
     }),
     set: vi.fn(),
     saveSettings: vi.fn(),


### PR DESCRIPTION
## Summary

- Read `Comfy.Network.Proxy.*` settings from `comfy.settings.json` on app startup
- Configure Chromium via `session.defaultSession.setProxy()` for Electron's own network
- Set `process.env` `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` for all child processes
- Inject `--http-proxy`/`--https-proxy`/`--no-proxy` into Python server launch args
- Forward proxy env vars to uv PTY sessions for pip/package installs

Part of a cross-repo feature. Related PRs:
- Comfy-Org/ComfyUI — backend CLI args + env var setup
- Comfy-Org/ComfyUI_frontend — proxy settings UI

Ref: Comfy-Org/desktop#1105

## Test plan

- [ ] Set proxy URL in Settings > Comfy > Network, restart app
- [ ] Verify Python server receives `--http-proxy` arg
- [ ] Verify Electron BrowserWindow routes through proxy
- [ ] Verify uv/pip operations use proxy during package installs
- [ ] No proxy configured = no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1679-feat-apply-proxy-settings-to-Electron-Python-and-child-processes-32f6d73d36508189a2b6d479ad4ebbd8) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network proxy support: users can configure HTTP proxy, HTTPS proxy, and proxy bypass rules; these are applied at app startup, affect the embedded browser/networking, server launch, and child processes.

* **Chores**
  * Extended settings schema to include proxy configuration keys with default empty values.

* **Tests**
  * Updated unit tests and fixtures to include the new proxy settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->