### PR TITLE
chore: bump ComfyUI to 0.18.5 and desktop to 0.8.28

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.38
+comfyui-workflow-templates==0.9.43
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.187
+comfyui-workflow-templates-core==0.3.192
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.67
+comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.113
+comfyui-workflow-templates-media-image==0.3.117
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.160
+comfyui-workflow-templates-media-other==0.3.164
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.67
+comfyui-workflow-templates-media-video==0.3.71
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.38
+comfyui-workflow-templates==0.9.43
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.187
+comfyui-workflow-templates-core==0.3.192
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.67
+comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.113
+comfyui-workflow-templates-media-image==0.3.117
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.160
+comfyui-workflow-templates-media-other==0.3.164
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.67
+comfyui-workflow-templates-media-video==0.3.71
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.38
+comfyui-workflow-templates==0.9.43
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.187
+comfyui-workflow-templates-core==0.3.192
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.67
+comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.113
+comfyui-workflow-templates-media-image==0.3.117
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.160
+comfyui-workflow-templates-media-other==0.3.164
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.67
+comfyui-workflow-templates-media-video==0.3.71
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1b6
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.38
+comfyui-workflow-templates==0.9.43
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.187
+comfyui-workflow-templates-core==0.3.192
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.67
+comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.113
+comfyui-workflow-templates-media-image==0.3.117
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.160
+comfyui-workflow-templates-media-other==0.3.164
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.67
+comfyui-workflow-templates-media-video==0.3.71
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.18.3",
+      "version": "0.18.5",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.41.21
- comfyui-workflow-templates==0.9.38
+ comfyui-workflow-templates==0.9.43
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI from `0.18.3` to `0.18.5`
- bump the desktop app version from `0.8.27` to `0.8.28`
- refresh the core requirements patch and committed compiled requirements for the workflow-template updates required by `ComfyUI v0.18.5`

## Why
Upstream `ComfyUI v0.18.5` is now published and the desktop repo pins ComfyUI by release tag. Updating the pin keeps the packaged core current and aligns the committed requirements snapshots with the upstream dependency set expected by that tag.

## Impact
Desktop builds will bundle `ComfyUI v0.18.5` and the corresponding workflow-template package family updates across macOS and Windows requirement snapshots. No frontend pin change was needed because `v0.18.5` still references `comfyui-frontend-package==1.41.21`.

## Root Cause
The desktop repo was still pinned to `ComfyUI v0.18.3`, so the packaged application would continue shipping the older core version and older compiled requirement snapshots until the pin and generated assets were refreshed together.

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1681-chore-bump-ComfyUI-to-0-18-5-and-desktop-to-0-8-28-3376d73d3650816ab401da4571812ea4) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow template dependencies and ComfyUI frontend components across all supported platforms.
  * Bumped application version to reflect latest dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->