### PR TITLE
fix: auto-create missing model subdirectories before download

### DIFF
--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -126,7 +126,7 @@ export class DownloadManager {
   startDownload(url: string, directoryPath: string, filename: string): boolean {
     const normalizedDirectoryPath = this.normalizeDirectoryPath(directoryPath);
     const localSavePath = this.getLocalSavePath(filename, normalizedDirectoryPath);
-    if (!this.isPathInModelsDirectory(localSavePath)) {
+    if (!this.isPathInModelsDirectory(localSavePath, { ensureTargetDirExists: true })) {
       log.error(`Save path ${localSavePath} is not in models directory ${this.modelsDirectory}`);
       this.reportProgress({
         url,
@@ -305,7 +305,7 @@ export class DownloadManager {
       : path.resolve(this.modelsDirectory, directoryPath);
   }
 
-  private isPathInModelsDirectory(filePath: string): boolean {
+  private isPathInModelsDirectory(filePath: string, options?: { ensureTargetDirExists?: boolean }): boolean {
     try {
       const targetDir = path.dirname(filePath);
 
@@ -318,7 +318,7 @@ export class DownloadManager {
       }
 
       // Ensure the target directory exists so realpathSync can resolve symlinks.
-      if (!fs.existsSync(targetDir)) {
+      if (options?.ensureTargetDirExists && !fs.existsSync(targetDir)) {
         fs.mkdirSync(targetDir, { recursive: true });
       }
 

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -307,8 +307,23 @@ export class DownloadManager {
 
   private isPathInModelsDirectory(filePath: string): boolean {
     try {
+      const targetDir = path.dirname(filePath);
+
+      // Pre-check using resolved (but not real) paths to catch traversal before mkdir.
+      const resolvedModelsDir = this.getPathForComparison(path.resolve(this.modelsDirectory));
+      const resolvedTargetDir = this.getPathForComparison(path.resolve(targetDir));
+      const preRelative = path.relative(resolvedModelsDir, resolvedTargetDir);
+      if (preRelative.startsWith('..') || path.isAbsolute(preRelative)) {
+        return false;
+      }
+
+      // Ensure the target directory exists so realpathSync can resolve symlinks.
+      if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+      }
+
       const realModelsDir = this.getPathForComparison(fs.realpathSync.native(this.modelsDirectory));
-      const realTargetDir = this.getPathForComparison(fs.realpathSync.native(path.dirname(filePath)));
+      const realTargetDir = this.getPathForComparison(fs.realpathSync.native(targetDir));
       const relative = path.relative(realModelsDir, realTargetDir);
 
       return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));

--- a/src/models/DownloadManager.ts
+++ b/src/models/DownloadManager.ts
@@ -126,7 +126,7 @@ export class DownloadManager {
   startDownload(url: string, directoryPath: string, filename: string): boolean {
     const normalizedDirectoryPath = this.normalizeDirectoryPath(directoryPath);
     const localSavePath = this.getLocalSavePath(filename, normalizedDirectoryPath);
-    if (!this.isPathInModelsDirectory(localSavePath, { ensureTargetDirExists: true })) {
+    if (!this.ensureDownloadTargetDirectory(localSavePath)) {
       log.error(`Save path ${localSavePath} is not in models directory ${this.modelsDirectory}`);
       this.reportProgress({
         url,
@@ -305,32 +305,76 @@ export class DownloadManager {
       : path.resolve(this.modelsDirectory, directoryPath);
   }
 
-  private isPathInModelsDirectory(filePath: string, options?: { ensureTargetDirExists?: boolean }): boolean {
+  /**
+   * Ensure the target download directory exists without allowing symlink escapes
+   * outside the models directory.
+   * @param filePath The final file path to be downloaded.
+   * @return `true` when the target directory exists and remains inside the models directory.
+   */
+  private ensureDownloadTargetDirectory(filePath: string): boolean {
     try {
       const targetDir = path.dirname(filePath);
-
-      // Pre-check using resolved (but not real) paths to catch traversal before mkdir.
-      const resolvedModelsDir = this.getPathForComparison(path.resolve(this.modelsDirectory));
-      const resolvedTargetDir = this.getPathForComparison(path.resolve(targetDir));
-      const preRelative = path.relative(resolvedModelsDir, resolvedTargetDir);
-      if (preRelative.startsWith('..') || path.isAbsolute(preRelative)) {
+      const nearestExistingAncestor = this.findNearestExistingAncestor(targetDir);
+      if (!nearestExistingAncestor) {
         return false;
       }
 
-      // Ensure the target directory exists so realpathSync can resolve symlinks.
-      if (options?.ensureTargetDirExists && !fs.existsSync(targetDir)) {
+      const realModelsDir = this.getPathForComparison(fs.realpathSync.native(this.modelsDirectory));
+      const realAncestorDir = this.getPathForComparison(fs.realpathSync.native(nearestExistingAncestor));
+      if (!this.isPathWithinDirectory(realModelsDir, realAncestorDir)) {
+        return false;
+      }
+
+      if (!fs.existsSync(targetDir)) {
         fs.mkdirSync(targetDir, { recursive: true });
       }
 
-      const realModelsDir = this.getPathForComparison(fs.realpathSync.native(this.modelsDirectory));
-      const realTargetDir = this.getPathForComparison(fs.realpathSync.native(targetDir));
-      const relative = path.relative(realModelsDir, realTargetDir);
+      return this.isPathInModelsDirectory(filePath);
+    } catch (error) {
+      log.error(`Failed to prepare download target directory for ${filePath}`, error);
+      return false;
+    }
+  }
 
-      return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+  /**
+   * Find the closest existing directory in the target path chain.
+   * @param targetPath The path whose nearest existing ancestor should be resolved.
+   * @return The nearest existing ancestor, or `null` when none can be found.
+   */
+  private findNearestExistingAncestor(targetPath: string): string | null {
+    let currentPath = path.resolve(targetPath);
+
+    while (!fs.existsSync(currentPath)) {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        return null;
+      }
+      currentPath = parentPath;
+    }
+
+    return currentPath;
+  }
+
+  private isPathInModelsDirectory(filePath: string): boolean {
+    try {
+      const realModelsDir = this.getPathForComparison(fs.realpathSync.native(this.modelsDirectory));
+      const realTargetDir = this.getPathForComparison(fs.realpathSync.native(path.dirname(filePath)));
+      return this.isPathWithinDirectory(realModelsDir, realTargetDir);
     } catch (error) {
       log.error(`Failed to validate models directory containment for ${filePath}`, error);
       return false;
     }
+  }
+
+  /**
+   * Check whether `candidatePath` is contained within `parentPath`.
+   * @param parentPath The parent path.
+   * @param candidatePath The path to check.
+   * @return `true` if the candidate is the parent or a descendant of it.
+   */
+  private isPathWithinDirectory(parentPath: string, candidatePath: string): boolean {
+    const relative = path.relative(parentPath, candidatePath);
+    return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
   }
 
   private getPathForComparison(targetPath: string): string {

--- a/tests/unit/models/DownloadManager.test.ts
+++ b/tests/unit/models/DownloadManager.test.ts
@@ -118,6 +118,34 @@ describe('DownloadManager', () => {
     expect(downloadURL).toHaveBeenCalledWith('https://example.com/model.safetensors');
   });
 
+  it('creates missing subdirectory inside models directory before downloading', () => {
+    const modelsDirectory = path.resolve('/mock/models');
+    const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
+    const url = 'https://example.com/model.safetensors';
+    const newSubdir = path.join(modelsDirectory, 'latent_upscale_models');
+
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      // Models directory exists, but the subdirectory and file do not.
+      if (String(p) === modelsDirectory) return true;
+      return false;
+    });
+
+    expect(manager.startDownload(url, newSubdir, 'model.safetensors')).toBe(true);
+    expect(fs.mkdirSync).toHaveBeenCalledWith(newSubdir, { recursive: true });
+    expect(downloadURL).toHaveBeenCalledWith(url);
+  });
+
+  it('does not create directories outside models directory', () => {
+    const modelsDirectory = path.resolve('/mock/models');
+    const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
+
+    expect(
+      manager.startDownload('https://example.com/model.safetensors', path.resolve('/tmp/evil'), 'model.safetensors')
+    ).toBe(false);
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
+    expect(downloadURL).not.toHaveBeenCalled();
+  });
+
   it('rejects symlinked model directories that resolve outside the models directory', () => {
     const modelsDirectory = path.resolve('/mock/models');
     const symlinkPath = path.join(modelsDirectory, 'link');

--- a/tests/unit/models/DownloadManager.test.ts
+++ b/tests/unit/models/DownloadManager.test.ts
@@ -7,6 +7,12 @@ import { electronMock } from '../setup';
 vi.mock('node:fs');
 
 const originalPlatform = process.platform;
+const mockExistingPaths = (...paths: string[]) => {
+  const existingPaths = new Set(paths.map((targetPath) => path.resolve(targetPath)));
+  existingPaths.add(path.parse(path.resolve('/')).root);
+
+  vi.mocked(fs.existsSync).mockImplementation((targetPath) => existingPaths.has(path.resolve(String(targetPath))));
+};
 
 describe('DownloadManager', () => {
   let DownloadManager: typeof import('@/models/DownloadManager').DownloadManager;
@@ -54,6 +60,7 @@ describe('DownloadManager', () => {
     const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
     const url = 'https://example.com/model.safetensors';
     const savePath = path.join(modelsDirectory, 'ipadapter');
+    mockExistingPaths(modelsDirectory, savePath);
 
     expect(manager.startDownload(url, savePath, 'model.safetensors')).toBe(true);
     expect(downloadURL).toHaveBeenCalledWith(url);
@@ -71,6 +78,7 @@ describe('DownloadManager', () => {
     const modelsDirectory = path.resolve('/mock/models');
     const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
     const url = 'https://example.com/model.safetensors';
+    mockExistingPaths(modelsDirectory, path.join(modelsDirectory, 'checkpoints'));
 
     expect(manager.startDownload(url, 'checkpoints', 'model.safetensors')).toBe(true);
     expect(downloadURL).toHaveBeenCalledWith(url);
@@ -87,14 +95,18 @@ describe('DownloadManager', () => {
   });
 
   it('rejects relative save paths that escape the models directory', () => {
-    const manager = DownloadManager.getInstance(mainWindow as never, path.resolve('/mock/models'));
+    const modelsDirectory = path.resolve('/mock/models');
+    const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
+    mockExistingPaths(modelsDirectory);
 
     expect(manager.startDownload('https://example.com/model.safetensors', '../tmp', 'model.safetensors')).toBe(false);
     expect(downloadURL).not.toHaveBeenCalled();
   });
 
   it('rejects absolute save paths outside the models directory', () => {
-    const manager = DownloadManager.getInstance(mainWindow as never, path.resolve('/mock/models'));
+    const modelsDirectory = path.resolve('/mock/models');
+    const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
+    mockExistingPaths(modelsDirectory, path.resolve('/tmp'));
 
     expect(
       manager.startDownload('https://example.com/model.safetensors', path.resolve('/tmp'), 'model.safetensors')
@@ -107,6 +119,7 @@ describe('DownloadManager', () => {
     vi.mocked(fs.realpathSync.native).mockImplementation(String);
 
     const manager = DownloadManager.getInstance(mainWindow as never, path.resolve('/Mock/Models'));
+    mockExistingPaths(path.resolve('/Mock/Models'), path.resolve('/mock/models/ipadapter'));
 
     expect(
       manager.startDownload(
@@ -123,12 +136,7 @@ describe('DownloadManager', () => {
     const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
     const url = 'https://example.com/model.safetensors';
     const newSubdir = path.join(modelsDirectory, 'latent_upscale_models');
-
-    vi.mocked(fs.existsSync).mockImplementation((p) => {
-      // Models directory exists, but the subdirectory and file do not.
-      if (String(p) === modelsDirectory) return true;
-      return false;
-    });
+    mockExistingPaths(modelsDirectory);
 
     expect(manager.startDownload(url, newSubdir, 'model.safetensors')).toBe(true);
     expect(fs.mkdirSync).toHaveBeenCalledWith(newSubdir, { recursive: true });
@@ -138,6 +146,7 @@ describe('DownloadManager', () => {
   it('does not create directories outside models directory', () => {
     const modelsDirectory = path.resolve('/mock/models');
     const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
+    mockExistingPaths(modelsDirectory, path.resolve('/tmp'));
 
     expect(
       manager.startDownload('https://example.com/model.safetensors', path.resolve('/tmp/evil'), 'model.safetensors')
@@ -150,6 +159,7 @@ describe('DownloadManager', () => {
     const modelsDirectory = path.resolve('/mock/models');
     const symlinkPath = path.join(modelsDirectory, 'link');
     const outsidePath = path.resolve('/outside/models-link');
+    mockExistingPaths(modelsDirectory, symlinkPath);
 
     vi.mocked(fs.realpathSync.native).mockImplementation((targetPath) => {
       const resolvedPath = path.resolve(String(targetPath));
@@ -166,10 +176,32 @@ describe('DownloadManager', () => {
     expect(downloadURL).not.toHaveBeenCalled();
   });
 
+  it('does not create missing directories through symlinked parents that resolve outside models', () => {
+    const modelsDirectory = path.resolve('/mock/models');
+    const symlinkPath = path.join(modelsDirectory, 'link');
+    const outsidePath = path.resolve('/outside/models-link');
+    const nestedPath = path.join(symlinkPath, 'latent_upscale_models');
+    mockExistingPaths(modelsDirectory, symlinkPath);
+
+    vi.mocked(fs.realpathSync.native).mockImplementation((targetPath) => {
+      const resolvedPath = path.resolve(String(targetPath));
+      if (resolvedPath === symlinkPath) {
+        return outsidePath;
+      }
+      return resolvedPath;
+    });
+    const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
+
+    expect(manager.startDownload('https://example.com/model.safetensors', nestedPath, 'model.safetensors')).toBe(false);
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
+    expect(downloadURL).not.toHaveBeenCalled();
+  });
+
   it('restarts interrupted downloads that cannot be resumed', () => {
     const modelsDirectory = path.resolve('/mock/models');
     const checkpointsDirectory = path.join(modelsDirectory, 'checkpoints');
     const manager = DownloadManager.getInstance(mainWindow as never, modelsDirectory);
+    mockExistingPaths(modelsDirectory, checkpointsDirectory);
     const downloads = (
       manager as unknown as {
         downloads: Map<


### PR DESCRIPTION
## Summary

- When a workflow references a model in a directory that doesn't yet exist on disk (e.g. `latent_upscale_models`), `fs.realpathSync.native()` in `isPathInModelsDirectory` throws because the path doesn't exist, causing the download to silently fail with no user-visible error.
- Add a `path.resolve`-based pre-check to validate directory containment before creating anything, then auto-create the missing subdirectory with `fs.mkdirSync({ recursive: true })` so `realpathSync` can proceed.
- Add two unit tests: one verifying subdirectory creation, one verifying directories outside the models directory are still rejected.

## Root cause

`isPathInModelsDirectory` uses `fs.realpathSync.native()` to resolve symlinks and validate the target is within the models directory. This function throws on non-existent paths, which the `catch` block treats as a validation failure (`return false`). The download is then rejected with `DownloadStatus.ERROR`, but the error message says "not in models directory" rather than "directory does not exist", making the failure confusing for users.

## Test plan

- [x] Existing unit tests pass (349 passed)
- [x] New test: `creates missing subdirectory inside models directory before downloading`
- [x] New test: `does not create directories outside models directory`
- [x] Manual verification: downloaded `ltx-2.3-spatial-upscaler-x2-1.1.safetensors` to a previously non-existent `latent_upscale_models` directory successfully

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1685-fix-auto-create-missing-model-subdirectories-before-download-33c6d73d36508147a4b8cdf2ff2c78e1) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened download path validation to block saves outside the configured models directory, including cases involving symlinked or non-existent ancestor directories.
  * Downloads now create missing model subdirectories automatically when the target is within the models directory.

* **Tests**
  * Added unit tests for out-of-directory and symlink-path rejections, successful creation of missing subdirectories, and a mocked filesystem helper to control existing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->