### PR TITLE
chore: bump ComfyUI to 0.19.0 and desktop to 0.8.29

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -61,25 +61,25 @@ comfy-kitchen==0.2.8
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b6
+comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.43
+comfyui-workflow-templates==0.9.47
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.192
+comfyui-workflow-templates-core==0.3.196
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.117
+comfyui-workflow-templates-media-image==0.3.118
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.164
+comfyui-workflow-templates-media-other==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.71
+comfyui-workflow-templates-media-video==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -57,25 +57,25 @@ comfy-kitchen==0.2.8
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b6
+comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.43
+comfyui-workflow-templates==0.9.47
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.192
+comfyui-workflow-templates-core==0.3.196
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.117
+comfyui-workflow-templates-media-image==0.3.118
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.164
+comfyui-workflow-templates-media-other==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.71
+comfyui-workflow-templates-media-video==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -65,25 +65,25 @@ comfy-kitchen==0.2.8
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b6
+comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.43
+comfyui-workflow-templates==0.9.47
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.192
+comfyui-workflow-templates-core==0.3.196
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.117
+comfyui-workflow-templates-media-image==0.3.118
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.164
+comfyui-workflow-templates-media-other==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.71
+comfyui-workflow-templates-media-video==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -66,25 +66,25 @@ comfy-kitchen==0.2.8
 comfyui-embedded-docs==0.4.3
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1b6
+comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.43
+comfyui-workflow-templates==0.9.47
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.192
+comfyui-workflow-templates-core==0.3.196
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.68
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.117
+comfyui-workflow-templates-media-image==0.3.118
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.164
+comfyui-workflow-templates-media-other==0.3.168
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.71
+comfyui-workflow-templates-media-video==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.41.21",
+      "version": "1.42.10",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.18.5",
+      "version": "0.19.0",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.41.21
- comfyui-workflow-templates==0.9.43
+-comfyui-frontend-package==1.42.10
+ comfyui-workflow-templates==0.9.47
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI from `0.18.5` to `0.19.0`
- bump the desktop frontend artifact pin from `1.41.21` to `1.42.10` to match the upstream core requirement
- bump the desktop app version from `0.8.28` to `0.8.29`
- regenerate the committed compiled requirements snapshots for macOS and Windows (AMD/CPU/NVIDIA)

## Why
Desktop is pinned to a tagged ComfyUI release. Upstream `ComfyUI v0.19.0` is now published, and it updates the required frontend package and workflow-template dependency family. This refresh keeps the packaged core aligned with upstream.

## Impact
Desktop builds will bundle `ComfyUI v0.19.0` with the matching desktop frontend artifact and refreshed requirement snapshots.

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1686-chore-bump-ComfyUI-to-0-19-0-and-desktop-to-0-8-29-3416d73d365081338ecfd739ce473135) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated core dependencies across all supported platforms (macOS and Windows variants) with the latest package versions and patches.
* Application version incremented to 0.8.29 with synchronized updates to frontend and core component versions to ensure optimal compatibility and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->