### PR TITLE
Increase ToDesktop upload size limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",

--- a/todesktop.json
+++ b/todesktop.json
@@ -4,7 +4,7 @@
   "icon": "./assets/UI/Comfy_Logo_x512.png",
   "appBuilderLibVersion": "25.1.8",
   "schemaVersion": 1,
-  "uploadSizeLimit": 500,
+  "uploadSizeLimit": 600,
   "appPath": ".",
   "appFiles": [
     "src/**",


### PR DESCRIPTION
## Summary
- increase ToDesktop `uploadSizeLimit` from 500 MB to 600 MB
- allow the current 517.4 MB application source upload to complete in CI

## Why
The ToDesktop build was failing during source upload because the app archive exceeded the default 500 MB cap. This change raises the configured limit instead of changing packaged contents.

## Validation
- yarn install
- yarn format
- yarn lint
- yarn typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the maximum file upload size limit from 500 to 600, allowing larger files (documents, images, videos) to be uploaded.
  * Bumped application version to 0.8.30 to reflect the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1687-Increase-ToDesktop-upload-size-limit-3416d73d36508186a237dc187ac0cead) by [Unito](https://www.unito.io)
