### PR TITLE
chore: bump ComfyUI to 0.19.1 and desktop to 0.8.31

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.47
+comfyui-workflow-templates==0.9.54
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.196
+comfyui-workflow-templates-core==0.3.206
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.68
+comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.118
+comfyui-workflow-templates-media-image==0.3.125
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.168
+comfyui-workflow-templates-media-other==0.3.174
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.74
+comfyui-workflow-templates-media-video==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.47
+comfyui-workflow-templates==0.9.54
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.196
+comfyui-workflow-templates-core==0.3.206
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.68
+comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.118
+comfyui-workflow-templates-media-image==0.3.125
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.168
+comfyui-workflow-templates-media-other==0.3.174
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.74
+comfyui-workflow-templates-media-video==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.47
+comfyui-workflow-templates==0.9.54
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.196
+comfyui-workflow-templates-core==0.3.206
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.68
+comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.118
+comfyui-workflow-templates-media-image==0.3.125
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.168
+comfyui-workflow-templates-media-other==0.3.174
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.74
+comfyui-workflow-templates-media-video==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.47
+comfyui-workflow-templates==0.9.54
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.196
+comfyui-workflow-templates-core==0.3.206
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.68
+comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.118
+comfyui-workflow-templates-media-image==0.3.125
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.168
+comfyui-workflow-templates-media-other==0.3.174
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.74
+comfyui-workflow-templates-media-video==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.42.10",
+      "version": "1.42.11",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.19.0",
+      "version": "0.19.1",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.42.10
- comfyui-workflow-templates==0.9.47
+-comfyui-frontend-package==1.42.11
+ comfyui-workflow-templates==0.9.54
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI from `0.19.0` to `0.19.1`
- bump the desktop frontend artifact pin from `1.42.10` to `1.42.11` to match upstream core
- bump the desktop app version from `0.8.30` to `0.8.31`
- regenerate the committed compiled requirements snapshots for macOS and Windows (AMD/CPU/NVIDIA)

## Why
Desktop pins ComfyUI by tag. Upstream `ComfyUI v0.19.1` is available and updates the required frontend package and workflow-template dependency family, so the desktop bundle should move in lockstep.

## Impact
Desktop builds will bundle `ComfyUI v0.19.1` with the matching desktop frontend artifact and refreshed requirement snapshots.

## Validation
- `yarn install`
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1688-chore-bump-ComfyUI-to-0-19-1-and-desktop-to-0-8-31-3436d73d3650814896dddf654f1adb0c) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version and related dependency versions across all platforms
  * Updated workflow templates and core component versions
  * Synchronized version configurations for frontend and ComfyUI components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->