### PR TITLE
chore: bump ComfyUI to 0.19.3 and desktop to 0.8.32

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.54
+comfyui-workflow-templates==0.9.57
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.206
+comfyui-workflow-templates-core==0.3.209
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.125
+comfyui-workflow-templates-media-image==0.3.127
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.174
+comfyui-workflow-templates-media-other==0.3.176
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.77
+comfyui-workflow-templates-media-video==0.3.78
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.54
+comfyui-workflow-templates==0.9.57
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.206
+comfyui-workflow-templates-core==0.3.209
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.125
+comfyui-workflow-templates-media-image==0.3.127
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.174
+comfyui-workflow-templates-media-other==0.3.176
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.77
+comfyui-workflow-templates-media-video==0.3.78
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.54
+comfyui-workflow-templates==0.9.57
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.206
+comfyui-workflow-templates-core==0.3.209
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.125
+comfyui-workflow-templates-media-image==0.3.127
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.174
+comfyui-workflow-templates-media-other==0.3.176
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.77
+comfyui-workflow-templates-media-video==0.3.78
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.54
+comfyui-workflow-templates==0.9.57
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.206
+comfyui-workflow-templates-core==0.3.209
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.69
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.125
+comfyui-workflow-templates-media-image==0.3.127
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.174
+comfyui-workflow-templates-media-other==0.3.176
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.77
+comfyui-workflow-templates-media-video==0.3.78
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.19.1",
+      "version": "0.19.3",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.42.11
- comfyui-workflow-templates==0.9.54
+ comfyui-workflow-templates==0.9.57
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump bundled ComfyUI from `0.19.1` to `0.19.3`
- bump the desktop app version from `0.8.31` to `0.8.32`
- refresh the compiled workflow template dependency snapshots to match upstream `v0.19.3`
- keep the desktop frontend pin at `1.42.11`, which upstream still requires
- address review feedback by restoring the macOS `torchaudio` snapshot line and reverting comment-only provenance churn

## Why
Desktop pins a tagged ComfyUI core release. Upstream `v0.19.3` is available and updates the workflow template dependency family while keeping the same frontend requirement. The follow-up snapshot edits keep the lockfiles aligned with known-good macOS behavior and avoid noisy comment-only diffs.

## Impact
Desktop bundles `ComfyUI v0.19.3` with refreshed requirement snapshots and no frontend artifact change.

## Validation
- `yarn format`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1691-chore-bump-ComfyUI-to-0-19-3-and-desktop-to-0-8-32-3456d73d3650815f8b46f6394a48838a) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.8.32
  * Updated ComfyUI runtime to version 0.19.3
  * Updated workflow templates ecosystem packages to latest patch versions across all platforms (macOS, Windows AMD, CPU, and NVIDIA)
  * Removed deprecated frontend package dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->