### PR TITLE
[codex] Consume frontend missing model download UI fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "config": {
     "frontend": {
       "version": "1.42.11",
-      "optionalBranch": ""
+      "optionalBranch": "bl/missing-model-download-ui-fix"
     },
     "comfyUI": {
       "version": "0.19.3",


### PR DESCRIPTION
## Summary
- point the desktop build at `bl/missing-model-download-ui-fix` via `config.frontend.optionalBranch`
- let the desktop regression-test stack consume the frontend fix before a tagged frontend release exists

## Why
The UI fix lives in `ComfyUI_frontend`, but the red regression test lives in `desktop`. This bridge PR makes the desktop branch build against the frontend fix branch so the stack can demonstrate red then green without waiting for a release cut.

## Stack
- base PR: #1692
- depends on frontend PR: comfyorg/ComfyUI_frontend#11350

## Notes
This is intentionally temporary. Once the frontend fix is merged and released, desktop should go back to consuming a tagged frontend release instead of an `optionalBranch` override.

## Validation
- `yarn prettier --check package.json`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1693-codex-Consume-frontend-missing-model-download-UI-fix-3456d73d3650813e9128f5b936d0c210) by [Unito](https://www.unito.io)
