### PR TITLE
[RELEASE] chore: bump desktop version to 0.8.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",


### PR DESCRIPTION
This bumps the desktop version from 0.8.32 to 0.8.33 so the already-merged Windows ROCm 7.2.1 changes on `main` can be released.\n\nChecks run locally: `yarn format`, `yarn lint`, `yarn typecheck`, and `yarn test:unit`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1695-RELEASE-chore-bump-desktop-version-to-0-8-33-3486d73d365081b79a00d1dce8abbe99) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version update to 0.8.33

<!-- end of auto-generated comment: release notes by coderabbit.ai -->