### PR TITLE
chore: bump ComfyUI to 0.19.4 and desktop to 0.8.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.42.11",
+      "version": "1.42.14",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.19.3",
+      "version": "0.19.4",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.42.11
+-comfyui-frontend-package==1.42.14
  comfyui-workflow-templates==0.9.57
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
## Summary
- bump desktop app from 0.8.33 to 0.8.34
- bump bundled ComfyUI from 0.19.3 to 0.19.4
- bump the desktop frontend artifact from 1.42.11 to 1.42.14
- update the core requirements patch to remove upstream comfyui-frontend-package 1.42.14

## Why
Upstream ComfyUI v0.19.4 is available as a backport release. Its requirements are identical to v0.19.3 after desktop removes the upstream frontend package, so the checked-in compiled requirement snapshots do not change.

Checks run locally: yarn format, yarn lint, yarn typecheck, yarn test:unit.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1696-chore-bump-ComfyUI-to-0-19-4-and-desktop-to-0-8-34-34a6d73d3650818babd2d39781065f64) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application and core component versions to the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->