### PR TITLE
chore: bump ComfyUI to 0.19.5 and desktop to 0.8.35

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.57
+comfyui-workflow-templates==0.9.61
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.209
+comfyui-workflow-templates-core==0.3.214
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.69
+comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.127
+comfyui-workflow-templates-media-image==0.3.131
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.176
+comfyui-workflow-templates-media-other==0.3.180
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.78
+comfyui-workflow-templates-media-video==0.3.80
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.57
+comfyui-workflow-templates==0.9.61
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.209
+comfyui-workflow-templates-core==0.3.214
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.69
+comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.127
+comfyui-workflow-templates-media-image==0.3.131
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.176
+comfyui-workflow-templates-media-other==0.3.180
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.78
+comfyui-workflow-templates-media-video==0.3.80
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.57
+comfyui-workflow-templates==0.9.61
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.209
+comfyui-workflow-templates-core==0.3.214
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.69
+comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.127
+comfyui-workflow-templates-media-image==0.3.131
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.176
+comfyui-workflow-templates-media-other==0.3.180
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.78
+comfyui-workflow-templates-media-video==0.3.80
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.4.3
 comfyui-manager==4.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.57
+comfyui-workflow-templates==0.9.61
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.209
+comfyui-workflow-templates-core==0.3.214
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.69
+comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.127
+comfyui-workflow-templates-media-image==0.3.131
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.176
+comfyui-workflow-templates-media-other==0.3.180
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.78
+comfyui-workflow-templates-media-video==0.3.80
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.19.4",
+      "version": "0.19.5",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.42.14
- comfyui-workflow-templates==0.9.57
+ comfyui-workflow-templates==0.9.61
  comfyui-embedded-docs==0.4.3
  torch


### PR DESCRIPTION
Updates desktop to bundle ComfyUI v0.19.5 and increments the desktop app version to 0.8.35.

The upstream v0.19.5 requirements delta from v0.19.4 is limited to comfyui-workflow-templates 0.9.57 -> 0.9.61; the frontend package remains 1.42.14. The core requirements patch still strips comfyui-frontend-package while matching the new upstream context, and the compiled requirement snapshots only update the workflow-template package family to avoid unrelated resolver/index churn.

Checked with yarn make:assets, yarn format, yarn lint, yarn typecheck, yarn test:unit, and git diff --check.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1698-chore-bump-ComfyUI-to-0-19-5-and-desktop-to-0-8-35-34b6d73d36508138af75f86b29906a3b) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.8.35
  * Updated embedded ComfyUI frontend to version 0.19.5
  * Updated workflow template dependencies to latest versions across all supported platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->