### PR TITLE
chore: bump ComfyUI to 0.20.1 and desktop to 0.8.36

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -52,34 +52,34 @@ click==8.3.1
     #   typer
     #   typer-slim
     # from https://pypi.org/simple
-comfy-aimdo==0.2.12
+comfy-aimdo==0.2.14
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.4.3
+comfyui-embedded-docs==0.4.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1
+comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.61
+comfyui-workflow-templates==0.9.63
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.214
+comfyui-workflow-templates-core==0.3.216
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.131
+comfyui-workflow-templates-media-image==0.3.132
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.180
+comfyui-workflow-templates-media-other==0.3.182
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.80
+comfyui-workflow-templates-media-video==0.3.81
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -48,34 +48,34 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.12
+comfy-aimdo==0.2.14
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.4.3
+comfyui-embedded-docs==0.4.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1
+comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.61
+comfyui-workflow-templates==0.9.63
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.214
+comfyui-workflow-templates-core==0.3.216
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.131
+comfyui-workflow-templates-media-image==0.3.132
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.180
+comfyui-workflow-templates-media-other==0.3.182
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.80
+comfyui-workflow-templates-media-video==0.3.81
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -56,34 +56,34 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.12
+comfy-aimdo==0.2.14
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.4.3
+comfyui-embedded-docs==0.4.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1
+comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.61
+comfyui-workflow-templates==0.9.63
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.214
+comfyui-workflow-templates-core==0.3.216
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.131
+comfyui-workflow-templates-media-image==0.3.132
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.180
+comfyui-workflow-templates-media-other==0.3.182
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.80
+comfyui-workflow-templates-media-video==0.3.81
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -57,34 +57,34 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://download.pytorch.org/whl/cu130
-comfy-aimdo==0.2.12
+comfy-aimdo==0.2.14
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-embedded-docs==0.4.3
+comfyui-embedded-docs==0.4.4
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-manager==4.1
+comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.61
+comfyui-workflow-templates==0.9.63
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.214
+comfyui-workflow-templates-core==0.3.216
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-api==0.3.70
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.131
+comfyui-workflow-templates-media-image==0.3.132
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.180
+comfyui-workflow-templates-media-other==0.3.182
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.80
+comfyui-workflow-templates-media-video==0.3.81
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.42.14",
+      "version": "1.42.15",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.19.5",
+      "version": "0.20.1",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.42.14
- comfyui-workflow-templates==0.9.61
- comfyui-embedded-docs==0.4.3
+-comfyui-frontend-package==1.42.15
+ comfyui-workflow-templates==0.9.63
+ comfyui-embedded-docs==0.4.4
  torch


### PR DESCRIPTION
## Summary

Bumps the desktop package to `0.8.36`, ComfyUI core to `0.20.1`, and the bundled frontend package to `1.42.15`.

Updates the core requirements patch so desktop continues stripping the upstream `comfyui-frontend-package` requirement, then refreshes the platform compiled requirement snapshots for the real upstream dependency changes in ComfyUI `v0.20.1`.

I checked the bump with `corepack yarn make:assets`, `corepack yarn format`, `corepack yarn lint`, `corepack yarn typecheck`, and `corepack yarn test:unit`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1701-chore-bump-ComfyUI-to-0-20-1-and-desktop-to-0-8-36-34f6d73d36508103aad2e89cbc2d9bc0) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.8.36
  * Updated frontend version to 1.42.15
  * Updated ComfyUI version to 0.20.1
  * Upgraded ComfyUI-related packages including manager, embedded documentation, workflow templates, and associated components across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->