### PR TITLE
chore: bump ComfyUI to 0.20.2

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.68
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.225
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.134
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.191
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.83
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.68
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.225
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.134
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.191
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.83
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.68
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.225
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.134
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.191
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.83
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.68
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.225
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.74
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.134
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.191
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.83
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.36",
+  "version": "0.9.0",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.20.1",
+      "version": "0.20.2",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.42.15
- comfyui-workflow-templates==0.9.63
+ comfyui-workflow-templates==0.9.68
  comfyui-embedded-docs==0.4.4
  torch


### PR DESCRIPTION
## Summary
- bump desktop from `0.8.36` to `0.9.0`
- bump bundled ComfyUI from `0.20.1` to `0.20.2`
- update the core requirements patch and compiled requirement snapshots for `comfyui-workflow-templates==0.9.68`

## Context
This is intentionally a minor desktop version bump rather than another patch release because the missing model downloader API surface changed. Desktop PR #1694 is expected to merge before this release and aligns the missing-model download contract that the newer frontend path depends on.

## Notes
- `v0.20.2` exists as the latest ComfyUI tag, though GitHub Releases still reports `v0.20.1` as the latest published release.
- `manager_requirements.txt` is unchanged between `v0.20.1` and `v0.20.2`, so `managerCommit` remains untouched.

## Checks
- `corepack yarn make:assets`
- compiled platform requirements from the commands embedded in `assets/requirements/*.compiled`, with unrelated resolver/index-source noise stripped
- `corepack yarn format`
- `corepack yarn lint`
- `corepack yarn typecheck`
- `corepack yarn test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 0.9.0
  * Updated ComfyUI version to 0.20.2
  * Updated workflow templates and related components to latest versions
  * Refreshed platform-specific dependency versions for macOS and Windows (AMD/CPU/NVIDIA)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->