### PR TITLE
Bump ComfyUI to 0.21.0

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -52,7 +52,7 @@ click==8.3.1
     #   typer
     #   typer-slim
     # from https://pypi.org/simple
-comfy-aimdo==0.2.14
+comfy-aimdo==0.3.0
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.73
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.229
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.75
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.138
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.195
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.85
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -48,7 +48,7 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.14
+comfy-aimdo==0.3.0
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.73
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.229
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.75
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.138
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.195
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.85
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -56,7 +56,7 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://pypi.org/simple
-comfy-aimdo==0.2.14
+comfy-aimdo==0.3.0
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.73
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.229
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.75
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.138
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.195
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.85
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -57,7 +57,7 @@ colorama==0.4.6
     #   click
     #   tqdm
     # from https://download.pytorch.org/whl/cu130
-comfy-aimdo==0.2.14
+comfy-aimdo==0.3.0
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
 comfy-kitchen==0.2.8
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.4.4
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.63
+comfyui-workflow-templates==0.9.73
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.216
+comfyui-workflow-templates-core==0.3.229
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.70
+comfyui-workflow-templates-media-api==0.3.75
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.132
+comfyui-workflow-templates-media-image==0.3.138
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.182
+comfyui-workflow-templates-media-other==0.3.195
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.81
+comfyui-workflow-templates-media-video==0.3.85
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.8.36",
+  "version": "0.9.0",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -11,11 +11,11 @@
   "type": "module",
   "config": {
     "frontend": {
-      "version": "1.42.15",
+      "version": "1.43.18",
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.20.1",
+      "version": "0.21.0",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -2,7 +2,7 @@ diff --git a/requirements.txt b/requirements.txt
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
--comfyui-frontend-package==1.42.15
- comfyui-workflow-templates==0.9.63
+-comfyui-frontend-package==1.43.18
+ comfyui-workflow-templates==0.9.73
  comfyui-embedded-docs==0.4.4
  torch


### PR DESCRIPTION
## Summary

Bumps the bundled ComfyUI core from `0.20.1` to `0.21.0` and updates the desktop package version to `0.9.0` for the core minor release.

This also updates the bundled frontend package pin to `1.43.18`, refreshes the desktop core requirements patch, and moves the compiled requirement snapshots to the new upstream direct dependency pins:

- `comfy-aimdo==0.3.0`
- `comfyui-workflow-templates==0.9.73`
- matching split workflow template package versions

The requirement snapshot diff is intentionally limited to the actual upstream ComfyUI dependency delta after trimming unrelated resolver/index-source churn from local regeneration.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1717-Bump-ComfyUI-to-0-21-0-35d6d73d3650812bb9d2c91853ea4311) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.9.0
  * Frontend bumped to 1.43.18; ComfyUI to 0.21.0
  * Updated core dependencies across macOS and Windows: upgraded Comfy-AIMDO and ComfyUI workflow templates (including related media/core packages) for newer releases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Comfy-Org/desktop/pull/1717)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->