### PR TITLE
chore: mark legacy desktop Comfy environment

### DIFF
--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -18,6 +18,8 @@ if (pkg.config.comfyUI.optionalBranch) {
   execAndLog(`git ${noWarning} clone ${comfyRepo} --depth 1 --branch v${pkg.config.comfyUI.version} assets/ComfyUI`);
 }
 const assetsComfyPath = path.join('assets', 'ComfyUI');
+fs.writeFileSync(path.join(assetsComfyPath, '.comfy_environment'), 'local-desktop\n');
+
 const managerRequirementsPath = path.join(assetsComfyPath, 'manager_requirements.txt');
 
 if (fs.existsSync(managerRequirementsPath)) {

--- a/scripts/verifyBuild.js
+++ b/scripts/verifyBuild.js
@@ -12,13 +12,14 @@ import path from 'node:path';
 const PATHS = /** @type {Record<'mac' | 'windows', VerifyConfig>} */ ({
   mac: {
     base: 'dist/mac-arm64/ComfyUI.app/Contents/Resources',
-    required: ['ComfyUI', 'UI', 'uv/macos/uv', 'uv/macos/uvx'],
+    required: ['ComfyUI', 'ComfyUI/.comfy_environment', 'UI', 'uv/macos/uv', 'uv/macos/uvx'],
   },
   windows: {
     base: 'dist/win-unpacked/resources',
     required: [
       // Add Windows-specific paths here
       'ComfyUI',
+      'ComfyUI/.comfy_environment',
       'UI',
       'uv/win/uv.exe',
       'uv/win/uvx.exe',

--- a/todesktop.json
+++ b/todesktop.json
@@ -9,6 +9,7 @@
   "appFiles": [
     "src/**",
     "scripts/**",
+    "assets/ComfyUI/.comfy_environment",
     "assets/ComfyUI/**",
     "assets/UI/**",
     "assets/requirements/**",


### PR DESCRIPTION
## Summary
- write `.comfy_environment` with `local-desktop` during legacy desktop ComfyUI asset generation
- explicitly include the marker in ToDesktop app files so dotfile glob behavior cannot drop it
- require the marker in `verifyBuild.js` for Mac and Windows packaged outputs

Linear: https://linear.app/comfyorg/issue/DESK2-78/add-comfy-environment-marker-for-legacy-desktop

Context: Comfy-Org/ComfyUI#13425 reads this marker from the ComfyUI install directory and sends it as the `Comfy-Env` header for partner-node API calls.