### PR TITLE
feat: write .comfy_environment marker for desktop builds

### DIFF
--- a/scripts/makeComfy.js
+++ b/scripts/makeComfy.js
@@ -20,6 +20,13 @@ if (pkg.config.comfyUI.optionalBranch) {
 const assetsComfyPath = path.join('assets', 'ComfyUI');
 const managerRequirementsPath = path.join(assetsComfyPath, 'manager_requirements.txt');
 
+// Mark this ComfyUI install as the desktop deploy environment. ComfyUI reads
+// `.comfy_environment` from its own install directory (next to main.py) and
+// sends the value as the `X-Comfy-Deploy-Env` header on partner-node API
+// calls. The file is gitignored upstream, so writing it into the freshly
+// cloned ComfyUI repo doesn't dirty the working tree.
+fs.writeFileSync(path.join(assetsComfyPath, '.comfy_environment'), 'local-desktop\n');
+
 if (fs.existsSync(managerRequirementsPath)) {
   console.log('Detected manager_requirements.txt, skipping legacy ComfyUI-Manager clone.');
 } else {

--- a/scripts/verifyBuild.js
+++ b/scripts/verifyBuild.js
@@ -12,13 +12,14 @@ import path from 'node:path';
 const PATHS = /** @type {Record<'mac' | 'windows', VerifyConfig>} */ ({
   mac: {
     base: 'dist/mac-arm64/ComfyUI.app/Contents/Resources',
-    required: ['ComfyUI', 'UI', 'uv/macos/uv', 'uv/macos/uvx'],
+    required: ['ComfyUI', 'ComfyUI/.comfy_environment', 'UI', 'uv/macos/uv', 'uv/macos/uvx'],
   },
   windows: {
     base: 'dist/win-unpacked/resources',
     required: [
       // Add Windows-specific paths here
       'ComfyUI',
+      'ComfyUI/.comfy_environment',
       'UI',
       'uv/win/uv.exe',
       'uv/win/uvx.exe',


### PR DESCRIPTION
## Summary

ComfyUI recently added a deploy-environment header (commits e7fbb3c2, 06e416bd, 38e5aac7, e35348aa upstream): `comfy/deploy_environment.py` reads a `.comfy_environment` file from the ComfyUI install directory (next to `main.py`) and sends its first line as the `X-Comfy-Deploy-Env` header on partner-node API calls. Falls back to `local-git` when missing.

The portable build already writes `local-portable`. This PR is the equivalent for legacy desktop, writing **`local-desktop`** so api.comfy.org can distinguish desktop traffic.

## Changes

- `scripts/makeComfy.js`: write `local-desktop\n` to `assets/ComfyUI/.comfy_environment` immediately after the ComfyUI clone. The file is gitignored upstream so it does not dirty the cloned working tree.
- `scripts/verifyBuild.js`: require `ComfyUI/.comfy_environment` in both Mac and Windows build outputs so a missing/dropped dotfile fails CI loudly instead of silently regressing to `local-git`.

## Why this is safe at runtime

The desktop app runs ComfyUI in place from `<resourcesPath>/ComfyUI/main.py`. Per upstream commit 38e5aac7, `deploy_environment.py` reads the marker from the install directory (next to `main.py`), **not** from `--base-directory` -- so the user's chosen base path is irrelevant and no Electron-side code changes are needed.

## Verification

- `yarn typecheck` -> passes
- `yarn prettier --check` on changed files -> passes
- `yarn eslint` on changed files -> passes
- `verify:build` will assert the file is bundled at the correct path

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1719-feat-write-comfy_environment-marker-for-desktop-builds-35d6d73d36508166a932f2ee9c1e1b7c) by [Unito](https://www.unito.io)
