### PR TITLE
Bump ComfyUI to 0.22.0

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,19 +64,19 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.75
+comfyui-workflow-templates==0.9.79
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.231
+comfyui-workflow-templates-core==0.3.235
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.76
+comfyui-workflow-templates-media-api==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.138
+comfyui-workflow-templates-media-image==0.3.140
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.197
+comfyui-workflow-templates-media-other==0.3.201
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.85

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,19 +60,19 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.75
+comfyui-workflow-templates==0.9.79
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.231
+comfyui-workflow-templates-core==0.3.235
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.76
+comfyui-workflow-templates-media-api==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.138
+comfyui-workflow-templates-media-image==0.3.140
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.197
+comfyui-workflow-templates-media-other==0.3.201
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.85

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,19 +68,19 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.75
+comfyui-workflow-templates==0.9.79
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.231
+comfyui-workflow-templates-core==0.3.235
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.76
+comfyui-workflow-templates-media-api==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.138
+comfyui-workflow-templates-media-image==0.3.140
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.197
+comfyui-workflow-templates-media-other==0.3.201
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.85

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,19 +69,19 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.75
+comfyui-workflow-templates==0.9.79
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.231
+comfyui-workflow-templates-core==0.3.235
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.76
+comfyui-workflow-templates-media-api==0.3.77
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.138
+comfyui-workflow-templates-media-image==0.3.140
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.197
+comfyui-workflow-templates-media-other==0.3.201
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 comfyui-workflow-templates-media-video==0.3.85

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "ComfyUI",
   "repository": "github:comfy-org/electron",
   "copyright": "Copyright © 2024 Comfy Org",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "homepage": "https://comfy.org",
   "description": "The best modular GUI to run AI diffusion models.",
   "main": ".vite/build/main.cjs",
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.21.1",
+      "version": "0.22.0",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.43.18
- comfyui-workflow-templates==0.9.75
+ comfyui-workflow-templates==0.9.79
  comfyui-embedded-docs==0.5.0
  torch


### PR DESCRIPTION
Updates the bundled ComfyUI version to v0.22.0 and bumps the desktop app version to 0.9.2.

Also refreshes the core requirements patch and compiled requirement snapshots for the upstream workflow-template package bump.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-1723-Bump-ComfyUI-to-0-22-0-3666d73d365081be8628c5a0bc6cf731) by [Unito](https://www.unito.io)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.9.2
  * Upgraded ComfyUI to version 0.22.0
  * Updated workflow template dependencies to latest versions across all platform configurations (macOS, Windows AMD/CPU/NVIDIA)
  * Removed pinned frontend package dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Comfy-Org/desktop/pull/1723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->