### PR TITLE
fix: ignore any `uv.toml` file

### DIFF
--- a/src/virtualEnvironment.ts
+++ b/src/virtualEnvironment.ts
@@ -164,6 +164,10 @@ export class VirtualEnvironment implements HasTelemetry, PythonExecutor {
   get uvEnv() {
     return {
       VIRTUAL_ENV: this.venvPath,
+      // The bundled uv must remain hermetic: ignore user/system/project uv config
+      // files (e.g. ~/.config/uv/uv.toml) so settings like `exclude-newer` cannot
+      // interfere with dependency resolution. See issue #1722.
+      UV_NO_CONFIG: '1',
       // Empty strings are not valid values for these env vars,
       // dropping them here to avoid passing them to uv.
       // `node-pty` does not support `undefined`.

--- a/tests/unit/virtualEnvironment.test.ts
+++ b/tests/unit/virtualEnvironment.test.ts
@@ -294,6 +294,13 @@ describe('VirtualEnvironment', () => {
       expect('UV_PYTHON_INSTALL_MIRROR' in uvEnv).toBe(false);
     });
 
+    test('always sets UV_NO_CONFIG=1 so bundled uv ignores user/system uv.toml', ({ virtualEnv }) => {
+      // Regression test for https://github.com/Comfy-Org/desktop/issues/1722.
+      // A user-level uv.toml with settings like `exclude-newer` would otherwise
+      // be applied to the bundled uv and break dependency resolution.
+      expect(virtualEnv.uvEnv.UV_NO_CONFIG).toBe('1');
+    });
+
     test('omits UV_PYTHON_INSTALL_MIRROR when pythonMirror is empty string', () => {
       vi.stubGlobal('process', {
         ...process,


### PR DESCRIPTION
## Summary
- Set `UV_NO_CONFIG=1` in the bundled uv's environment so user/system `uv.toml` files (e.g. `~/.config/uv/uv.toml`) cannot influence dependency resolution.
- Add a regression test asserting `uvEnv.UV_NO_CONFIG === '1'`.

Closes #1722.

## Root cause
The bundled `uv` binary still performs uv's normal config discovery — user config at `~/.config/uv/uv.toml`, system config, and project-level `uv.toml` / `[tool.uv]`. Setting `exclude-newer` in my personal `uv.toml` applied that constraint every `uv pip install` and `uv pip install --dry-run` (the latter is what `hasRequirements()` runs to verify the venv), causing dependency resolution / verification to fail.

The desktop app already passes all needed configuration to uv via CLI args (`--index-url`, `--python-preference`, `--index-strategy`, etc.) and env vars (`UV_PYTHON_INSTALL_MIRROR`), so ignoring `uv.toml` config files shouldn't be an issue. *Note*: if a project-level uv config file is ever used instead of CLI args, then this fix would interfere with that.

## Test plan
- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test:unit` (351 + 1 new test passing)
- [x] Built locally with `yarn make` and ran the app: venv creation and requirements installation completed cleanly while the offending user `uv.toml` was in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dependency resolution consistency by ensuring the bundled package manager ignores user/system/project configuration files during dependency resolution.
* **Tests**
  * Added a unit regression test to verify this behavior remains enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->