### PR TITLE
Bump bundled ComfyUI to v0.22.3

### DIFF
--- a/assets/requirements/macos.compiled
+++ b/assets/requirements/macos.compiled
@@ -64,22 +64,22 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.79
+comfyui-workflow-templates==0.9.85
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.235
+comfyui-workflow-templates-core==0.3.239
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.77
+comfyui-workflow-templates-media-api==0.3.79
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.140
+comfyui-workflow-templates-media-image==0.3.143
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.201
+comfyui-workflow-templates-media-other==0.3.205
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.85
+comfyui-workflow-templates-media-video==0.3.88
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_amd.compiled
+++ b/assets/requirements/windows_amd.compiled
@@ -60,22 +60,22 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.79
+comfyui-workflow-templates==0.9.85
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.235
+comfyui-workflow-templates-core==0.3.239
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.77
+comfyui-workflow-templates-media-api==0.3.79
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.140
+comfyui-workflow-templates-media-image==0.3.143
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.201
+comfyui-workflow-templates-media-other==0.3.205
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.85
+comfyui-workflow-templates-media-video==0.3.88
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.3

--- a/assets/requirements/windows_cpu.compiled
+++ b/assets/requirements/windows_cpu.compiled
@@ -68,22 +68,22 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.79
+comfyui-workflow-templates==0.9.85
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.235
+comfyui-workflow-templates-core==0.3.239
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.77
+comfyui-workflow-templates-media-api==0.3.79
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.140
+comfyui-workflow-templates-media-image==0.3.143
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.201
+comfyui-workflow-templates-media-other==0.3.205
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.85
+comfyui-workflow-templates-media-video==0.3.88
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/assets/requirements/windows_nvidia.compiled
+++ b/assets/requirements/windows_nvidia.compiled
@@ -69,22 +69,22 @@ comfyui-embedded-docs==0.5.0
 comfyui-manager==4.2.1
     # via -r assets/ComfyUI/manager_requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates==0.9.79
+comfyui-workflow-templates==0.9.85
     # via -r assets/ComfyUI/requirements.txt
     # from https://pypi.org/simple
-comfyui-workflow-templates-core==0.3.235
+comfyui-workflow-templates-core==0.3.239
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-api==0.3.77
+comfyui-workflow-templates-media-api==0.3.79
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-image==0.3.140
+comfyui-workflow-templates-media-image==0.3.143
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-other==0.3.201
+comfyui-workflow-templates-media-other==0.3.205
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
-comfyui-workflow-templates-media-video==0.3.85
+comfyui-workflow-templates-media-video==0.3.88
     # via comfyui-workflow-templates
     # from https://pypi.org/simple
 cryptography==46.0.4

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "optionalBranch": ""
     },
     "comfyUI": {
-      "version": "0.22.0",
+      "version": "0.22.3",
       "optionalBranch": ""
     },
     "managerCommit": "d82e1f5d677fec0b85a6be6beb1e32d5627ef6af",

--- a/scripts/core-requirements.patch
+++ b/scripts/core-requirements.patch
@@ -3,6 +3,6 @@ diff --git a/requirements.txt b/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,3 @@
 -comfyui-frontend-package==1.43.18
- comfyui-workflow-templates==0.9.79
+ comfyui-workflow-templates==0.9.85
  comfyui-embedded-docs==0.5.0
  torch


### PR DESCRIPTION
## Summary
- Updated the desktop bundle pin to ComfyUI `0.22.3`
- Refreshed the compiled requirement files to match the newer `comfyui-workflow-templates` dependency set
- Kept the change scoped to the bundled ComfyUI version and its generated requirement locks

## Testing
- `yarn format`
- `yarn lint`
- `yarn typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped app version to 0.9.4 and ComfyUI to 0.22.3
  * Updated workflow templates and related media packages to newer pinned versions across all supported platforms
  * Removed an unused frontend package dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Comfy-Org/desktop/pull/1727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->