### PR TITLE
docs(readme): add deprecation banner pointing to Comfy-Org/Comfy-Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]
 > **This repository is no longer the home of Comfy Desktop.** The app has been rewritten and now lives at **[Comfy-Org/Comfy-Desktop](https://github.com/Comfy-Org/Comfy-Desktop)**.
 >
-> - **New downloads:** [dl.comfy.org](https://dl.comfy.org)
+> - **New downloads:** [comfy.org/download](https://comfy.org/download)
 > - **Existing 0.9.x users:** your app will receive an in-app update to the new version as we roll out — no action needed.
 > - **New issues, PRs, discussions:** please file them on the [new repo](https://github.com/Comfy-Org/Comfy-Desktop).
 >

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # ComfyUI Desktop
 
+> [!IMPORTANT]
+> **This repository is no longer the home of Comfy Desktop.** The app has been rewritten and now lives at **[Comfy-Org/Comfy-Desktop](https://github.com/Comfy-Org/Comfy-Desktop)**.
+>
+> - **New downloads:** [dl.comfy.org](https://dl.comfy.org)
+> - **Existing 0.9.x users:** your app will receive an in-app update to the new version as we roll out — no action needed.
+> - **New issues, PRs, discussions:** please file them on the [new repo](https://github.com/Comfy-Org/Comfy-Desktop).
+>
+> The content below is retained for reference.
+
 ![Beta](https://img.shields.io/badge/beta-blue.svg)
 
 # USER GUIDE


### PR DESCRIPTION
Adds a GitHub-alert banner at the very top of the README pointing visitors to the rewrite at [Comfy-Org/Comfy-Desktop](https://github.com/Comfy-Org/Comfy-Desktop).

- New downloads: [dl.comfy.org](https://dl.comfy.org)
- Existing 0.9.x users: in-app update to the new version as we roll out
- New issues / PRs / discussions: route to the new repo

The rest of the README is kept as historical reference — no content removed.

9-line addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an important notice that the project has moved to a new GitHub home with updated links for downloads, issues, pull requests, and discussions.
  * Notified existing 0.9.x users they will receive an in-app update about the relocation.
  * Preserved the previous README content below the notice for reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->